### PR TITLE
Fixed switched titles for header/paragraph dropdowns (#301)

### DIFF
--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -912,12 +912,12 @@ end
 local function onContainerTagClicked(button, frame, isP)
 	local values = {};
 	if not isP then
-		tinsert(values, {loc.REG_PLAYER_ABOUT_P});
+		tinsert(values, {loc.REG_PLAYER_ABOUT_HEADER});
 		tinsert(values, {loc.CM_LEFT, 1});
 		tinsert(values, {loc.CM_CENTER, 2});
 		tinsert(values, {loc.CM_RIGHT, 3});
 	else
-		tinsert(values, {loc.REG_PLAYER_ABOUT_HEADER});
+		tinsert(values, {loc.REG_PLAYER_ABOUT_P});
 		tinsert(values, {loc.CM_CENTER, 1});
 		tinsert(values, {loc.CM_RIGHT, 2});
 	end


### PR DESCRIPTION
Header dropdowns had the paragraph title and vice versa

![](https://cdn.discordapp.com/emojis/540113499377106955.png)