### PR TITLE
Fix for duplicate MSP profiles

### DIFF
--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -241,11 +241,11 @@ function TRP3_API.register.saveCurrentProfileID(unitID, currentProfileID, isMSP)
 	local oldProfileID = character.profileID;
 	character.profileID = currentProfileID;
 	-- Search if this character was bounded to another profile
-	for _, profile in pairs(profiles) do
+	for profileID, profile in pairs(profiles) do
 		if profile.link and profile.link[unitID] then
 			profile.link[unitID] = nil; -- unbound
 			if profile.msp then
-				profile = nil;
+				profiles[profileID] = nil;
 			end
 		end
 	end

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -244,6 +244,9 @@ function TRP3_API.register.saveCurrentProfileID(unitID, currentProfileID, isMSP)
 	for _, profile in pairs(profiles) do
 		if profile.link and profile.link[unitID] then
 			profile.link[unitID] = nil; -- unbound
+			if profile.msp then
+				profile = nil;
+			end
 		end
 	end
 	if not profileExists(unitID) then
@@ -596,6 +599,13 @@ local function cleanupProfiles()
 	log("Purging profiles with no data")
 	for profileID, profile in pairs(profiles) do
 		if not profile.characteristics or Ellyb.Tables.isEmpty(profile.characteristics) then
+			deleteProfile(profileID, true);
+		end
+	end
+
+	log("Purging unbound MSP profiles")
+	for profileID, profile in pairs(profiles) do
+		if profile.msp and Ellyb.Tables.isEmpty(profile.link) then
 			deleteProfile(profileID, true);
 		end
 	end


### PR DESCRIPTION
*we did it reddit ?*

It seems like the duplicate profile issue was coming from MSP sometimes replying faster than TRP, which caused it to create a MSP profile that it would unbind immediately upon receiving the info from TRP, leaving the profile on its own.

This fix should clean up the leftover MSP profile (cannot be bound to multiple characters) upon receiving TRP info, and auto-purges unbound MSP profiles for good measure.