### PR TITLE
Checking UNKNOWN for YELL broadcast (because 1.13.3)

### DIFF
--- a/totalRP3/core/impl/communication_protocol_broadcast.lua
+++ b/totalRP3/core/impl/communication_protocol_broadcast.lua
@@ -237,7 +237,8 @@ local function onMessageReceived(...)
 		end
 
 		if not isIDIgnored(sender) then
-			if distributionType == "YELL" or distributionType == "CHANNEL" and string.lower(channel) == string.lower(config_BroadcastChannel()) then
+			-- Have to test "UNKNOWN" for "YELL" addon messages because Blizzard lul
+			if distributionType == "YELL" or distributionType == "UNKNOWN" or distributionType == "CHANNEL" and string.lower(channel) == string.lower(config_BroadcastChannel()) then
 				onBroadcastReceived(message, sender, channel);
 			else
 				onP2PMessageReceived(message, sender);


### PR DESCRIPTION
Receiving an addon message sent on YELL in 1.13.3 will mark it as coming from UNKNOWN. So we gotta check it as well.