### PR TITLE
Use upstream packager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ git:
 
 install: luarocks install --local luacheck
 
-before_script: /home/travis/.luarocks/bin/luacheck .
+script: /home/travis/.luarocks/bin/luacheck .
 
-script: curl -s https://raw.githubusercontent.com/Ellypse/packager/master/release.sh | bash -s -- -p 75973 -w 24113 -g 8.2.0 -o
+deploy:
+  provider: script
+  script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -p 75973 -w 24113 -g 8.2.0 -o
+  on:
+    tags: true
 
 notifications:
   email:


### PR DESCRIPTION
Use a deploy block with a restriction to only deploy tagged builds, this preserves the custom behaviour from our old packager fork.