### PR TITLE
Speculative fix for map anchoring errors

### DIFF
--- a/totalRP3/modules/map/map.xml
+++ b/totalRP3/modules/map/map.xml
@@ -32,11 +32,8 @@
 		</Frames>
 	</Button>
 
-	<Frame name="TRP3_ScanLoaderFrame" hidden="true">
+	<Frame name="TRP3_ScanLoaderFrame" parent="UIParent" hidden="true">
 		<Size x="200" y="200"/>
-		<Anchors>
-			<Anchor point="CENTER" x="0" y="0"/>
-		</Anchors>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture alphaMode="ADD" file="Interface\UNITPOWERBARALT\PandarenTrainingLarge_Circular_Fill" alpha="0.5">


### PR DESCRIPTION
Explicitly initialize the frame as parented to UIParent and remove its initial anchors.

We're clearing these on module init anyway, so we might as well see if this approach works. Personally I couldn't reproduce the issue *without* the ClearAllPoints line removed either, so there seems to be some other issues at play.