### PR TITLE
Remove 7.2.5 era GameTooltip bug workaround

### DIFF
--- a/totalRP3/tools/workarounds.lua
+++ b/totalRP3/tools/workarounds.lua
@@ -25,47 +25,10 @@ TRP3_API.Workarounds = Workarounds ;
 
 local workaroundsToApply = {};
 
--- Workaround for 7.2.5 issue with debuff on friendly nameplates in dungeons that would forever forbid the GameTooltip
--- from being accessible from add-ons.
--- I do not like to override CVar for the user and impose options, but there is no way around it as we need to use
--- the GameTooltip and Blizzard is giving us no choice. This situation is a fucking sad joke.
--- See https://www.wowace.com/projects/libactionbutton-1-0/issues/23
-table.insert(workaroundsToApply, function()
-	local IsInInstance = IsInInstance;
-	local InCombatLockdown = InCombatLockdown;
-	local SetCVar = SetCVar;
-	local GetCVar = GetCVar;
-	local previousUserSetting = GetCVar("nameplateShowDebuffsOnFriendly");
-
-	local function fix(value)
-		SetCVar("nameplateShowDebuffsOnFriendly", value)
-	end
-
-	-- To make sure the user never turns that option on again, we hook SetCVar and check if someone is trying to turn that on
-	hooksecurefunc("SetCVar", function(cvarName, value)
-		if InCombatLockdown() then return end
-		if cvarName == "nameplateShowDebuffsOnFriendly" and value == 1 and IsInInstance() then
-			fix(0)
-		end
-	end)
-
-	TRP3_API.Ellyb.GameEvents.registerCallback("PLAYER_ENTERING_WORLD", function()
-		if InCombatLockdown() then return end
-		if IsInInstance() and GetCVar("nameplateShowDebuffsOnFriendly") == 1 then
-			previousUserSetting = 1
-			-- Set the nameplateShowDebuffsOnFriendly to false, never show debuff on friendly nameplates
-			fix(0)
-		else
-			fix(previousUserSetting)
-		end
-	end)
-end)
-
 function Workarounds.applyWorkarounds()
 	for _, workaround in pairs(workaroundsToApply) do
 		workaround();
 	end
 end
-
 
 Workarounds.applyWorkarounds();


### PR DESCRIPTION
As noted on the [issue tracker](https://www.wowace.com/projects/libactionbutton-1-0/issues/23), this issue was fixed by Blizzard back in 8.0.

I've not tested to confirm if this is the case, but I'm willing to trust them on this.