### PR TITLE
Speech detections tweaks

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -354,7 +354,7 @@ TRP3_API.utils.getCharacterInfoTab = getCharacterInfoTab;
 
 ---@param message string
 ---@param NPCEmoteChatColor Color
-local function detectEmoteAndOOC(message, isEmote, NPCEmoteChatColor)
+local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 	if disabledByOOC() then
 		return message;
 	end
@@ -609,7 +609,7 @@ function handleCharacterMessage(_, event, message, ...)
 
 			if message == " " then
 				-- Colorize emote and OOC (it's an NPC emote, the content is in the name)
-				npcMessageName = detectEmoteAndOOC(npcMessageName, true, NPCEmoteChatColor);
+				npcMessageName = detectEmoteAndOOC(npcMessageName, NPCEmoteChatColor, true);
 			else
 				isEmote = false;
 			end
@@ -640,7 +640,7 @@ function handleCharacterMessage(_, event, message, ...)
 
 	-- Colorize emote and OOC
 	if message ~= " " then
-		message = detectEmoteAndOOC(message, isEmote, NPCEmoteChatColor);
+		message = detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote);
 	end
 
 	return false, message, ...;

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -607,7 +607,10 @@ function handleCharacterMessage(_, event, message, ...)
 			npcMessageId = messageID;
 			npcMessageName, message, NPCEmoteChatColor = handleNPCEmote(message, messageSender);
 
-			if message ~= " " then
+			if message == " " then
+				-- Colorize emote and OOC (it's an NPC emote, the content is in the name)
+				npcMessageName = detectEmoteAndOOC(npcMessageName, true, NPCEmoteChatColor);
+			else
 				isEmote = false;
 			end
 
@@ -636,7 +639,9 @@ function handleCharacterMessage(_, event, message, ...)
 	end
 
 	-- Colorize emote and OOC
-	message = detectEmoteAndOOC(message, isEmote, NPCEmoteChatColor);
+	if message ~= " " then
+		message = detectEmoteAndOOC(message, isEmote, NPCEmoteChatColor);
+	end
 
 	return false, message, ...;
 end


### PR DESCRIPTION
- Speech detection will only apply to emotes
- This applies to NPC emotes (and NPC speech) which will also get other detections (the content of NPC emotes being stored in the name, it wasn't passing through the detection function).