### PR TITLE
Add check before IsMountable

### DIFF
--- a/totalRP3/modules/register/main/register_cursor.lua
+++ b/totalRP3/modules/register/main/register_cursor.lua
@@ -58,7 +58,7 @@ local function canInteractWithUnit()
 	not Mouseover:Exists()
 	or InCombatLockdown() -- We don't want to open stuff in combat
 	or not Mouseover:IsPlayer() -- Unit has to be a player
-	or Mouseover:IsMountable() -- Avoid unit on multi seats mounts
+	or not TRP3_API.globals.is_classic and Mouseover:IsMountable() -- Avoid unit on multi seats mounts
 	or Mouseover:IsAttackable() -- Unit must not be attackable
 	then
 		return false;


### PR DESCRIPTION
When checking if we can show the "Right-click to open profile cursor", we check if the mouseover unit is mountable, which includes counting the amount of seats on the vehicle. This function doesn't exist on Classic, nor do multi-seat mounts, so we can just skip this check to prevent errors.