### PR TITLE
Fix toolbar overlaying frames

### DIFF
--- a/totalRP3/modules/toolbar/toolbar.xml
+++ b/totalRP3/modules/toolbar/toolbar.xml
@@ -24,7 +24,7 @@
 	</Button>
 
 	<!-- Toolbar -->
-	<Frame name="TRP3_ToolbarTemplate" frameStrata="DIALOG" toplevel="true" parent="UIParent" enableMouse="true" virtual="true">
+	<Frame name="TRP3_ToolbarTemplate" frameStrata="MEDIUM" toplevel="true" parent="UIParent" enableMouse="true" virtual="true">
 		<Size x="190" y="60" />
 		<Scripts>
 			<OnLoad>


### PR DESCRIPTION
Fixes #324.

"Fullscreen" frames like the world map when maximized don't set the frame strata to FULLSCREEN, which I guess is what used to happen pre-world map rework. Instead they just bump up their frame levels, which is why opening things like the talent panel will show it above the world map.

The best fix for this is to set the strata of the toolbar down to MEDIUM, which will cause it to no longer overlay such panels. This also fixes the issue whereby we'd overlay our own TRP main window with the toolbar if maximized.