### PR TITLE
Removed wrong default value

### DIFF
--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
@@ -163,7 +163,7 @@ TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
 	broadcast.registerP2PCommand(SCAN_COMMAND, function(sender, x, y, hasWarModeActive)
 		-- Booleans received from commands are strings, need to cast to boolean
 		hasWarModeActive = hasWarModeActive == "true"
-		local checkWarMode = not TRP3_API.globals.is_classic;
+		local checkWarMode;
 
 		-- If the option to show people in different War Mode is not enabled we will filter them out from the result
 		if not TRP3_API.globals.is_classic and not getConfigValue(CONFIG_SHOW_DIFFERENT_WAR_MODES) then


### PR DESCRIPTION
checkWarMode has to stay nil if we're not checking the war mode. In this version, if the setting to show different war modes was enabled on retail, it would consider the player to always be in war mode, effectively hiding all scan responses in capital cities.