### PR TITLE
Fix MSP MU field integration

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -340,7 +340,12 @@ local function onStart()
 						end
 					elseif ABOUT_FIELDS[field] then
 						if field == "MU" then
-							profile.about.MU = tonumber(value) or Utils.music.convertPathToID(value);
+							local fileID = tonumber(value);
+							if not fileID and type(value) == "string" then
+								fileID = Utils.music.convertPathToID(value);
+							end
+
+							profile.about.MU = fileID;
 						else
 							local old;
 							if profile.about.T3 and profile.about.T3[ABOUT_FIELDS[field]] then

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -91,7 +91,7 @@ local function onStart()
 			msp.my['DE'] = table.concat(t, "\n\n---\n\n");
 		end
 
-		msp.my['MU'] = tostring(dataTab.MU);
+		msp.my['MU'] = dataTab.MU and tostring(dataTab.MU) or nil;
 	end
 
 	local function updateCharacteristicsData()


### PR DESCRIPTION
If a TRP profile contains no MU field data, we're sending `"nil"` through as a string via MSP. Other addons cope with this fine, but it's still clearly incorrect.

More problematically, if we get an empty MU field back from MSP (if for example someone sets music and then later unsets it), the `emptyToNil` function is applied to `value` which makes it nil, and we were then passing that to LibRPMedia's conversion function which would explode in your face.