### PR TITLE
Show player POIs with relations above others

### DIFF
--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
@@ -110,7 +110,8 @@ function TRP3_PlayerMapPinMixin:Decorate(displayData)
 	end
 
 	-- Adjust the frame level of pins that have a priority assigned.
-	if displayData.categoryPriority then
+	local priority = displayData.categoryPriority or 0;
+	if priority > 0 then
 		-- Topmost level if there's any sort of priority.
 		self:UseFrameLevelType("PIN_FRAME_LEVEL_TOPMOST");
 	else

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
@@ -109,6 +109,15 @@ function TRP3_PlayerMapPinMixin:Decorate(displayData)
 		self.Texture:SetVertexColor(1, 1, 1, 1);
 	end
 
+	-- Adjust the frame level of pins that have a priority assigned.
+	if displayData.categoryPriority then
+		-- Topmost level if there's any sort of priority.
+		self:UseFrameLevelType("PIN_FRAME_LEVEL_TOPMOST");
+	else
+		-- Default level.
+		self:UseFrameLevelType("PIN_FRAME_LEVEL_VEHICLE_ABOVE_GROUP_MEMBER");
+	end
+
 	self.Texture:SetAlpha(displayData.opacity or 1)
 
 	Ellyb.Tooltips.getTooltip(self):SetTitle(ORANGE(loc.REG_PLAYERS)):ClearLines();

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
@@ -112,7 +112,7 @@ function TRP3_PlayerMapPinMixin:Decorate(displayData)
 	-- Adjust the frame level of pins that have a zero or higher priority.
 	-- This applies to pins that have a relationship status set.
 	local priority = displayData.categoryPriority or -1;
-	if priority >= 0 then
+	if type(priority) == "number" and priority >= 0 then
 		-- Topmost level if there's any sort of priority.
 		self:UseFrameLevelType("PIN_FRAME_LEVEL_TOPMOST");
 	else

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
@@ -109,9 +109,10 @@ function TRP3_PlayerMapPinMixin:Decorate(displayData)
 		self.Texture:SetVertexColor(1, 1, 1, 1);
 	end
 
-	-- Adjust the frame level of pins that have a priority assigned.
-	local priority = displayData.categoryPriority or 0;
-	if priority > 0 then
+	-- Adjust the frame level of pins that have a zero or higher priority.
+	-- This applies to pins that have a relationship status set.
+	local priority = displayData.categoryPriority or -1;
+	if priority >= 0 then
 		-- Topmost level if there's any sort of priority.
 		self:UseFrameLevelType("PIN_FRAME_LEVEL_TOPMOST");
 	else


### PR DESCRIPTION
We'll use the topmost framelevel as there's not too many other supported options (short of registering our own).