### PR TITLE
Added apostrophe to the icon pattern matching

### DIFF
--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -728,8 +728,8 @@ local function convertTextTag(tag)
 		return Utils.str.color(tag:match("^col%:(%a)$"));
 	elseif tag:match("^col:%x%x%x%x%x%x$") then -- Hexa color replacement
 		return "|cff"..tag:match("^col:(%x%x%x%x%x%x)$");
-	elseif tag:match("^icon%:[%w%s%_%-%d]+%:%d+$") then -- Icon
-		local icon, size = tag:match("^icon%:([%w%s%_%-%d]+)%:(%d+)$");
+	elseif tag:match("^icon%:[%w%s%_%-%'%d]+%:%d+$") then -- Icon
+		local icon, size = tag:match("^icon%:([%w%s%_%-%'%d]+)%:(%d+)$");
 		return Utils.str.icon(icon, size);
 	end
 

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -728,8 +728,8 @@ local function convertTextTag(tag)
 		return Utils.str.color(tag:match("^col%:(%a)$"));
 	elseif tag:match("^col:%x%x%x%x%x%x$") then -- Hexa color replacement
 		return "|cff"..tag:match("^col:(%x%x%x%x%x%x)$");
-	elseif tag:match("^icon%:[%w%s%_%-%'%d]+%:%d+$") then -- Icon
-		local icon, size = tag:match("^icon%:([%w%s%_%-%'%d]+)%:(%d+)$");
+	elseif tag:match("^icon%:[^:]+%:%d+$") then -- Icon
+		local icon, size = tag:match("^icon%:([^:]+)%:(%d+)$");
 		return Utils.str.icon(icon, size);
 	end
 


### PR DESCRIPTION
Opening a PR right now but won't merge until next week.

Some icons break formatting because they have an apostrophe (achievement_boss_kael'thassunstrider_01, achievement_dungeon_drak'tharon_heroic) which was not currently included as a possible character in the icon pattern.

**It should be considered to switch the pattern with [^:]+ or [^%:]+ to avoid issues if more unexpected characters were to be found, unless there's a specific reason not to do so. Will need to test to be sure.**