### PR TITLE
Added default values for character tab

### DIFF
--- a/totalRP3/modules/dashboard/dashboard.lua
+++ b/totalRP3/modules/dashboard/dashboard.lua
@@ -52,6 +52,9 @@ local get, getDefaultProfile = TRP3_API.profile.getData, TRP3_API.profile.getDef
 
 getDefaultProfile().player.character = {
 	v = 1,
+	RP = TRP3_Enums.ROLEPLAY_STATUS.IN_CHARACTER,
+	XP = TRP3_Enums.ROLEPLAY_EXPERIENCE.EXPERIENCED,
+	LC = TRP3_Configuration["AddonLocale"] or GetLocale(),
 }
 
 local function incrementCharacterVernum()


### PR DESCRIPTION
When creating a new profile, the values on the dashboard for RP status, experience and language were all shown as "custom" because there was no value for them. Default profile now sets all three with default values.