### PR TITLE
Clear temporary tooltip lines when showing tooltip

### DIFF
--- a/totalRP3/modules/map/WorldMapButton.lua
+++ b/totalRP3/modules/map/WorldMapButton.lua
@@ -98,6 +98,7 @@ Events.registerCallback(Events.WORKFLOW_ON_LOADED, function()
 	Ellyb.Tooltips.getTooltip(WorldMapButton)
 		 :SetTitle(loc.MAP_BUTTON_TITLE)
 		 :OnShow(function(tooltip)
+		tooltip:ClearTempLines();
 		tooltip:AddTempLine(WorldMapButton.subtitle)
 	end)
 	--}}}


### PR DESCRIPTION
For some reason Show on the tooltip gets called a couple of times when some aspects of the scan button change without a Hide occurring in between, so we end up putting multiple temporary lines into the tooltip.

Annoyingly, the tooltip code doesn't provide any callbacks for Hide nor telling if the tooltip is shown/hidden, so we can't fix any other issues with the scan tooltip (like the line text being incorrect if you've mouse-overed the button as it changes state on initial addon load), but this at least fixes one issue with it.