### PR TITLE
Fix errors loading when target bar is disabled

### DIFF
--- a/totalRP3/modules/register/characters/ReportProfileButton.lua
+++ b/totalRP3/modules/register/characters/ReportProfileButton.lua
@@ -24,26 +24,31 @@ local loc = TRP3_API.loc;
 local REPORT_ICON = Ellyb.Icon([[Interface\HelpFrame\HelpIcon-OpenTicket]]);
 
 TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
-    TRP3_API.target.registerButton({
-        id = "zzzzzzzzzz_player_report",
-        configText = loc.REG_REPORT_PLAYER_PROFILE,
-        onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-        condition = function(_, unitID)
-            return UnitIsPlayer("target") and unitID ~= TRP3_API.globals.player_id
-        end,
-        onClick = function()
-            local playerID = TRP3_API.utils.str.getUnitID("target");
-            local profile = TRP3_API.register.getUnitIDProfile(playerID)
+	if not TRP3_API.target then
+		-- Target bar module disabled.
+		return;
+	end
 
-            local reportText = loc.REG_REPORT_PLAYER_OPEN_URL_160:format(playerID);
-            if profile.time then
-                local DATE_FORMAT = "%Y-%m-%d around %H:%M";
-                reportText = reportText .. "\n\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_DATE:format(date(DATE_FORMAT, profile.time));
-            end
-            Ellyb.Popups:OpenURL("https://battle.net/support/help/product/wow/197/1501/solution", reportText);
-        end,
-        tooltip =  REPORT_ICON:GenerateString(25) .. loc.REG_REPORT_PLAYER_PROFILE,
-        tooltipSub = loc.REG_REPORT_PLAYER_PROFILE_TT,
-        icon = REPORT_ICON
-    });
+	TRP3_API.target.registerButton({
+		id = "zzzzzzzzzz_player_report",
+		configText = loc.REG_REPORT_PLAYER_PROFILE,
+		onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
+		condition = function(_, unitID)
+			return UnitIsPlayer("target") and unitID ~= TRP3_API.globals.player_id
+		end,
+		onClick = function()
+			local playerID = TRP3_API.utils.str.getUnitID("target");
+			local profile = TRP3_API.register.getUnitIDProfile(playerID)
+
+			local reportText = loc.REG_REPORT_PLAYER_OPEN_URL_160:format(playerID);
+			if profile.time then
+				local DATE_FORMAT = "%Y-%m-%d around %H:%M";
+				reportText = reportText .. "\n\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_DATE:format(date(DATE_FORMAT, profile.time));
+			end
+			Ellyb.Popups:OpenURL("https://battle.net/support/help/product/wow/197/1501/solution", reportText);
+		end,
+		tooltip =  REPORT_ICON:GenerateString(25) .. loc.REG_REPORT_PLAYER_PROFILE,
+		tooltipSub = loc.REG_REPORT_PLAYER_PROFILE_TT,
+		icon = REPORT_ICON
+	});
 end)

--- a/totalRP3/modules/register/characters/register_notes.lua
+++ b/totalRP3/modules/register/characters/register_notes.lua
@@ -39,99 +39,104 @@ local NOTES_ICON = Ellyb.Icon(Globals.is_classic and "INV_Scroll_02" or "Inv_mis
 
 local function displayNotes(context)
 
-    local profileID = context.profileID;
-    if context.isPlayer then
-        profileID = getPlayerCurrentProfileID();
-        TRP3_RegisterNotesViewAccount:Hide();
-        TRP3_RegisterNotesViewProfile:SetPoint("BOTTOM", TRP3_RegisterNotesView, "BOTTOM", 0, 10);
-    else
-        TRP3_RegisterNotesViewProfile:SetPoint("BOTTOM", TRP3_RegisterNotesViewPoint, "TOP", 0, 5);
-        TRP3_RegisterNotesViewAccount:Show();
-    end
+	local profileID = context.profileID;
+	if context.isPlayer then
+		profileID = getPlayerCurrentProfileID();
+		TRP3_RegisterNotesViewAccount:Hide();
+		TRP3_RegisterNotesViewProfile:SetPoint("BOTTOM", TRP3_RegisterNotesView, "BOTTOM", 0, 10);
+	else
+		TRP3_RegisterNotesViewProfile:SetPoint("BOTTOM", TRP3_RegisterNotesViewPoint, "TOP", 0, 5);
+		TRP3_RegisterNotesViewAccount:Show();
+	end
 
-    local currentName = GetCurrentUser():GetRoleplayingName();
-    local profileNotesTitle = loc.REG_PLAYER_NOTES_PROFILE_NONAME;
-    if currentName then
-        profileNotesTitle = string.format(loc.REG_PLAYER_NOTES_PROFILE, currentName);
-    end
-    TRP3_RegisterNotesViewProfileTitle:SetText(profileNotesTitle);
+	local currentName = GetCurrentUser():GetRoleplayingName();
+	local profileNotesTitle = loc.REG_PLAYER_NOTES_PROFILE_NONAME;
+	if currentName then
+		profileNotesTitle = string.format(loc.REG_PLAYER_NOTES_PROFILE, currentName);
+	end
+	TRP3_RegisterNotesViewProfileTitle:SetText(profileNotesTitle);
 
-    assert(profileID, "No profileID in context !");
+	assert(profileID, "No profileID in context !");
 
-    local profileNotes = getPlayerCurrentProfile().notes;
-    TRP3_RegisterNotesViewProfileScrollText:SetText(profileNotes and profileNotes[profileID] or "");
-    TRP3_RegisterNotesViewAccountScrollText:SetText(TRP3_Notes and TRP3_Notes[profileID] or "");
+	local profileNotes = getPlayerCurrentProfile().notes;
+	TRP3_RegisterNotesViewProfileScrollText:SetText(profileNotes and profileNotes[profileID] or "");
+	TRP3_RegisterNotesViewAccountScrollText:SetText(TRP3_Notes and TRP3_Notes[profileID] or "");
 end
 
 local function onProfileNotesChanged()
-    local context = getCurrentContext();
-    local profileID = context.profileID;
-    if context.isPlayer then
-        profileID = getPlayerCurrentProfileID();
-    end
+	local context = getCurrentContext();
+	local profileID = context.profileID;
+	if context.isPlayer then
+		profileID = getPlayerCurrentProfileID();
+	end
 
-    local profile = getPlayerCurrentProfile();
-    if not profile.notes then
-        profile.notes = {};
-    end
+	local profile = getPlayerCurrentProfile();
+	if not profile.notes then
+		profile.notes = {};
+	end
 
-    profile.notes[profileID] = stEtN(TRP3_RegisterNotesViewProfileScrollText:GetText());
+	profile.notes[profileID] = stEtN(TRP3_RegisterNotesViewProfileScrollText:GetText());
 end
 
 local function onAccountNotesChanged()
-    local context = getCurrentContext();
-    local profileID = context.profileID;
-    if context.isPlayer then
-        profileID = getPlayerCurrentProfileID();
-    end
+	local context = getCurrentContext();
+	local profileID = context.profileID;
+	if context.isPlayer then
+		profileID = getPlayerCurrentProfileID();
+	end
 
-    TRP3_Notes[profileID] = stEtN(TRP3_RegisterNotesViewAccountScrollText:GetText());
+	TRP3_Notes[profileID] = stEtN(TRP3_RegisterNotesViewAccountScrollText:GetText());
 end
 
 local function showNotesTab()
-    local context = getCurrentContext();
-    assert(context, "No context for page player_main !");
-    assert(context.profile, "No profile in context");
-    TRP3_ProfileReportButton:Hide();
-    displayNotes(context);
-    TRP3_RegisterNotes:Show();
+	local context = getCurrentContext();
+	assert(context, "No context for page player_main !");
+	assert(context.profile, "No profile in context");
+	TRP3_ProfileReportButton:Hide();
+	displayNotes(context);
+	TRP3_RegisterNotes:Show();
 end
 TRP3_API.register.ui.showNotesTab = showNotesTab;
 
 function TRP3_API.register.inits.notesInit()
 
-    if not TRP3_Notes then
-        TRP3_Notes = {};
-    end
+	if not TRP3_Notes then
+		TRP3_Notes = {};
+	end
 
-    setupFieldSet(TRP3_RegisterNotesView, loc.REG_PLAYER_NOTES, 150);
+	setupFieldSet(TRP3_RegisterNotesView, loc.REG_PLAYER_NOTES, 150);
 
-    TRP3_RegisterNotesViewAccountTitle:SetText(loc.REG_PLAYER_NOTES_ACCOUNT);
+	TRP3_RegisterNotesViewAccountTitle:SetText(loc.REG_PLAYER_NOTES_ACCOUNT);
 
-    setTooltipForSameFrame(TRP3_RegisterNotesViewProfileHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_PROFILE_NONAME, loc.REG_PLAYER_NOTES_PROFILE_HELP);
-    setTooltipForSameFrame(TRP3_RegisterNotesViewAccountHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_ACCOUNT, loc.REG_PLAYER_NOTES_ACCOUNT_HELP);
+	setTooltipForSameFrame(TRP3_RegisterNotesViewProfileHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_PROFILE_NONAME, loc.REG_PLAYER_NOTES_PROFILE_HELP);
+	setTooltipForSameFrame(TRP3_RegisterNotesViewAccountHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_ACCOUNT, loc.REG_PLAYER_NOTES_ACCOUNT_HELP);
 
-    TRP3_RegisterNotesViewAccountScrollText:SetScript("OnTextChanged", onAccountNotesChanged);
-    TRP3_RegisterNotesViewProfileScrollText:SetScript("OnTextChanged", onProfileNotesChanged);
+	TRP3_RegisterNotesViewAccountScrollText:SetScript("OnTextChanged", onAccountNotesChanged);
+	TRP3_RegisterNotesViewProfileScrollText:SetScript("OnTextChanged", onProfileNotesChanged);
 
-    TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
-        local openPageByUnitID = TRP3_API.register.openPageByUnitID;
-        local openNotesTab = TRP3_TabBar_Tab_5:GetScript("OnClick");    -- This was a quick workaround for RP.IO, is there a better option ?
-        TRP3_API.target.registerButton({
-            id = "za_notes",
-            configText = loc.REG_NOTES_PROFILE,
-            onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-            condition = function(_, unitID)
-                return unitID == Globals.player_id or (isUnitIDKnown(unitID) and hasProfile(unitID));
-            end,
-            onClick = function(unitID)
-                openMainFrame();
-                openPageByUnitID(unitID);
-                openNotesTab();
-            end,
-            tooltip = loc.REG_NOTES_PROFILE,
-            tooltipSub = loc.REG_NOTES_PROFILE_TT,
-            icon = NOTES_ICON
-        });
-    end)
+	TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
+		if not TRP3_API.target then
+			-- Target bar module disabled.
+			return;
+		end
+
+		local openPageByUnitID = TRP3_API.register.openPageByUnitID;
+		local openNotesTab = TRP3_TabBar_Tab_5:GetScript("OnClick");    -- This was a quick workaround for RP.IO, is there a better option ?
+		TRP3_API.target.registerButton({
+			id = "za_notes",
+			configText = loc.REG_NOTES_PROFILE,
+			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
+			condition = function(_, unitID)
+				return unitID == Globals.player_id or (isUnitIDKnown(unitID) and hasProfile(unitID));
+			end,
+			onClick = function(unitID)
+				openMainFrame();
+				openPageByUnitID(unitID);
+				openNotesTab();
+			end,
+			tooltip = loc.REG_NOTES_PROFILE,
+			tooltipSub = loc.REG_NOTES_PROFILE_TT,
+			icon = NOTES_ICON
+		});
+	end)
 end

--- a/totalRP3/modules/register/filter/register_mature_filter.lua
+++ b/totalRP3/modules/register/filter/register_mature_filter.lua
@@ -566,67 +566,69 @@ local function onStart()
 	-- TARGET FRAME BUTTONS
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	-- Add to white list button
-	TRP3_API.target.registerButton({
-		id = "aa_player_w_mature_white_list",
-		configText = loc.MATURE_FILTER_ADD_TO_WHITELIST_OPTION,
-		onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-		condition = function(_, unitID)
-			if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
-				local profileID = getUnitIDProfileID(unitID);
-				return profileID and TRP3_API.register.unitIDIsFilteredForMatureContent(unitID)
-			else
-				return false;
-			end
-		end,
-		onClick = whitelistProfileByUnitIDConfirm,
-		tooltipSub = "|cffffff00" .. loc.CM_CLICK .. "|r: " .. loc.MATURE_FILTER_ADD_TO_WHITELIST_TT,
-		tooltip = loc.MATURE_FILTER_ADD_TO_WHITELIST,
-		icon = "INV_ValentinesCard02"
-	});
-	-- Remove from white list button
-	TRP3_API.target.registerButton({
-		id = "aa_player_w_mature_remove_white_list",
-		configText = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_OPTION,
-		onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-		condition = function(_, unitID)
-			if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
-				local profile = getUnitIDProfile(unitID);
-				local profileID = getUnitIDProfileID(unitID);
-				return profileID and profile.hasMatureContent and isProfileWhitelisted(profileID);
-			else
-				return false;
-			end
-		end,
-		onClick = function(unitID)
-			removeUnitProfileFromWhitelistConfirm(unitID);
-		end,
-		tooltipSub = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_TT,
-		tooltip = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST,
-		icon = TRP3_API.globals.is_classic and "INV_Scroll_07" or "INV_Inscription_ParchmentVar03"
-	});
+	if TRP3_API.target then
+		-- Add to white list button
+		TRP3_API.target.registerButton({
+			id = "aa_player_w_mature_white_list",
+			configText = loc.MATURE_FILTER_ADD_TO_WHITELIST_OPTION,
+			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
+			condition = function(_, unitID)
+				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
+					local profileID = getUnitIDProfileID(unitID);
+					return profileID and TRP3_API.register.unitIDIsFilteredForMatureContent(unitID)
+				else
+					return false;
+				end
+			end,
+			onClick = whitelistProfileByUnitIDConfirm,
+			tooltipSub = "|cffffff00" .. loc.CM_CLICK .. "|r: " .. loc.MATURE_FILTER_ADD_TO_WHITELIST_TT,
+			tooltip = loc.MATURE_FILTER_ADD_TO_WHITELIST,
+			icon = "INV_ValentinesCard02"
+		});
+		-- Remove from white list button
+		TRP3_API.target.registerButton({
+			id = "aa_player_w_mature_remove_white_list",
+			configText = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_OPTION,
+			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
+			condition = function(_, unitID)
+				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
+					local profile = getUnitIDProfile(unitID);
+					local profileID = getUnitIDProfileID(unitID);
+					return profileID and profile.hasMatureContent and isProfileWhitelisted(profileID);
+				else
+					return false;
+				end
+			end,
+			onClick = function(unitID)
+				removeUnitProfileFromWhitelistConfirm(unitID);
+			end,
+			tooltipSub = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_TT,
+			tooltip = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST,
+			icon = TRP3_API.globals.is_classic and "INV_Scroll_07" or "INV_Inscription_ParchmentVar03"
+		});
 
-	-- Manually flag player button
-	TRP3_API.target.registerButton({
-		id = "aa_player_w_mature_flag",
-		configText = loc.MATURE_FILTER_FLAG_PLAYER_OPTION,
-		onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-		condition = function(_, unitID)
-			if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
-				local profile = getUnitIDProfile(unitID);
-				local profileID = getUnitIDProfileID(unitID);
-				return profileID and not profile.hasMatureContent and not isProfileWhitelisted(profileID);
-			else
-				return false;
-			end
-		end,
-		onClick = function(unitID)
-			flagUnitProfileHasHavingMatureContentConfirm(unitID);
-		end,
-		tooltipSub = loc.MATURE_FILTER_FLAG_PLAYER_TT,
-		tooltip = loc.MATURE_FILTER_FLAG_PLAYER,
-		icon = TRP3_API.globals.is_classic and "Ability_Hunter_SniperShot" or "Ability_Hunter_MasterMarksman"
-	});
+		-- Manually flag player button
+		TRP3_API.target.registerButton({
+			id = "aa_player_w_mature_flag",
+			configText = loc.MATURE_FILTER_FLAG_PLAYER_OPTION,
+			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
+			condition = function(_, unitID)
+				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
+					local profile = getUnitIDProfile(unitID);
+					local profileID = getUnitIDProfileID(unitID);
+					return profileID and not profile.hasMatureContent and not isProfileWhitelisted(profileID);
+				else
+					return false;
+				end
+			end,
+			onClick = function(unitID)
+				flagUnitProfileHasHavingMatureContentConfirm(unitID);
+			end,
+			tooltipSub = loc.MATURE_FILTER_FLAG_PLAYER_TT,
+			tooltip = loc.MATURE_FILTER_FLAG_PLAYER,
+			icon = TRP3_API.globals.is_classic and "Ability_Hunter_SniperShot" or "Ability_Hunter_MasterMarksman"
+		});
+	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- EVENT LISTENER


### PR DESCRIPTION
Disabling the target bar module breaks the addon quite horrifically, but you *can* still get to the settings page to re-enable it.

This fixes the errors by adding a few key `if TRP3_API.target` checks in areas where it was initially failing.

One issue that I still need to look at after this fix is with the module disabled, it seems the glance portion doesn't quite take the hint:

![image](https://user-images.githubusercontent.com/287102/64071317-9a14c780-cc6f-11e9-8a87-050a97195f81.png)
