### PR TITLE
Removed April Fools stuff

### DIFF
--- a/totalRP3/core/impl/configuration.lua
+++ b/totalRP3/core/impl/configuration.lua
@@ -453,17 +453,6 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			},
 		}
 	}
-
-	if TRP3_API.globals.serious_day then
-		registerConfigKey("AF_STUFF", true);
-		local customAFColor = TRP3_API.globals.is_classic and TRP3_API.utils.Rainbowify or TRP3_API.utils.Oldgodify;
-		tinsert(TRP3_API.configuration.CONFIG_STRUCTURE_GENERAL.elements, 2, {
-			inherit = "TRP3_ConfigCheck",
-			title = customAFColor("Enable April Fools' joke"),
-			help = "Disable this option to remove this year's April Fools' joke.",
-			configKey = "AF_STUFF",
-		})
-	end
 end);
 
 AddOn_TotalRP3.Configuration = {}

--- a/totalRP3/core/impl/globals.lua
+++ b/totalRP3/core/impl/globals.lua
@@ -28,8 +28,6 @@ local faction, faction_loc = UnitFactionGroup("player");
 
 local Player = AddOn_TotalRP3.Player.GetCurrentUser();
 
-local currentDate = date("*t");
-
 -- Public accessor
 TRP3_API.r = {};
 TRP3_API.formats = {
@@ -87,7 +85,6 @@ TRP3_API.globals = {
 	},
 
 	is_classic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC,
-	serious_day = currentDate.month == 4 and currentDate.day == 1,
 
 	-- Profile Constants
 	PSYCHO_DEFAULT_VALUE_V1 = 3,

--- a/totalRP3/core/impl/main_structure.lua
+++ b/totalRP3/core/impl/main_structure.lua
@@ -40,7 +40,6 @@ local TRP3_MainFrameMenuContainer, TRP3_MainFramePageContainer, TRP3_MainFrame =
 local assert, pairs, tinsert, table, error, type, _G = assert, pairs, tinsert, table, error, type, _G;
 local selectMenu, unregisterMenu;
 
-local Globals = TRP3_API.globals;
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Menu management
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -293,11 +292,6 @@ TRP3_API.navigation.page.getCurrentPageID = getCurrentPageID;
 TRP3_API.navigation.openMainFrame = function()
 	TRP3_MainFrame:Show();
 	TRP3_MainFrame:Raise();
-
-	if not Globals.is_classic and Globals.serious_day and TRP3_API.configuration.getValue("AF_STUFF") then
-		TRP3_MainFrame.Eye:SetCreature(161946);
-	end
-
 	TRP3_API.ui.misc.playUISound(SOUNDKIT.ACHIEVEMENT_MENU_OPEN);
 end
 
@@ -456,15 +450,6 @@ TRP3_API.navigation.init = function()
 	closeAllButton:SetText(loc.UI_CLOSE_ALL);
 	closeAllButton:SetScript("OnClick", function(self)
 		closeAll(self.parentMenu);
-	end);
-
-	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_FINISH, function()
-		if not Globals.is_classic and Globals.serious_day and TRP3_API.configuration.getValue("AF_STUFF") then
-			TRP3_MainFrame.Eye:SetScript("OnModelLoaded", function()
-				TRP3_MainFrame.Eye:SetCameraPosition(0.5,-1.5,3);
-				TRP3_MainFrame.Eye:SetFacing(-math.pi/4);
-			end)
-		end
 	end);
 
 	TRP3_API.events.listenToEvent(TRP3_API.events.NAVIGATION_TUTORIAL_REFRESH, onTutorialRefresh);

--- a/totalRP3/core/ui/main.xml
+++ b/totalRP3/core/ui/main.xml
@@ -419,13 +419,6 @@
 
 			</Frame>
 
-			<CinematicModel parentKey="Eye" frameLevel="2">
-				<Size x="200" y="400" />
-				<Anchors>
-					<Anchor point="BOTTOM" relativeTo="TRP3_MainFrameMenuScroll" y="-20" />
-				</Anchors>
-			</CinematicModel>
-
 			<!-- RIGHT PART : TUTORIAL FRAME : blocking access to content behind it -->
 			<Frame name="TRP3_TutorialFrame" frameStrata="DIALOG" enableMouse="true" hidden="true">
 				<Anchors>

--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -1053,17 +1053,4 @@ function TRP3_API.register.inits.aboutInit()
 		TRP3_RegisterAbout_Edit_Template3_PsyTextScrollText:SetWidth(containerwidth - 290);
 		TRP3_RegisterAbout_Edit_Template3_HistTextScrollText:SetWidth(containerwidth - 290);
 	end);
-
-	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_FINISH, function()
-		if not Globals.is_classic and Globals.serious_day and getConfigValue("AF_STUFF") then
-			TRP3_RegisterAbout_AboutPanel.Corruption1:SetAtlas("bfa-threats-cornereye-background", true);
-			TRP3_RegisterAbout_AboutPanel.Corruption2:SetAtlas("bfa-threats-cornereye-background", true);
-			TRP3_RegisterAbout_AboutPanel.Corruption3:SetAtlas("bfa-threats-cornereye-background", true);
-			TRP3_RegisterAbout_AboutPanel.Corruption4:SetAtlas("bfa-threats-cornereye-background", true);
-			TRP3_RegisterAbout_AboutPanel.Corruption1:Show();
-			TRP3_RegisterAbout_AboutPanel.Corruption2:Show();
-			TRP3_RegisterAbout_AboutPanel.Corruption3:Show();
-			TRP3_RegisterAbout_AboutPanel.Corruption4:Show();
-		end
-	end);
 end

--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -366,35 +366,6 @@
 			</Frame>
 			<Frame name="TRP3_RegisterAbout_AboutPanel" setAllPoints="true">
 				<Layers>
-					<Layer level="ARTWORK">
-						<Texture parentKey="Corruption1" alphaMode="BLEND" alpha="0.8" hidden="true">
-							<Size x="181" y="165"/>
-							<Anchors>
-								<Anchor point="BOTTOMLEFT" x="5" y="5"/>
-							</Anchors>
-						</Texture>
-						<Texture parentKey="Corruption2" alphaMode="BLEND" alpha="0.8" hidden="true">
-							<Size x="181" y="165"/>
-							<Anchors>
-								<Anchor point="BOTTOMRIGHT" x="-5" y="5"/>
-							</Anchors>
-							<TexCoords top="0" left="1.0" bottom="1.0" right="0"/>
-						</Texture>
-						<Texture parentKey="Corruption3" alphaMode="BLEND" alpha="0.8" hidden="true">
-							<Size x="181" y="165"/>
-							<Anchors>
-								<Anchor point="TOPLEFT" x="5" y="-5"/>
-							</Anchors>
-							<TexCoords top="1.0" left="0" bottom="0" right="1.0"/>
-						</Texture>
-						<Texture parentKey="Corruption4" alphaMode="BLEND" alpha="0.8" hidden="true">
-							<Size x="181" y="165"/>
-							<Anchors>
-								<Anchor point="TOPRIGHT" x="-5" y="-5"/>
-							</Anchors>
-							<TexCoords top="1.0" left="1.0" bottom="0" right="0"/>
-						</Texture>
-					</Layer>
 					<Layer level="OVERLAY">
 						<FontString name="TRP3_RegisterAbout_AboutPanel_Empty" inherits="GameFontNormalLarge" justifyH="LEFT" text="[EMPTY]">
 							<Size x="0" y="10"/>

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -101,8 +101,6 @@ local ANCHOR_TAB;
 local MATURE_CONTENT_ICON = Utils.str.texture("Interface\\AddOns\\totalRP3\\resources\\18_emoji.tga", 20);
 local registerTooltipModuleIsEnabled = false;
 
-local customAFColor = TRP3_API.globals.is_classic and TRP3_API.utils.Rainbowify or TRP3_API.utils.Oldgodify;
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Config getters
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -452,11 +450,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		completeName = crop(completeName, FIELDS_TO_CROP.NAME);
 	end
 
-	if Globals.serious_day and getConfigValue("AF_STUFF") then
-		completeName = customAFColor(completeName);
-	else
-		completeName = color:WrapTextInColorCode(completeName);
-	end
+	completeName = color:WrapTextInColorCode(completeName);
 
 	-- OOC
 	if info.character and info.character.RP ~= 1 then
@@ -621,11 +615,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 				name = crop(name, FIELDS_TO_CROP.NAME);
 			end
 
-			if Globals.serious_day and getConfigValue("AF_STUFF") then
-				name = customAFColor(name);
-			else
-				name = targetClassColor:WrapTextInColorCode(name);
-			end
+			name = targetClassColor:WrapTextInColorCode(name);
 		end
 		tooltipBuilder:AddLine(loc.REG_TT_TARGET:format(name), 1, 1, 1, getSubLineFontSize());
 	end
@@ -785,9 +775,6 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 		petName = crop(petName, FIELDS_TO_CROP.NAME);
 	end
 
-	if Globals.serious_day and getConfigValue("AF_STUFF") then
-		petName = customAFColor(petName);
-	end
 
 	---@type Ellyb_Color
 	local companionCustomColor = info.NH and TRP3_API.Ellyb.Color.CreateFromHexa(info.NH) or ColorManager.WHITE
@@ -848,12 +835,7 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 			end
 		end
 
-		if Globals.serious_day and getConfigValue("AF_STUFF") then
-			ownerFinalName = customAFColor(ownerFinalName);
-		else
-			ownerFinalName = ownerColor:WrapTextInColorCode(ownerFinalName);
-		end
-
+		ownerFinalName = ownerColor:WrapTextInColorCode(ownerFinalName);
 		ownerFinalName = loc("REG_COMPANION_TF_OWNER"):format(ownerFinalName);
 
 		tooltipBuilder:AddLine(ownerFinalName, 1, 1, 1, getSubLineFontSize());
@@ -967,10 +949,6 @@ local function writeTooltipForMount(ownerID, companionFullID, mountName)
 		mountCustomName = crop(mountCustomName, FIELDS_TO_CROP.NAME);
 	end
 
-	if Globals.serious_day and getConfigValue("AF_STUFF") then
-		mountCustomName = customAFColor(mountCustomName);
-	end
-
 	---@type Ellyb_Color
 	local mountCustomColor = info.NH and TRP3_API.Ellyb.Color.CreateFromHexa(info.NH) or ColorManager.WHITE
 	if AddOn_TotalRP3.Configuration.shouldDisplayIncreasedColorContrast() then
@@ -1076,10 +1054,6 @@ local function show(targetType, targetID, targetMode)
 					ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
 				end
 
-				if not Globals.is_classic and Globals.serious_day and getConfigValue("AF_STUFF") then
-					GameTooltip_SetBackdropStyle(ui_CharacterTT, GAME_TOOLTIP_BACKDROP_STYLE_CORRUPTED_ITEM);
-					GameTooltip_SetBackdropStyle(ui_CompanionTT, GAME_TOOLTIP_BACKDROP_STYLE_CORRUPTED_ITEM);
-				end
 				ui_CharacterTT:SetBackdropBorderColor(1, 1, 1);
 				if targetMode == TYPE_CHARACTER then
 					writeTooltipForCharacter(targetID, originalTexts, targetType);


### PR DESCRIPTION
Basically reverted the whole April Fools commit, with the exception of two modifications:
- The Luacheck addition of the corrupted tooltip border
- The old god colouring functions. We didn't remove the rainbow one before, maybe both should be removed, but for now I didn't want to get rid of it.