### PR TITLE
Companion target frame dropdown improvements

### DIFF
--- a/totalRP3/modules/register/companions/register_companions_profiles.lua
+++ b/totalRP3/modules/register/companions/register_companions_profiles.lua
@@ -372,7 +372,6 @@ end
 
 local function getPlayerCompanionProfilesAsList(companionID)
 	local list = {};
-	tinsert(list, {loc.REG_COMPANION_TF_CREATE, 2});
 	for profileID, profile in pairs(getProfiles()) do
 		if getCompanionProfileID(companionID) == profileID then
 			tinsert(list, {profile.profileName, nil});
@@ -380,6 +379,7 @@ local function getPlayerCompanionProfilesAsList(companionID)
 			tinsert(list, {profile.profileName, profileID});
 		end
 	end
+	table.sort(list, function(a,b) return string.lower(a[1]) < string.lower(b[1]) end);
 	return list;
 end
 
@@ -414,7 +414,11 @@ local function companionProfileSelectionList(unitID, targetType, _, button)
 			tinsert(list, {loc.REG_COMPANION_TF_OPEN, 0});
 			tinsert(list, {loc.REG_COMPANION_TF_UNBOUND, 1});
 		end
-		tinsert(list, {loc.REG_COMPANION_TF_BOUND_TO, getPlayerCompanionProfilesAsList(companionID)});
+		tinsert(list, {loc.REG_COMPANION_TF_CREATE, 2});
+		local profileList = getPlayerCompanionProfilesAsList(companionID);
+		if not Ellyb.Tables.isEmpty(profileList) then
+			tinsert(list, {loc.REG_COMPANION_TF_BOUND_TO, profileList});
+		end
 
 		displayDropDown(button, list, function(value) onCompanionProfileSelection(value, companionID, targetType) end, 0, true);
 	else


### PR DESCRIPTION
Hi it's me again

"Create new profile" has been moved out of the profile list onto the main dropdown. This means the option to bind a profile can appear empty if you have no companion profile at all, hence the empty table check.

Also, quick alphabetical sort for companion profiles. It's not yet a fix for #54 but it's a small improvement for those with lists that don't go off screen. I will finish the fix eventually when I can work on Extended (since that was my reason for doing it in the first place).