### PR TITLE
Fix recursive dependency in TOC

### DIFF
--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -3,8 +3,7 @@
 ## Author: Telkostrasz & Ellypse
 ## Notes: Data storage
 ## URL: http://totalrp3.info
-## RequiredDeps: totalRP3
 ## DefaultState: Enabled
-## LoadOnDemand: 0
+## LoadOnDemand: 1
 ## SavedVariables: TRP3_Register
 totalRP3_Data.lua


### PR DESCRIPTION
The main addon depends upon the registry data, which itself depends upon the main addon. The fact this works is pure luck, but it's by no means likely meant to be supported.

As the registry data addon does nothing, we'll instead remove its dependency upon the main addon. Additionally, flag it as LoD since there's no need to load the registry data if the main addon is itself disabled.

I've tested the following:

* Disabling the main addon means the registry data won't be loaded (as it's LoD now)
* Disabling the data addon prevents the main addon loading (as it's still a dependency that way).
* Enabling both = good.