### PR TITLE
Added indicator for mismatched music title

### DIFF
--- a/totalRP3/core/impl/popup.lua
+++ b/totalRP3/core/impl/popup.lua
@@ -271,9 +271,19 @@ local function decorateMusic(lineFrame, musicID)
 	local musicFile = filteredMusicList[musicID][2];
 	local musicDuration = filteredMusicList[musicID][3];
 
-	setTooltipForFrame(lineFrame, lineFrame, "RIGHT", 0, -30, musicName,
-	("|cff00ff00%s: %ss\n\n|cffff9900%s: |cffffffff%s\n|cffff9900%s: |cffffffff%s"):format(loc.UI_MUSIC_DURATION, floor(musicDuration + 0.5), loc.CM_L_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_SELECT2, loc.CM_R_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_LISTEN));
+	local musicShortName = Utils.music.getTitle(musicName);
+	local musicDefaultName = Utils.music.getTitle(musicFile);
+	local tooltipContent;
+	if musicDefaultName == musicShortName then
+		tooltipContent = ("|cff00ff00%s: %ss\n\n|cffff9900%s: |cffffffff%s\n|cffff9900%s: |cffffffff%s"):format(loc.UI_MUSIC_DURATION, floor(musicDuration + 0.5), loc.CM_L_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_SELECT2, loc.CM_R_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_LISTEN);
+	else
+		tooltipContent = ("|cffffff00%s: %s\n|cff00ff00%s: %ss\n\n|cffff9900%s: |cffffffff%s\n|cffff9900%s: |cffffffff%s"):format(loc.UI_MUSIC_ALTTITLE, musicDefaultName, loc.UI_MUSIC_DURATION, floor(musicDuration + 0.5), loc.CM_L_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_SELECT2, loc.CM_R_CLICK, loc.REG_PLAYER_ABOUT_MUSIC_LISTEN);
+		musicName = musicName.."|cffffff00*";
+	end
+
+	setTooltipForFrame(lineFrame, lineFrame, "RIGHT", 0, -30, musicShortName, tooltipContent);
 	_G[lineFrame:GetName().."Text"]:SetText(musicName);
+
 	lineFrame.musicURL = musicFile;
 end
 

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -781,6 +781,7 @@ This will works:|cff00ff00
 	UI_ICON_SELECT = "Select icon",
 	UI_MUSIC_BROWSER = "Music browser",
 	UI_MUSIC_SELECT = "Select music",
+	UI_MUSIC_DURATION = "Duration",
 	UI_COLOR_BROWSER = "Color browser",
 	UI_COLOR_BROWSER_SELECT = "Select color",
 	UI_COLOR_BROWSER_PRESETS = "Presets",
@@ -1249,12 +1250,6 @@ The register also received a checkbox to only display profiles on which you wrot
 - Removed April Fools' code (including the forgotten rainbow companion names).
 
 ]],
-	------------------------------------------------------------------------------------------------
-	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
-	--- THEN MOVE IT UP ONCE IMPORTED
-	------------------------------------------------------------------------------------------------
-
-	UI_MUSIC_DURATION = "Duration",
 	WHATS_NEW_23_1 = [[
 # Changelog version 1.6.1
 
@@ -1275,6 +1270,12 @@ The register also received a checkbox to only display profiles on which you wrot
 - Fixed an error message that could be caused by other addons misusing official API functions.
 
 ]],
+	------------------------------------------------------------------------------------------------
+	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
+	--- THEN MOVE IT UP ONCE IMPORTED
+	------------------------------------------------------------------------------------------------
+
+	UI_MUSIC_ALTTITLE = "Alternate title",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
When filtering the music list and happening on musics with multiple names, the line will display the matched name which might be different from the default name shown after selection.

This will add an asterisk to any line where the matched name differs from the default name, and indicate the alternate title in the tooltip, to help curb confusion when the selected music name doesn't match the one on the line.