### PR TITLE
#298: Improved usage of player custom color

### DIFF
--- a/totalRP3/core/impl/configuration.lua
+++ b/totalRP3/core/impl/configuration.lua
@@ -389,6 +389,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	registerConfigKey("ui_sounds", true);
 	registerConfigKey("ui_animations", true);
 	registerConfigKey("default_color_picker", false);
+	registerConfigKey("increase_color_contrast", false);
 
 	-- Build widgets
 	TRP3_API.configuration.CONFIG_STRUCTURE_GENERAL = {
@@ -434,6 +435,12 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 				help = loc.CO_GENERAL_DEFAULT_COLOR_PICKER_TT,
 			},
 			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_TOOLTIP_CONTRAST ,
+				configKey = "increase_color_contrast",
+				help = loc.CO_TOOLTIP_CONTRAST_TT ,
+			},
+			{
 				inherit = "TRP3_ConfigButton",
 				title = loc.CO_GENERAL_RESET_CUSTOM_COLORS,
 				help = loc.CO_GENERAL_RESET_CUSTOM_COLORS_TT,
@@ -447,6 +454,15 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		}
 	}
 end);
+
+AddOn_TotalRP3.Configuration = {}
+
+--- Returns true if the user checked the setting to increase color contrast to make text colored using user selected custom
+--- colors more readable.
+--- @return boolean
+function AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast()
+	return getValue("increase_color_contrast")
+end
 
 function TRP3_API.configuration.constructConfigPage()
 	TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_FRAME_PAGE);

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -66,7 +66,6 @@ local CONFIG_OOC_PATTERN = "chat_ooc_pattern";
 local CONFIG_OOC_COLOR = "chat_ooc_color";
 local CONFIG_YELL_NO_EMOTE = "chat_yell_no_emote";
 local CONFIG_INSERT_FULL_RP_NAME = "chat_insert_full_rp_name";
-local CONFIG_INCREASE_CONTRAST = "chat_color_contrast";
 local CONFIG_SHOW_ICON = "chat_show_icon";
 local CONFIG_NPCSPEECH_REPLACEMENT = "chat_npcspeech_replacement";
 
@@ -88,10 +87,8 @@ local function configShowNameCustomColors()
 end
 TRP3_API.chat.configShowNameCustomColors = configShowNameCustomColors;
 
-local function configIncreaseNameColorContrast()
-	return getConfigValue(CONFIG_INCREASE_CONTRAST);
-end
-TRP3_API.chat.configIncreaseNameColorContrast = configIncreaseNameColorContrast;
+---@deprecated
+TRP3_API.chat.configIncreaseNameColorContrast = TRP3_API.Ellyb.DeprecationWarnings.wrapFunction(AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast, "TRP3_API.chat.configIncreaseNameColorContrast", "AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast");
 
 local function configIsChannelUsed(channel)
 	return getConfigValue(CONFIG_USAGE .. channel);
@@ -137,7 +134,6 @@ local function createConfigPage()
 	registerConfigKey(CONFIG_DISABLE_OOC, false);
 	registerConfigKey(CONFIG_REMOVE_REALM, true);
 	registerConfigKey(CONFIG_NAME_COLOR, true);
-	registerConfigKey(CONFIG_INCREASE_CONTRAST, false);
 	registerConfigKey(CONFIG_EMOTE, true);
 	registerConfigKey(CONFIG_EMOTE_PATTERN, "(%*.-%*)");
 	registerConfigKey(CONFIG_OOC, true);
@@ -207,12 +203,6 @@ local function createConfigPage()
 				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_CHAT_MAIN_COLOR,
 				configKey = CONFIG_NAME_COLOR,
-			},
-			{
-				inherit = "TRP3_ConfigCheck",
-				title = loc.CO_CHAT_INCREASE_CONTRAST,
-				configKey = CONFIG_INCREASE_CONTRAST,
-				dependentOnOptions = { CONFIG_NAME_COLOR },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
@@ -676,6 +666,8 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	end
 	-- Make sure we have a unitID formatted as "Player-Realm"
 	unitID = unitInfoToID(character, realm);
+	---@type Player
+	local player = AddOn_TotalRP3.Player.static.CreateFromGUID(GUID)
 
 	-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 	if realm == Globals.player_realm_id or getConfigValue(CONFIG_REMOVE_REALM) then
@@ -694,15 +686,7 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	end
 
 	if configShowNameCustomColors() then
-		local customColor = GetCustomColorByGUID(GUID);
-
-		if customColor then
-			if configIncreaseNameColorContrast() then
-				customColor:LightenColorUntilItIsReadable();
-			end
-
-			characterColor = customColor;
-		end
+		characterColor = player:GetCustomColorForDisplay() or characterColor;
 	end
 
 	-- If we did get a color wrap the name inside the color code

--- a/totalRP3/modules/flyway/flyway.lua
+++ b/totalRP3/modules/flyway/flyway.lua
@@ -22,7 +22,7 @@ TRP3_API.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 9;
+local SCHEMA_VERSION = 10;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -113,3 +113,15 @@ TRP3_API.flyway.patches["9"] = function()
 		end
 	end)
 end
+
+TRP3_API.flyway.patches["10"] = function()
+	-- Migrate contrast settings to the new common one
+	if TRP3_Configuration then
+		if TRP3_Configuration["chat_color_contrast"] or TRP3_Configuration["tooltip_char_contrast"] then
+			TRP3_Configuration["increase_color_contrast"] = true;
+		end
+
+		TRP3_Configuration["chat_color_contrast"] = nil;
+		TRP3_Configuration["tooltip_char_contrast"] = nil;
+	end
+end

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -73,7 +73,6 @@ local CONFIG_IN_CHARACTER_ONLY = "tooltip_in_character_only";
 local CONFIG_CHARACT_COMBAT = "tooltip_char_combat";
 local CONFIG_CHARACT_COLOR = "tooltip_char_color";
 local CONFIG_CROP_TEXT = "tooltip_crop_text";
-local CONFIG_CHARACT_CONTRAST = "tooltip_char_contrast";
 local CONFIG_CHARACT_ANCHORED_FRAME = "tooltip_char_AnchoredFrame";
 local CONFIG_CHARACT_ANCHOR = "tooltip_char_Anchor";
 local CONFIG_CHARACT_HIDE_ORIGINAL = "tooltip_char_HideOriginal";
@@ -406,6 +405,8 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	local info = getCharacterInfoTab(targetID);
 	local character = getCharacter(targetID);
 	local targetName = UnitName(targetType);
+	---@type Player
+	local player = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetID)
 
 	local FIELDS_TO_CROP = {
 		TITLE = 150,
@@ -441,14 +442,8 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 
 
     -- Only use custom colors if the option is enabled and if we have one
-    if getConfigValue(CONFIG_CHARACT_COLOR) and info.characteristics and info.characteristics.CH then
-        local customColor = Utils.color.getColorFromHexadecimalCode(info.characteristics.CH);
-
-		if getConfigValue(CONFIG_CHARACT_CONTRAST) then
-			customColor:LightenColorUntilItIsReadable();
-		end
-
-		color = customColor or color;
+    if getConfigValue(CONFIG_CHARACT_COLOR) then
+		color = player:GetCustomColorForDisplay() or color;
     end
 
 
@@ -607,19 +602,14 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		local name = UnitName(targetType .. "target");
 		local targetTargetID = getUnitID(targetType .. "target");
 		if targetTargetID then
+			---@type Player
+			local targetTarget = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetTargetID)
 			local _, targetEnglishClass = UnitClass(targetType .. "target");
 			local targetInfo = getCharacterInfoTab(targetTargetID);
 			local targetClassColor = targetEnglishClass and Utils.color.getClassColor(targetEnglishClass) or Utils.color.CreateColor(1, 1, 1, 1);
 
-			-- Only use custom colors if the option is enabled and if we have one
-			if getConfigValue(CONFIG_CHARACT_COLOR) and targetInfo.characteristics and targetInfo.characteristics.CH then
-				local customColor = Utils.color.getColorFromHexadecimalCode(targetInfo.characteristics.CH);
-
-				if getConfigValue(CONFIG_CHARACT_CONTRAST) then
-					customColor:LightenColorUntilItIsReadable();
-				end
-
-				targetClassColor = customColor or targetClassColor;
+			if getConfigValue(CONFIG_CHARACT_COLOR) then
+				targetClassColor = targetTarget:GetCustomColorForDisplay() or targetClassColor;
 			end
 
 			name = getCompleteName(targetInfo.characteristics or {}, name, true);
@@ -637,7 +627,6 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	-- Quick peek & new description notifications & Client
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local player = AddOn_TotalRP3.Player.CreateFromCharacterID(targetID)
 	if showNotifications() then
 		local notifText = "";
 		if info.misc and info.misc.PE and checkGlanceActivation(info.misc.PE) then
@@ -808,7 +797,7 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 				if getConfigValue(CONFIG_CHARACT_COLOR) and ownerInfo.characteristics.CH then
 					local customColor = Utils.color.getColorFromHexadecimalCode(ownerInfo.characteristics.CH);
 
-						if getConfigValue(CONFIG_CHARACT_CONTRAST) then
+						if AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast() then
 							customColor:LightenColorUntilItIsReadable();
 						end
 
@@ -1150,7 +1139,6 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_IN_CHARACTER_ONLY, false);
 	registerConfigKey(CONFIG_CHARACT_COMBAT, false);
 	registerConfigKey(CONFIG_CHARACT_COLOR, true);
-	registerConfigKey(CONFIG_CHARACT_CONTRAST, false);
 	registerConfigKey(CONFIG_CROP_TEXT, true);
 	registerConfigKey(CONFIG_CHARACT_ANCHORED_FRAME, "GameTooltip");
 	registerConfigKey(CONFIG_CHARACT_ANCHOR, "ANCHOR_TOPRIGHT");
@@ -1226,13 +1214,6 @@ local function onModuleInit()
 				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_TOOLTIP_COLOR,
 				configKey = CONFIG_CHARACT_COLOR,
-			},
-			{
-				inherit = "TRP3_ConfigCheck",
-				title = loc.CO_TOOLTIP_CONTRAST,
-				configKey = CONFIG_CHARACT_CONTRAST,
-				help = loc.CO_TOOLTIP_CONTRAST_TT,
-				dependentOnOptions = {CONFIG_CHARACT_COLOR},
 			},
 			{
 				inherit = "TRP3_ConfigCheck",


### PR DESCRIPTION
- Removed individual settings for color contrast, consolidated into one setting on the General settings
- Added `:GetCustomColorForDisplay()` to the Player model, to get color that follows the global setting for increased color contrast. `:GetCustomColoredRoleplayingNamePrefixedWithIcon()` uses this one instead of the raw `:GetCustomColor()` now
- Added more ways to creates a `Player` to accomodate chat frames, such as `Player.static.CreateFromGUID(guid)` or `Player.static.CreateFromNameAndRealm(name[, realm])`
- Added PUBLIC `AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast()` for third parties