### PR TITLE
Map scan button anchor wasn't working

### DIFF
--- a/totalRP3/modules/map/WorldMapButton.lua
+++ b/totalRP3/modules/map/WorldMapButton.lua
@@ -24,6 +24,7 @@ local Ellyb = TRP3_API.Ellyb;
 local loc = TRP3_API.loc;
 local Events = TRP3_API.Events;
 local getConfigValue = TRP3_API.configuration.getValue;
+local setConfigValue = TRP3_API.configuration.setValue;
 local registerConfigKey = TRP3_API.configuration.registerConfigKey;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
 --endregion
@@ -48,8 +49,9 @@ local ON_COOLDOWN_STATE_MAP_ICON = Ellyb.Icon("ability_mage_timewarp")
 Events.registerCallback(Events.WORKFLOW_ON_LOADED, function()
 	registerConfigKey(CONFIG_MAP_BUTTON_POSITION, "BOTTOMLEFT");
 
-	local function placeMapButton()
-		local position = getConfigValue(CONFIG_MAP_BUTTON_POSITION)
+	local function placeMapButton(newPosition)
+		if newPosition then setConfigValue(newPosition) end
+		local position = newPosition or getConfigValue(CONFIG_MAP_BUTTON_POSITION)
 
 		WorldMapButton:SetParent(WorldMapFrame.BorderFrame);
 		WorldMapButton:ClearAllPoints();


### PR DESCRIPTION
It turns out that when a dropdown setting is assigned a listCallback function to call after a new value is selected, that callback function has to set the value in the config itself. It was done properly in the advanced settings for the locale selection (which is the only other dropdown setting to use a listCallback function), but not for the world map button anchor selection, so the setting wasn't doing anything.