### PR TITLE
Update LibRPMedia to v1.0.1

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -14,6 +14,8 @@ ignore:
   - totalRP3/libs/LibDeflate/examples
   - totalRP3/libs/LibDeflate/tests
   - totalRP3/libs/LibRPMedia/*.manifest
+  - totalRP3/libs/LibRPMedia/Makefile
+  - totalRP3/libs/LibRPMedia/Tests
 
 manual-changelog:
   filename: CHANGELOG.md

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -13,6 +13,7 @@ ignore:
   - totalRP3/libs/LibDeflate/docs
   - totalRP3/libs/LibDeflate/examples
   - totalRP3/libs/LibDeflate/tests
+  - totalRP3/libs/LibRPMedia/*.manifest
 
 manual-changelog:
   filename: CHANGELOG.md


### PR DESCRIPTION
No API changes in this update, just a few fixes/improvements.

This also adds the new manifest files to the exclusion list for the packager. The manifests give a human-readable dump of the database contents, if you ever need to search for something manually or see what changed between each version.