### PR TITLE
Update naming to "blocklist" and "safelist"

### DIFF
--- a/totalRP3/modules/flyway/flyway.lua
+++ b/totalRP3/modules/flyway/flyway.lua
@@ -22,7 +22,7 @@ TRP3_API.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 11;
+local SCHEMA_VERSION = 12;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -153,3 +153,15 @@ TRP3_API.flyway.patches["11"] = function()
 		end
 	end
 end
+
+-- Migrate from register from "BlackList" to "BlockList" and "WhiteList" to "SafeList" naming conventions.
+TRP3_API.flyway.patches["12"] = function()
+	if TRP3_Register.blackList then
+		TRP3_Register.blockList = TRP3_Register.blackList;
+		TRP3_Register.blackList = nil;
+	end
+	if not TRP3_Register.whiteList then
+		TRP3_Register.safeList = TRP3_Register.whiteList;
+		TRP3_Register.whiteList = nil;
+	end
+end

--- a/totalRP3/modules/register/characters/register_ignore.lua
+++ b/totalRP3/modules/register/characters/register_ignore.lua
@@ -29,7 +29,7 @@ local UnitIsPlayer = UnitIsPlayer;
 local get, getPlayerCurrentProfile, hasProfile = TRP3_API.profile.getData, TRP3_API.profile.getPlayerCurrentProfile, TRP3_API.register.hasProfile;
 local getProfile, getUnitID = TRP3_API.register.getProfile, TRP3_API.utils.str.getUnitID;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
-local characters, blackList= {}, {};
+local characters, blockList = {}, {};
 local is_classic = Globals.is_classic;
 
 -- These functions gets replaced by the proper TRP3 one once the addon has finished loading
@@ -139,7 +139,7 @@ end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 local function isIDIgnored(ID)
-	return blackList[ID] ~= nil;
+	return blockList[ID] ~= nil;
 end
 TRP3_API.register.isIDIgnored = isIDIgnored;
 
@@ -147,7 +147,7 @@ local function ignoreID(unitID, reason)
 	if reason:len() == 0 then
 		reason = loc.TF_IGNORE_NO_REASON;
 	end
-	blackList[unitID] = reason;
+	blockList[unitID] = reason;
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), nil);
 end
 TRP3_API.register.ignoreID = ignoreID;
@@ -160,14 +160,14 @@ end
 TRP3_API.register.ignoreIDConfirm = ignoreIDConfirm;
 
 local function getIgnoreReason(unitID)
-	return blackList[unitID];
+	return blockList[unitID];
 end
 TRP3_API.register.getIgnoreReason = getIgnoreReason;
 
 function TRP3_API.register.getIDsToPurge()
 	local profileToPurge = {};
 	local characterToPurge = {};
-	for unitID, _ in pairs(blackList) do
+	for unitID, _ in pairs(blockList) do
 		if characters[unitID] then
 			tinsert(characterToPurge, unitID);
 			if characters[unitID].profileID then
@@ -179,12 +179,12 @@ function TRP3_API.register.getIDsToPurge()
 end
 
 function TRP3_API.register.unignoreID(unitID)
-	blackList[unitID] = nil;
+	blockList[unitID] = nil;
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, TRP3_API.register.isUnitIDKnown(unitID) and hasProfile(unitID) or nil, nil);
 end
 
 function TRP3_API.register.getIgnoredList()
-	return blackList;
+	return blockList;
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -215,14 +215,14 @@ end
 Events.listenToEvent(Events.WORKFLOW_ON_LOAD, function()
 	getCompleteName, getPlayerCompleteName = TRP3_API.register.getCompleteName, TRP3_API.register.getPlayerCompleteName;
 
-	if not TRP3_Register.blackList then
-		TRP3_Register.blackList = {};
+	if not TRP3_Register.blockList then
+		TRP3_Register.blockList = {};
 	end
-	if not TRP3_Register.whiteList then
-		TRP3_Register.whiteList = {};
+	if not TRP3_Register.safeList then
+		TRP3_Register.safeList = {};
 	end
 	characters = TRP3_Register.character;
-	blackList = TRP3_Register.blackList;
+	blockList = TRP3_Register.blockList;
 end);
 
 TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -197,7 +197,7 @@ local function unitIDIsFilteredForMatureContent(unitID)
 	local profileID = getUnitIDProfileID(unitID);
 	-- Check if the profile has been flagged as containing mature content, that the option to filter such content is enabled
 	-- and that the profile is not in the pink list.
-	return profile.hasMatureContent and getConfigValue("register_mature_filter") and not (TRP3_API.register.mature_filter.isProfileWhitelisted(profileID))
+	return profile.hasMatureContent and getConfigValue("register_mature_filter") and not (TRP3_API.register.mature_filter.isProfileSafeListed(profileID))
 end
 
 TRP3_API.register.unitIDIsFilteredForMatureContent = unitIDIsFilteredForMatureContent;
@@ -207,7 +207,7 @@ local function profileIDISFilteredForMatureContent (profileID)
 
 	local profile = getProfileOrNil(profileID);
 
-	return profile and profile.hasMatureContent and not TRP3_API.register.mature_filter.isProfileWhitelisted(profileID);
+	return profile and profile.hasMatureContent and not TRP3_API.register.mature_filter.isProfileSafeListed(profileID);
 end
 
 TRP3_API.register.profileIDISFilteredForMatureContent = profileIDISFilteredForMatureContent;

--- a/totalRP3/modules/register/filter/register_mature_filter.lua
+++ b/totalRP3/modules/register/filter/register_mature_filter.lua
@@ -26,6 +26,8 @@
 ---@type TRP3_API
 local _, TRP3_API = ...;
 
+local Ellyb = Ellyb(...);
+
 local function onStart()
 
 	-- TRP3 API imports
@@ -60,48 +62,48 @@ local function onStart()
 
 	-- Saved variables
 	TRP3_MatureFilter = TRP3_MatureFilter or {
-		whitelist = {},
+		safeList = {},
 		dictionary = nil
 	}
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-	-- WHITE LIST MANAGEMENT
+	-- SAFE LIST MANAGEMENT
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local whiteList = TRP3_MatureFilter.whitelist;
+	local safeList = TRP3_MatureFilter.safeList;
 
 	---
-	-- Add a profile ID to the whitelist
+	-- Add a profile ID to the safe list
 	-- @param profileID
 	--
-	local function whitelistProfileID(profileID)
-		assert(profileID, ("Trying to call whitelistProfileID with a nil profileID."));
+	local function addProfileIdToSafeList(profileID)
+		assert(profileID, ("Trying to call addProfileIdToSafeList with a nil profileID."));
 
-		whiteList[profileID] = true;
+		safeList[profileID] = true;
 	end
 
-	TRP3_API.register.mature_filter.whitelistProfileID = whitelistProfileID;
+	TRP3_API.register.mature_filter.addProfileIdToSafeList = addProfileIdToSafeList;
 
 	---
-	-- Remove a profile from the white list
+	-- Remove a profile from the safe list
 	-- @param profileID ID of the profile to remove
 	--
-	local function removeProfileIDFromWhiteList(profileID)
-		assert(profileID, ("Trying to call removeProfileIDFromWhiteList with a nil profileID."));
-		assert(whiteList[profileID], ("Profile %s is not currently in the whitelist."):format(profileID));
+	local function removeProfileIdFromSafeList(profileID)
+		assert(profileID, ("Trying to call removeProfileIdFromSafeList with a nil profileID."));
+		assert(safeList[profileID], ("Profile %s is not currently in the safe list."):format(profileID));
 
-		whiteList[profileID] = nil;
+		safeList[profileID] = nil;
 	end
 
 	---
-	-- Check if a profile is white listed
+	-- Check if a profile is the safe list.
 	-- @param profileID ID of the profile to check
 	--
-	local function isProfileWhitelisted(profileID)
-		return whiteList[profileID] or false;
+	local function isProfileSafeListed(profileID)
+		return safeList[profileID] or false;
 	end
 
-	TRP3_API.register.mature_filter.isProfileWhitelisted = isProfileWhitelisted;
+	TRP3_API.register.mature_filter.isProfileSafeListed = isProfileSafeListed;
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- DICTIONARY MANAGEMENT
@@ -196,31 +198,30 @@ local function onStart()
 		end);
 	end
 
-	local function removeUnitProfileFromWhitelistConfirm(unitID)
-		TRP3_API.popup.showConfirmPopup(loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_TEXT:format(unitID), function()
+	local function presentRemoveUnitFromSafeListPopup(unitID)
+		TRP3_API.popup.showConfirmPopup(loc.MATURE_FILTER_REMOVE_FROM_SAFELIST_TEXT:format(unitID), function()
 			local profileID = getUnitIDProfileID(unitID);
-			-- Flag the profile of the unit has having mature content
-			removeProfileIDFromWhiteList(profileID);
+			removeProfileIdFromSafeList(profileID);
 			-- Fire the event that the register has been updated so the UI stuff get refreshed
 			Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), nil);
 		end);
 	end
 
 	---
-	-- Open a confirm popup to add the profile of a given unit ID to the whitelist
+	-- Open a confirm popup to add the profile of a given unit ID to the safe list
 	-- @param unitID
 	--
-	local function whitelistProfileByUnitIDConfirm(unitID, callback)
+	local function presentAddUnitToSafeListPopup(unitID, callback)
 		local profileID = getUnitIDProfileID(unitID);
 
-		TRP3_API.popup.showConfirmPopup(loc.MATURE_FILTER_ADD_TO_WHITELIST_TEXT:format(unitID), function()
-			whitelistProfileID(profileID);
+		TRP3_API.popup.showConfirmPopup(loc.MATURE_FILTER_ADD_TO_SAFELIST_TEXT:format(unitID), function()
+			addProfileIdToSafeList(profileID);
 			Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), nil);
 			if callback and type(callback) == "function" then callback() end;
 		end);
 	end
 
-	TRP3_API.register.mature_filter.whitelistProfileByUnitIDConfirm = whitelistProfileByUnitIDConfirm;
+	TRP3_API.register.mature_filter.presentAddUnitToSafeListPopup = presentAddUnitToSafeListPopup;
 
 	local function getBadWordsThreshold()
 		return 11 - getConfigValue(MATURE_FILTER_CONFIG_STRENGTH);
@@ -455,7 +456,7 @@ local function onStart()
 	TRP3_MatureFilterPopup.remember:SetText("Remember for this profile");
 	TRP3_MatureFilterPopup.remember:SetScript("OnClick", function()
 		-- Ask to confirm then hide the popup
-		whitelistProfileByUnitIDConfirm(TRP3_MatureFilterPopup.unitID, function()
+		presentAddUnitToSafeListPopup(TRP3_MatureFilterPopup.unitID, function()
 			hidePopups();
 		end);
 	end)
@@ -567,10 +568,10 @@ local function onStart()
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	if TRP3_API.target then
-		-- Add to white list button
+		-- Add to safe list button
 		TRP3_API.target.registerButton({
 			id = "aa_player_w_mature_white_list",
-			configText = loc.MATURE_FILTER_ADD_TO_WHITELIST_OPTION,
+			configText = loc.MATURE_FILTER_ADD_TO_SAFELIST_OPTION,
 			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
 			condition = function(_, unitID)
 				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
@@ -580,30 +581,30 @@ local function onStart()
 					return false;
 				end
 			end,
-			onClick = whitelistProfileByUnitIDConfirm,
-			tooltipSub = "|cffffff00" .. loc.CM_CLICK .. "|r: " .. loc.MATURE_FILTER_ADD_TO_WHITELIST_TT,
-			tooltip = loc.MATURE_FILTER_ADD_TO_WHITELIST,
+			onClick = presentAddUnitToSafeListPopup,
+			tooltipSub = "|cffffff00" .. loc.CM_CLICK .. "|r: " .. loc.MATURE_FILTER_ADD_TO_SAFELIST_TT,
+			tooltip = loc.MATURE_FILTER_ADD_TO_SAFELIST,
 			icon = "INV_ValentinesCard02"
 		});
-		-- Remove from white list button
+		-- Remove from safe list button
 		TRP3_API.target.registerButton({
 			id = "aa_player_w_mature_remove_white_list",
-			configText = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_OPTION,
+			configText = loc.MATURE_FILTER_REMOVE_FROM_SAFELIST_OPTION,
 			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
 			condition = function(_, unitID)
 				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
 					local profile = getUnitIDProfile(unitID);
 					local profileID = getUnitIDProfileID(unitID);
-					return profileID and profile.hasMatureContent and isProfileWhitelisted(profileID);
+					return profileID and profile.hasMatureContent and isProfileSafeListed(profileID);
 				else
 					return false;
 				end
 			end,
 			onClick = function(unitID)
-				removeUnitProfileFromWhitelistConfirm(unitID);
+				presentRemoveUnitFromSafeListPopup(unitID);
 			end,
-			tooltipSub = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST_TT,
-			tooltip = loc.MATURE_FILTER_REMOVE_FROM_WHITELIST,
+			tooltipSub = loc.MATURE_FILTER_REMOVE_FROM_SAFELIST_TT,
+			tooltip = loc.MATURE_FILTER_REMOVE_FROM_SAFELIST,
 			icon = TRP3_API.globals.is_classic and "INV_Scroll_07" or "INV_Inscription_ParchmentVar03"
 		});
 
@@ -616,7 +617,7 @@ local function onStart()
 				if UnitIsPlayer("target") and unitID ~= player_id and not TRP3_API.register.isIDIgnored(unitID) then
 					local profile = getUnitIDProfile(unitID);
 					local profileID = getUnitIDProfileID(unitID);
-					return profileID and not profile.hasMatureContent and not isProfileWhitelisted(profileID);
+					return profileID and not profile.hasMatureContent and not isProfileSafeListed(profileID);
 				else
 					return false;
 				end
@@ -642,15 +643,20 @@ local function onStart()
 	end
 
 	-- We listen to data updates in the register and apply the filter if enabled
-	-- and the profile is not already whitelisted
+	-- and the profile is not already safe listed.
 	Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(_, profileID, _)
-		if isMatureFilterEnabled() and profileID and getProfileOrNil(profileID) and not isProfileWhitelisted(profileID) then
+		if isMatureFilterEnabled() and profileID and getProfileOrNil(profileID) and not isProfileSafeListed(profileID) then
 			local profile = getProfileByID(profileID);
 			if not profile.hasMatureContent or shouldReEvaluateContent(profile.lastMatureContentEvaluation) then
 				filterData(getProfileByID(profileID), profileID);
 			end
 		end
 	end);
+
+	-- TODO: Remove these deprecation warning wrappers in a future major version.
+	TRP3_API.register.mature_filter.whitelistProfileID = Ellyb.DeprecationWarnings.wrapFunction(addProfileIdToSafeList, "TRP3_API.register.mature_filter.whitelistProfileID", "TRP3_API.register.mature_filter.addProfileIdToSafeList");
+	TRP3_API.register.mature_filter.whitelistProfileByUnitIDConfirm = Ellyb.DeprecationWarnings.wrapFunction(presentAddUnitToSafeListPopup, "TRP3_API.register.mature_filter.whitelistProfileByUnitIDConfirm", "TRP3_API.register.mature_filter.presentAddUnitToSafeListPopup");
+	TRP3_API.register.mature_filter.isProfileWhitelisted = Ellyb.DeprecationWarnings.wrapFunction(isProfileSafeListed, "TRP3_API.register.mature_filter.isProfileWhitelisted", "TRP3_API.register.mature_filter.isProfileSafeListed");
 end
 
 local MODULE_STRUCTURE = {

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -988,18 +988,6 @@ A mature profile will have a muted tooltip and you will have to confirm that you
 	MATURE_FILTER_STRENGTH_TT = [[Set the strength of the mature filter.
 
 |cffcccccc1 is weak (10 bad words required to flag), 10 is strong (only 1 bad word required to flag).|r]],
-	MATURE_FILTER_ADD_TO_WHITELIST = "Add this profile to the |cffffffffmature white list|r",
-	MATURE_FILTER_ADD_TO_WHITELIST_TT = "Add this profile to the |cffffffffmature white list|r and reveal the mature content found inside.",
-	MATURE_FILTER_ADD_TO_WHITELIST_OPTION = "Add to the |cffffffffmature white list|r",
-	MATURE_FILTER_ADD_TO_WHITELIST_TEXT = [[Confirm that you want to add %s to the |cffffffffmature white list|r.
-
-The content of their profiles will no longer be hidden.]],
-	MATURE_FILTER_REMOVE_FROM_WHITELIST = "Remove this profile from the |cffffffffmature white list|r",
-	MATURE_FILTER_REMOVE_FROM_WHITELIST_TT = "Remove this profile from the |cffffffffmature white list|r and hide again the mature content found inside.",
-	MATURE_FILTER_REMOVE_FROM_WHITELIST_OPTION = "Remove from the |cffffffffmature white list|r",
-	MATURE_FILTER_REMOVE_FROM_WHITELIST_TEXT = [[Confirm that you want to remove %s from the |cffffffffmature white list|r.
-
-The content of their profiles will be hidden again.]],
 	MATURE_FILTER_FLAG_PLAYER = "Flag as mature",
 	MATURE_FILTER_FLAG_PLAYER_TT = "Flag this profile has containing mature content. The profile content will be hidden.",
 	MATURE_FILTER_FLAG_PLAYER_OPTION = "Flag as mature",
@@ -1375,7 +1363,18 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
+	MATURE_FILTER_ADD_TO_SAFELIST = "Add this profile to the |cffffffffmature safelist|r",
+	MATURE_FILTER_ADD_TO_SAFELIST_TT = "Add this profile to the |cffffffffmature safelist|r and reveal the mature content found inside.",
+	MATURE_FILTER_ADD_TO_SAFELIST_OPTION = "Add to the |cffffffffmature safelist|r",
+	MATURE_FILTER_ADD_TO_SAFELIST_TEXT = [[Confirm that you want to add %s to the |cffffffffmature safelist|r.
 
+The content of their profiles will no longer be hidden.]],
+	MATURE_FILTER_REMOVE_FROM_SAFELIST = "Remove this profile from the |cffffffffmature safelist|r",
+	MATURE_FILTER_REMOVE_FROM_SAFELIST_TT = "Remove this profile from the |cffffffffmature safelist|r and hide again the mature content found inside.",
+	MATURE_FILTER_REMOVE_FROM_SAFELIST_OPTION = "Remove from the |cffffffffmature safelist|r",
+	MATURE_FILTER_REMOVE_FROM_SAFELIST_TEXT = [[Confirm that you want to remove %s from the |cffffffffmature safelist|r.
+
+The content of their profiles will be hidden again.]],
 	WHATS_NEW_23_11 = [[
 	# Changelog version 1.6.11
 


### PR DESCRIPTION
Replaced occurrences of the terms "blacklist" and "whitelist" in the code and in the add-ons localization in favor of the terms "blocklist" and "safelist".

I have also slightly improved the naming of internal methods that were already being renamed in the process (such as `removeUnitProfileFromWhitelistConfirm` -> `presentRemoveUnitFromSafeListPopup`)

The motivation behind this is that the current world context has brought this ancestral naming convention to the spotlight and many experts advise to use more neutral terms. Here are examples of such move away from "blacklist" and "whitelist".
https://9to5google.com/2020/06/07/google-chrome-blacklist-blocklist-more-inclusive/
https://www.theregister.com/2019/09/03/chromium_microsoft_offensive/
https://jmla.pitt.edu/ojs/jmla/article/view/490