### PR TITLE
Fix usages of UIDropDownMenuTemplate

### DIFF
--- a/totalRP3/core/ui/configuration.xml
+++ b/totalRP3/core/ui/configuration.xml
@@ -86,7 +86,7 @@
 
 	<Frame name="TRP3_ConfigDropDown" inherits="TRP3_ConfigNote" virtual="true">
 		<Frames>
-			<Frame name="$parentDropDown" inherits="UIDropDownMenuTemplate" enableMouse="true">
+			<Frame name="$parentDropDown" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 				<Anchors>
 					<Anchor point="RIGHT" x="5" y="0"/>
 				</Anchors>

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -19,6 +19,140 @@
 		limitations under the License.
 	-->
 
+	<!--
+		Dropdown Menu
+
+		This mirrors UIDropDownMenuTemplate except the scripts for activating
+		the menu go through the MSA-DropDownMenu-1.0 library instead.
+	-->
+	<Frame name="TRP3_DropDownMenuTemplate" virtual="true">
+		<Size>
+			<AbsDimension x="40" y="32"/>
+		</Size>
+		<Layers>
+			<Layer level="ARTWORK">
+				<Texture name="$parentLeft" parentKey="Left" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
+					<Size>
+						<AbsDimension x="25" y="64"/>
+					</Size>
+					<Anchors>
+						<Anchor point="TOPLEFT">
+							<Offset>
+								<AbsDimension x="0" y="17"/>
+							</Offset>
+						</Anchor>
+					</Anchors>
+					<TexCoords left="0" right="0.1953125" top="0" bottom="1"/>
+				</Texture>
+				<Texture name="$parentMiddle" parentKey="Middle" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
+					<Size>
+						<AbsDimension x="115" y="64"/>
+					</Size>
+					<Anchors>
+						<Anchor point="LEFT" relativeKey="$parent.Left" relativePoint="RIGHT"/>
+					</Anchors>
+					<TexCoords left="0.1953125" right="0.8046875" top="0" bottom="1"/>
+				</Texture>
+				<Texture name="$parentRight" parentKey="Right" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
+					<Size>
+						<AbsDimension x="25" y="64"/>
+					</Size>
+					<Anchors>
+						<Anchor point="LEFT" relativeKey="$parent.Middle" relativePoint="RIGHT"/>
+					</Anchors>
+					<TexCoords left="0.8046875" right="1" top="0" bottom="1"/>
+				</Texture>
+				<FontString parentKey="Text" name="$parentText" inherits="GameFontHighlightSmall" wordwrap="false" justifyH="RIGHT">
+					<Size>
+						<AbsDimension x="0" y="10"/>
+					</Size>
+					<Anchors>
+						<Anchor point="RIGHT" relativeKey="$parent.Right">
+							<Offset>
+								<AbsDimension x="-43" y="2"/>
+							</Offset>
+						</Anchor>
+					</Anchors>
+				</FontString>
+			</Layer>
+			<Layer level="OVERLAY">
+				<Texture parentKey="Icon" name="$parentIcon" hidden="true">
+					<Size>
+						<AbsDimension x="16" y="16"/>
+					</Size>
+					<Anchors>
+						<Anchor point="LEFT">
+							<Offset x="30" y="2"/>
+						</Anchor>
+					</Anchors>
+				</Texture>
+			</Layer>
+		</Layers>
+		<Frames>
+			<Button parentKey="Button" name="$parentButton" motionScriptsWhileDisabled="true" >
+				<Size>
+					<AbsDimension x="24" y="24"/>
+				</Size>
+				<Anchors>
+					<Anchor point="TOPRIGHT" relativeKey="$parent.Right">
+						<Offset>
+							<AbsDimension x="-16" y="-18"/>
+						</Offset>
+					</Anchor>
+				</Anchors>
+				<Scripts>
+					<OnEnter>
+						ExecuteFrameScript(self:GetParent(), "OnEnter");
+					</OnEnter>
+					<OnLeave>
+						ExecuteFrameScript(self:GetParent(), "OnLeave");
+					</OnLeave>
+					<OnClick>
+						MSA_ToggleDropDownMenu(nil, nil, self:GetParent());
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+					</OnClick>
+				</Scripts>
+				<NormalTexture name="$parentNormalTexture" parentKey="NormalTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Up">
+					<Size>
+						<AbsDimension x="24" y="24"/>
+					</Size>
+					<Anchors>
+						<Anchor point="RIGHT"/>
+					</Anchors>
+				</NormalTexture>
+				<PushedTexture name="$parentPushedTexture" parentKey="PushedTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Down">
+					<Size>
+						<AbsDimension x="24" y="24"/>
+					</Size>
+					<Anchors>
+						<Anchor point="RIGHT"/>
+					</Anchors>
+				</PushedTexture>
+				<DisabledTexture name="$parentDisabledTexture" parentKey="DisabledTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Disabled">
+					<Size>
+						<AbsDimension x="24" y="24"/>
+					</Size>
+					<Anchors>
+						<Anchor point="RIGHT"/>
+					</Anchors>
+				</DisabledTexture>
+				<HighlightTexture name="$parentHighlightTexture" parentKey="HighlightTexture" file="Interface\Buttons\UI-Common-MouseHilight" alphaMode="ADD">
+					<Size>
+						<AbsDimension x="24" y="24"/>
+					</Size>
+					<Anchors>
+						<Anchor point="RIGHT"/>
+					</Anchors>
+				</HighlightTexture>
+			</Button>
+		</Frames>
+		<Scripts>
+			<OnHide>
+				MSA_CloseDropDownMenus();
+			</OnHide>
+		</Scripts>
+	</Frame>
+
 	<!-- Common close button  -->
 	<Button name="TRP3_CloseButton" inherits="UIPanelCloseButton" virtual="true">
 		<Scripts>
@@ -1141,7 +1275,7 @@
 			</Layer>
 		</Layers>
 	</Frame>
-	<Frame name="TRP3_TitledDropdown" inherits="UIDropDownMenuTemplate" enableMouse="true" virtual="true">
+	<Frame name="TRP3_TitledDropdown" inherits="TRP3_DropDownMenuTemplate" enableMouse="true" virtual="true">
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString name="$parentTitle" parentKey="title" text="" inherits="GameFontNormalSmall" justifyH="LEFT" justifyV="TOP">
@@ -1160,140 +1294,6 @@
 			<OnLeave>
 				TRP3_MainTooltip:Hide();
 			</OnLeave>
-		</Scripts>
-	</Frame>
-
-	<!--
-		Dropdown Menu
-
-		This mirrors UIDropDownMenuTemplate except the scripts for activating
-		the menu go through the MSA-DropDownMenu-1.0 library instead.
-	-->
-	<Frame name="TRP3_DropDownMenuTemplate" virtual="true">
-		<Size>
-			<AbsDimension x="40" y="32"/>
-		</Size>
-		<Layers>
-			<Layer level="ARTWORK">
-				<Texture name="$parentLeft" parentKey="Left" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
-					<Size>
-						<AbsDimension x="25" y="64"/>
-					</Size>
-					<Anchors>
-						<Anchor point="TOPLEFT">
-							<Offset>
-								<AbsDimension x="0" y="17"/>
-							</Offset>
-						</Anchor>
-					</Anchors>
-					<TexCoords left="0" right="0.1953125" top="0" bottom="1"/>
-				</Texture>
-				<Texture name="$parentMiddle" parentKey="Middle" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
-					<Size>
-						<AbsDimension x="115" y="64"/>
-					</Size>
-					<Anchors>
-						<Anchor point="LEFT" relativeKey="$parent.Left" relativePoint="RIGHT"/>
-					</Anchors>
-					<TexCoords left="0.1953125" right="0.8046875" top="0" bottom="1"/>
-				</Texture>
-				<Texture name="$parentRight" parentKey="Right" file="Interface\Glues\CharacterCreate\CharacterCreate-LabelFrame">
-					<Size>
-						<AbsDimension x="25" y="64"/>
-					</Size>
-					<Anchors>
-						<Anchor point="LEFT" relativeKey="$parent.Middle" relativePoint="RIGHT"/>
-					</Anchors>
-					<TexCoords left="0.8046875" right="1" top="0" bottom="1"/>
-				</Texture>
-				<FontString parentKey="Text" name="$parentText" inherits="GameFontHighlightSmall" wordwrap="false" justifyH="RIGHT">
-					<Size>
-						<AbsDimension x="0" y="10"/>
-					</Size>
-					<Anchors>
-						<Anchor point="RIGHT" relativeKey="$parent.Right">
-							<Offset>
-								<AbsDimension x="-43" y="2"/>
-							</Offset>
-						</Anchor>
-					</Anchors>
-				</FontString>
-			</Layer>
-			<Layer level="OVERLAY">
-				<Texture parentKey="Icon" name="$parentIcon" hidden="true">
-					<Size>
-						<AbsDimension x="16" y="16"/>
-					</Size>
-					<Anchors>
-						<Anchor point="LEFT">
-							<Offset x="30" y="2"/>
-						</Anchor>
-					</Anchors>
-				</Texture>
-			</Layer>
-		</Layers>
-		<Frames>
-			<Button parentKey="Button" name="$parentButton" motionScriptsWhileDisabled="true" >
-				<Size>
-					<AbsDimension x="24" y="24"/>
-				</Size>
-				<Anchors>
-					<Anchor point="TOPRIGHT" relativeKey="$parent.Right">
-						<Offset>
-							<AbsDimension x="-16" y="-18"/>
-						</Offset>
-					</Anchor>
-				</Anchors>
-				<Scripts>
-					<OnEnter>
-						ExecuteFrameScript(self:GetParent(), "OnEnter");
-					</OnEnter>
-					<OnLeave>
-						ExecuteFrameScript(self:GetParent(), "OnLeave");
-					</OnLeave>
-					<OnClick>
-						MSA_ToggleDropDownMenu(nil, nil, self:GetParent());
-						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-					</OnClick>
-				</Scripts>
-				<NormalTexture name="$parentNormalTexture" parentKey="NormalTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Up">
-					<Size>
-						<AbsDimension x="24" y="24"/>
-					</Size>
-					<Anchors>
-						<Anchor point="RIGHT"/>
-					</Anchors>
-				</NormalTexture>
-				<PushedTexture name="$parentPushedTexture" parentKey="PushedTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Down">
-					<Size>
-						<AbsDimension x="24" y="24"/>
-					</Size>
-					<Anchors>
-						<Anchor point="RIGHT"/>
-					</Anchors>
-				</PushedTexture>
-				<DisabledTexture name="$parentDisabledTexture" parentKey="DisabledTexture" file="Interface\ChatFrame\UI-ChatIcon-ScrollDown-Disabled">
-					<Size>
-						<AbsDimension x="24" y="24"/>
-					</Size>
-					<Anchors>
-						<Anchor point="RIGHT"/>
-					</Anchors>
-				</DisabledTexture>
-				<HighlightTexture name="$parentHighlightTexture" parentKey="HighlightTexture" file="Interface\Buttons\UI-Common-MouseHilight" alphaMode="ADD">
-					<Size>
-						<AbsDimension x="24" y="24"/>
-					</Size>
-					<Anchors>
-						<Anchor point="RIGHT"/>
-					</Anchors>
-				</HighlightTexture>
-			</Button>
-		</Frames>
-		<Scripts>
-			<OnHide>
-				MSA_CloseDropDownMenus();
-			</OnHide>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/modules/dashboard/dashboard.xml
+++ b/totalRP3/modules/dashboard/dashboard.xml
@@ -150,7 +150,7 @@
 					<Anchor point="RIGHT" relativePoint="CENTER" relativeKey="$parent" x="-20"/>
 				</Anchors>
 			</EditBox>
-			<Frame parentKey="channelDropdown" inherits="UIDropDownMenuTemplate" enableMouse="true" name="$parentChannelDropdown">
+			<Frame parentKey="channelDropdown" inherits="TRP3_DropDownMenuTemplate" enableMouse="true" name="$parentChannelDropdown">
 				<Anchors>
 					<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" y="-5"/>
 					<Anchor point="RIGHT" relativePoint="RIGHT" x="-25"/>

--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -101,7 +101,7 @@
 					<Anchor point="TOPLEFT" x="15" y="-12"/>
 				</Anchors>
 			</Button>
-			<Frame name="$parentBkg" inherits="UIDropDownMenuTemplate" enableMouse="true">
+			<Frame name="$parentBkg" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 				<Anchors>
 					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="$parentIcon" x="-20" y="-5"/>
 				</Anchors>
@@ -191,7 +191,7 @@
 				<PushedTexture file="Interface\Buttons\UI-Panel-CollapseButton-Down"/>
 				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
-			<Frame name="$parentBkg" inherits="UIDropDownMenuTemplate" enableMouse="true">
+			<Frame name="$parentBkg" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="42" y="5"/>
 				</Anchors>
@@ -261,12 +261,12 @@
 							</Layer>
 						</Layers>
 					</Frame>
-					<Frame name="TRP3_RegisterAbout_Edit_BckField" inherits="UIDropDownMenuTemplate" enableMouse="true">
+					<Frame name="TRP3_RegisterAbout_Edit_BckField" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 						<Anchors>
 							<Anchor point="TOPLEFT" x="0" y="-35"/>
 						</Anchors>
 					</Frame>
-					<Frame name="TRP3_RegisterAbout_Edit_TemplateField" inherits="UIDropDownMenuTemplate" enableMouse="true">
+					<Frame name="TRP3_RegisterAbout_Edit_TemplateField" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 						<Anchors>
 							<Anchor point="LEFT" relativePoint="RIGHT" x="0" y="0" relativeTo="TRP3_RegisterAbout_Edit_BckField"/>
 						</Anchors>

--- a/totalRP3/modules/register/characters/register_ui_misc.xml
+++ b/totalRP3/modules/register/characters/register_ui_misc.xml
@@ -41,7 +41,7 @@
 			</Layer>
 		</Layers>
 		<Frames>
-			<Frame name="$parentValues" inherits="UIDropDownMenuTemplate" enableMouse="true">
+			<Frame name="$parentValues" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 				<Anchors>
 					<Anchor point="LEFT" relativePoint="RIGHT" relativeTo="$parentFieldName" x="0" y="0"/>
 				</Anchors>

--- a/totalRP3/modules/register/companions/register_ui_companions_page.xml
+++ b/totalRP3/modules/register/companions/register_ui_companions_page.xml
@@ -222,7 +222,7 @@
 							<Anchor point="RIGHT" x="-10" y="0"/>
 						</Anchors>
 						<Frames>
-							<Frame name="$parent_BckField" inherits="UIDropDownMenuTemplate" enableMouse="true">
+							<Frame name="$parent_BckField" inherits="TRP3_DropDownMenuTemplate" enableMouse="true">
 								<Anchors>
 									<Anchor point="TOPLEFT" x="0" y="-15"/>
 								</Anchors>


### PR DESCRIPTION
These would spread taint to the stock dropdowns due to script handlers present in the inherited template/child frames using the global dropdown menu functions. TRP3_DropDownMenuTemplate was added a while back which resolves this issue.

This changeset could be fast-forwarded to dev for a live release if we need to do anything between now and Shadowlands.