### PR TITLE
Add nil protection to UnitCreatureType in tooltip

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -824,10 +824,24 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 		local text;
 		if targetMode == TYPE_PET then
 			local creatureType = UnitCreatureType(targetType);
+			if not creatureType then
+				-- Can be nil if the creature type isn't available yet
+				-- such as after freshly crossing a load screen.
+				creatureType = UNKNOWNOBJECT;
+			end
+
 			text = TOOLTIP_UNIT_LEVEL_TYPE:format(UnitLevel(targetType) or "??", creatureType);
 		elseif targetMode == TYPE_BATTLE_PET then
 			local type = UnitBattlePetType(targetType);
-			type = _G["BATTLE_PET_NAME_" .. type];
+			if type then
+				type = _G["BATTLE_PET_NAME_" .. type];
+			else
+				-- Not sure if UnitBattlePetType can be nil, but it would
+				-- make sense for the same edge cases to possibly occur as
+				-- with UnitCreatureType.
+				type = UNKNOWNOBJECT;
+			end
+
 			text = TOOLTIP_UNIT_LEVEL_TYPE:format(UnitBattlePetLevel(targetType) or "??", type);
 		end
 


### PR DESCRIPTION
Fixes #320. 

This can return nil when crossing a loading screen, or when the type simply isn't available. If nil, we'll default it to the global token `UNKNOWNOBJECT` which is used by the base UI elsewhere when referring to an unknown unit. The token itself is the localized string for "Unknown".