### PR TITLE
Preventing calls to war mode function on Classic

### DIFF
--- a/totalRP3/modules/map/Map.lua
+++ b/totalRP3/modules/map/Map.lua
@@ -60,7 +60,7 @@ function Map.playerCanSeeTarget(target, targetHasWarModeEnabled)
 		-- If the player is in a personal phased zone, the target has to be in their group to be seen
 		return UnitInParty(Ambiguate(target, "none"));
 	end
-	if targetHasWarModeEnabled ~= nil then
+	if not TRP3_API.globals.is_classic and targetHasWarModeEnabled ~= nil then
 		return C_PvP.IsWarModeActive() == targetHasWarModeEnabled
 	end
 	return true;

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
@@ -144,7 +144,7 @@ TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
 				end
 				local x, y = Map.getPlayerCoordinates();
 				if x and y then
-					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, C_PvP.IsWarModeActive());
+					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, TRP3_API.globals.is_classic or C_PvP.IsWarModeActive());
 				end
 			end
 		end


### PR DESCRIPTION
Forgot a couple of references to the warmode function in the Classic version, so the map scan would error out every time someone scans