### PR TITLE
Bump TOC for Classic

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 curl -s https://raw.githubusercontent.com/Total-RP/packager/master/release.sh | bash -s -- -p 75973 -w 24113 -g 8.3.0
-curl -s https://raw.githubusercontent.com/Total-RP/packager/master/release.sh | bash -s -- -p 335857 -w 25153 -g 1.13.4
+curl -s https://raw.githubusercontent.com/Total-RP/packager/master/release.sh | bash -s -- -p 335857 -w 25153 -g 1.13.5

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -2,7 +2,7 @@
 ## Interface: 80300
 #@end-retail@
 #@non-retail@
-# ## Interface: 11304
+# ## Interface: 11305
 #@end-non-retail@
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse


### PR DESCRIPTION
Also updates the packager script invokation; note that our fork of the packager will need to integrate the changes from upstream for the new version to work, and the CF API doesn't yet have support for 1.13.5 so it'll get flagged as something else.