### PR TITLE
Target/Focus RP name token (#123)

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -852,7 +852,7 @@ function hooking()
 	end);
 
 	-- Restore the text without substitution before it's stored in the chat history
-	hooksecurefunc("SubstituteChatMessageBeforeSend", function(text)
+	hooksecurefunc("SubstituteChatMessageBeforeSend", function()
 		if parsedEditBox and textBeforeParse then
 			parsedEditBox:SetText(textBeforeParse);
 			parsedEditBox = nil;


### PR DESCRIPTION
As suggested in the ticket, I used the same tokens as XRP (`%xt` for target and `%xf` for focus). The substitute hook is there to ensure scrolling back the edit box history will show the tags instead of the replacement.