### PR TITLE
Add backdrop support for 9.0

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11887,6 +11887,7 @@ stds.wow = {
 		"AzeriteTierPowerSelectedAnimationMixin",
 		"AzeriteTierRevealAnimationMixin",
 		"AzeriteUtil",
+		"BackdropTemplateMixin",
 		"BAG_FILTER_ICONS",
 		"BAG_FILTER_LABELS",
 		"BAG_ITEM_QUALITY_COLORS",

--- a/totalRP3/core/core.xml
+++ b/totalRP3/core/core.xml
@@ -29,7 +29,8 @@
 		</Scripts>
 	</GameTooltip>
 
-	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true" inherits="TRP3_BackdropTemplate">
+	<!-- FIXME: Requires BackdropTemplate, but loads before it. -->
+	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true">
 		<KeyValues>
 			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555" type="global"/>
 		</KeyValues>

--- a/totalRP3/core/core.xml
+++ b/totalRP3/core/core.xml
@@ -29,11 +29,10 @@
 		</Scripts>
 	</GameTooltip>
 
-	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true" bgFile="Interface\DialogFrame\UI-DialogBox-Background">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString parentKey="text" inherits="GameFontNormal" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">

--- a/totalRP3/core/core.xml
+++ b/totalRP3/core/core.xml
@@ -18,6 +18,7 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 -->
+	<Include file="ui\widgets.xml"/>
 
 	<!-- Please note that the loading order matters a lot -->
 	<GameTooltip name="TRP3_MainTooltip" frameStrata="TOOLTIP" hidden="false" parent="UIParent" inherits="GameTooltipTemplate"/>
@@ -29,8 +30,7 @@
 		</Scripts>
 	</GameTooltip>
 
-	<!-- FIXME: Requires BackdropTemplate, but loads before it. -->
-	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true">
+	<Frame name="TRP3_ResizeShadowFrame" parent="UIParent" frameStrata="FULLSCREEN" hidden="true" resizable="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
 			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555" type="global"/>
 		</KeyValues>
@@ -53,7 +53,6 @@
 	<Script file="impl\ui_tools.lua"/>
 	<Script file="impl\slash.lua"/>
 
-	<Include file="ui\widgets.xml"/>
 
 	<Include file="ui\main.xml"/>
 	<Script file="impl\main_structure.lua"/>

--- a/totalRP3/core/ui/browsers/colors.xml
+++ b/totalRP3/core/ui/browsers/colors.xml
@@ -20,11 +20,10 @@
 -->
 
 	<!-- Color browser  -->
-	<Frame name="TRP3_ColorBrowser" parent="TRP3_PopupsFrame" hidden="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_ColorBrowser" parent="TRP3_PopupsFrame" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_24_5555" type="global"/>
+		</KeyValues>
 		<Size x="440" y="285"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -54,12 +53,11 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<Frame>
+			<Frame inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_24_5555" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-					<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="TOP" relativePoint="BOTTOM" relativeTo="TRP3_ColorBrowserTitle" x="0" y="-10"/>
 					<Anchor point="BOTTOMLEFT" x="10" y="10"/>

--- a/totalRP3/core/ui/browsers/companions.xml
+++ b/totalRP3/core/ui/browsers/companions.xml
@@ -20,18 +20,10 @@
 -->
 
 	<!-- Icon browser  -->
-	<Frame name="TRP3_CompanionBrowser" parent="TRP3_PopupsFrame" hidden="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_CompanionBrowser" parent="TRP3_PopupsFrame" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="420" y="400"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -58,20 +50,12 @@
 				</Frames>
 			</Frame>
 			<!-- Filter section -->
-			<Frame name="TRP3_CompanionBrowserFilter">
+			<Frame name="TRP3_CompanionBrowserFilter" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333" type="global"/>
+					<KeyValue key="backdropColor" value="TRP3_BACKDROP_COLOR_DARK" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="16"/>
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="415"/>
-					</TileSize>
-					<Color r="0.4" g="0.4" b="0.4"/>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="10" y="10"/>
 					<Anchor point="BOTTOMRIGHT" x="-10" y="10"/>

--- a/totalRP3/core/ui/browsers/icons.xml
+++ b/totalRP3/core/ui/browsers/icons.xml
@@ -45,18 +45,10 @@
 	</Button>
 
 	<!-- Icon browser  -->
-	<Frame name="TRP3_IconBrowser" parent="TRP3_PopupsFrame" hidden="true" enableMouse="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_IconBrowser" parent="TRP3_PopupsFrame" hidden="true" enableMouse="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="425" y="400"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -83,19 +75,11 @@
 				</Frames>
 			</Frame>
 			<!-- Filter section -->
-			<Frame name="TRP3_IconBrowserFilter">
+			<Frame name="TRP3_IconBrowserFilter" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="16"/>
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="415"/>
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="10" y="10"/>
 					<Anchor point="BOTTOMRIGHT" x="-10" y="10"/>

--- a/totalRP3/core/ui/browsers/images.xml
+++ b/totalRP3/core/ui/browsers/images.xml
@@ -20,18 +20,10 @@
 -->
 
 	<!-- Images browser  -->
-	<Frame name="TRP3_ImageBrowser" parent="TRP3_PopupsFrame" hidden="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_ImageBrowser" parent="TRP3_PopupsFrame" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="420" y="400"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -86,19 +78,11 @@
 				</Frames>
 			</Frame>
 			<!-- Filter section -->
-			<Frame name="TRP3_ImageBrowserFilter">
+			<Frame name="TRP3_ImageBrowserFilter" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="16"/>
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="415"/>
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="10" y="10"/>
 					<Anchor point="BOTTOMRIGHT" x="-10" y="10"/>

--- a/totalRP3/core/ui/browsers/musics.xml
+++ b/totalRP3/core/ui/browsers/musics.xml
@@ -20,19 +20,11 @@
 -->
 
 	<!-- Music browser line  -->
-	<Button name="TRP3_MusicBrowserLine" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<Color r="0.4" g="0.4" b="0.4"/>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Button name="TRP3_MusicBrowserLine" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_415_16_3333" type="global"/>
+			<KeyValue key="backdropColor" value="TRP3_BACKDROP_COLOR_DARK" type="global"/>
+		</KeyValues>
 		<Size x="0" y="28"/>
 		<Anchors>
 			<Anchor point="LEFT" x="8" y="0"/>
@@ -64,7 +56,7 @@
 			</Frame>
 		</Frames>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				self:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 			</OnLoad>
 			<OnEnter>
@@ -79,18 +71,10 @@
 	</Button>
 
 	<!-- Music browser  -->
-	<Frame name="TRP3_MusicBrowser" parent="TRP3_PopupsFrame" hidden="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_MusicBrowser" parent="TRP3_PopupsFrame" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="420" y="400"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -117,19 +101,11 @@
 				</Frames>
 			</Frame>
 			<!-- Filter section -->
-			<Frame name="TRP3_MusicBrowserFilter">
+			<Frame name="TRP3_MusicBrowserFilter" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="16"/>
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="415"/>
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="10" y="10"/>
 					<Anchor point="BOTTOMRIGHT" x="-10" y="10"/>

--- a/totalRP3/core/ui/configuration.xml
+++ b/totalRP3/core/ui/configuration.xml
@@ -142,10 +142,10 @@
 		GENERAL SETTINGS
 	-->
 
-	<Frame name="TRP3_ConfigurationPage" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="24" />
-		</Backdrop>
+	<Frame name="TRP3_ConfigurationPage" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString name="$parentTitle" inherits="GameFontNormalHuge" justifyH="CENTER" text="[settings_title]">

--- a/totalRP3/core/ui/configuration.xml
+++ b/totalRP3/core/ui/configuration.xml
@@ -144,7 +144,7 @@
 
 	<Frame name="TRP3_ConfigurationPage" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
 		</KeyValues>
 		<Layers>
 			<Layer level="OVERLAY">

--- a/totalRP3/core/ui/main.xml
+++ b/totalRP3/core/ui/main.xml
@@ -261,7 +261,7 @@
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				tinsert(UISpecialFrames, self:GetName());
 			</OnLoad>
 		</Scripts>

--- a/totalRP3/core/ui/main.xml
+++ b/totalRP3/core/ui/main.xml
@@ -112,19 +112,11 @@
 		</Scripts>
 	</Frame>
 
-	<Frame name="TRP3_MainFrameTemplate" toplevel="true" parent="UIParent" frameStrata="MEDIUM" enableMouse="true" clampedToScreen="true" virtual="true">
+	<Frame name="TRP3_MainFrameTemplate" toplevel="true" parent="UIParent" frameStrata="MEDIUM" enableMouse="true" clampedToScreen="true" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_ACHIEVEMENTS_32_64_5555" type="global"/>
+		</KeyValues>
 		<Size x="768" y="500"/>
-		<Backdrop edgeFile="Interface\AchievementFrame\UI-Achievement-WoodBorder" tile="true">
-			<EdgeSize>
-				<AbsValue val="64"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="32"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="5" right="5" top="5" bottom="5"/>
-			</BackgroundInsets>
-		</Backdrop>
 		<Layers>
 			<Layer level="ARTWORK">
 				<Texture file="Interface\AchievementFrame\UI-Achievement-MetalBorder-Left">
@@ -349,11 +341,10 @@
 			</Frame>
 
 			<!-- RIGHT PART : STATIC POPUP : blocking access to content behind it -->
-			<Frame name="TRP3_PopupsFrame" frameStrata="DIALOG" enableMouse="true" hidden="true">
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize><AbsValue val="16"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-					<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-				</Backdrop>
+			<Frame name="TRP3_PopupsFrame" frameStrata="DIALOG" enableMouse="true" hidden="true" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555" type="global"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-20" y="-20"/>
 					<Anchor point="BOTTOMRIGHT" x="-20" y="20"/>
@@ -362,12 +353,10 @@
 			</Frame>
 
 			<!-- Update alert popup -->
-			<Frame name="TRP3_UpdateFrame" frameStrata="DIALOG" enableMouse="true" hidden="true">
-
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize><AbsValue val="16"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-					<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-				</Backdrop>
+			<Frame name="TRP3_UpdateFrame" frameStrata="DIALOG" enableMouse="true" hidden="true" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555" type="global"/>
+				</KeyValues>
 
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-20" y="-20"/>

--- a/totalRP3/core/ui/profiles.xml
+++ b/totalRP3/core/ui/profiles.xml
@@ -220,7 +220,7 @@
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_ProfileManager" inherits="TRP3_ProfileManagerTemplate" hidden="true" />
+	<Frame name="TRP3_ProfileManager" parent="UIParent" inherits="TRP3_ProfileManagerTemplate" hidden="true" />
 
 	<Frame name="TRP3_ProfileExport" parentKey="export" parent="TRP3_ProfileManager" inherits="TRP3_AltHoveredFrame" enableMouse="true" frameStrata="HIGH" hidden="true">
 		<Size x="400" y="300"/>

--- a/totalRP3/core/ui/profiles.xml
+++ b/totalRP3/core/ui/profiles.xml
@@ -124,7 +124,7 @@
 	</Frame>
 
 	<!-- Profile manager -->
-	<Frame name="TRP3_ProfileManagerTemplate" virtual="true">
+	<Frame name="TRP3_ProfileManagerTemplate" hidden="true" virtual="true">
 		<Frames>
 			<Frame frameLevel="2" parentKey="list" inherits="TRP3_BackdropTemplate">
 				<KeyValues>
@@ -220,7 +220,7 @@
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_ProfileManager" parent="UIParent" inherits="TRP3_ProfileManagerTemplate" hidden="true" />
+	<Frame name="TRP3_ProfileManager" inherits="TRP3_ProfileManagerTemplate" hidden="true" />
 
 	<Frame name="TRP3_ProfileExport" parentKey="export" parent="TRP3_ProfileManager" inherits="TRP3_AltHoveredFrame" enableMouse="true" frameStrata="HIGH" hidden="true">
 		<Size x="400" y="300"/>

--- a/totalRP3/core/ui/profiles.xml
+++ b/totalRP3/core/ui/profiles.xml
@@ -18,12 +18,10 @@
 -->
 
 	<!-- Profile manager : Line -->
-	<Frame name="TRP3_ProfileManagerLine" virtual="true">
-		<Backdrop bgFile="Interface\TutorialFrame\TutorialFrameBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="16" />
-			<TileSize val="418" />
-			<BackgroundInsets left="5" right="3" top="5" bottom="3"/>
-		</Backdrop>
+	<Frame name="TRP3_ProfileManagerLine" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_5353" type="global"/>
+		</KeyValues>
 		<Size x="0" y="65" />
 		<Frames>
 			<Frame name="$parentIcon" inherits="TRP3_SimpleIcon">
@@ -128,10 +126,10 @@
 	<!-- Profile manager -->
 	<Frame name="TRP3_ProfileManagerTemplate" virtual="true">
 		<Frames>
-			<Frame frameLevel="2" parentKey="list">
-				<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-					<EdgeSize val="24"/>
-				</Backdrop>
+			<Frame frameLevel="2" parentKey="list" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="2" y="-28" />
 					<Anchor point="BOTTOMLEFT" x="2" y="0" />

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -1,0 +1,326 @@
+----------------------------------------------------------------------------------
+--- Total RP 3
+--- ---------------------------------------------------------------------------
+--- Copyright 2020 Total RP 3 Development Team
+---
+--- Licensed under the Apache License, Version 2.0 (the "License");
+--- you may not use this file except in compliance with the License.
+--- You may obtain a copy of the License at
+---
+---   http://www.apache.org/licenses/LICENSE-2.0
+---
+--- Unless required by applicable law or agreed to in writing, software
+--- distributed under the License is distributed on an "AS IS" BASIS,
+--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--- See the License for the specific language governing permissions and
+--- limitations under the License.
+----------------------------------------------------------------------------------
+
+--[[
+	Backdrop Tables
+
+	The 9.x Backdrop API requires using <KeyValue> elements in XML that
+	reference global variables to provide color and backdrop information;
+	the below tables are all of our old <Backdrop> elements converted to
+	the appropriate format.
+
+	The naming format matches the Blizzard convention to avoid bikeshedding
+	over specific names.
+--]]
+
+TRP3_BACKDROP_COLOR_DARK = CreateColor(0.4, 0.4, 0.4);
+
+TRP3_BACKDROP_DIALOG_20_20_5555 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 20,
+    edgeSize = 20,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_PARTY_DIALOG_16_16_5555 = {
+    bgFile   = "Interface\\CHARACTERFRAME\\UI-Party-Background",
+    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 16,
+    edgeSize = 16,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 400,
+    edgeSize = 24,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_TOOLTIP_0_16 = {
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    edgeSize = 16,
+};
+
+TRP3_BACKDROP_TOOLTIP_0_24 = {
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    edgeSize = 24,
+};
+
+TRP3_BACKDROP_TOOLTIP_415_16_3333 = {
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_380_16_3333 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 380,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+};
+
+TRP3_BACKDROP_MIXED_MARBLE_TOOLTIP_415_24_5555 = {
+    bgFile   = "Interface\\FrameGeneral\\UI-Background-Marble",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 24,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_BANK_TOOLTIP_400_24_5555 = {
+    bgFile   = "Interface\\BankFrame\\Bank-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 400,
+    edgeSize = 24,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_BANK_TOOLTIP_100_16_4222 = {
+    bgFile   = "Interface\\BankFrame\\Bank-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 100,
+    edgeSize = 16,
+    insets   = { left = 4, right = 2, top = 2, bottom = 2 },
+};
+
+TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_3353 = {
+    bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 418,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 5, bottom = 3 },
+};
+
+TRP3_BACKDROP_ACHIEVEMENTS_32_64_5555 = {
+    edgeFile = "Interface\\AchievementFrame\\UI-Achievement-WoodBorder",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 32,
+    edgeSize = 64,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_3333 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_24_5555 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 24,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 16,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_5555 = {
+    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    edgeSize = 16,
+    insets   = { left = 5, right = 5, top = 5, bottom = 3 },
+};
+
+TRP3_BACKDROP_GOLD_DIALOG_0_26 = {
+    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Gold-Border",
+    edgeSize = 26,
+};
+
+TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_5353 = {
+    bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 418,
+    edgeSize = 16,
+    insets   = { left = 5, right = 3, top = 5, bottom = 3 },
+};
+
+TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_24_5555 = {
+    bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 24,
+    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333 = {
+    bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
+    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+    tile     = true,
+    tileEdge = true,
+    tileSize = 415,
+    edgeSize = 16,
+    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+};
+
+--[[
+	BackdropTemplatePolyfillMixin
+
+	Polyfill mixin that mirrors the API exposed by the BackdropTemplateMixin
+	in 9.x clients.
+
+	This implements all the methods provided by the Blizzard mixin, using
+	no-op stubs for areas of functionality that can't be handed in pre-9.x
+	client code.
+
+	Generally, this mixin shouldn't be used directly - use the globally
+	accessible TRP3_BackdropTemplateMixin instead which will default to
+	preferring the Blizzard mixin on supported clients.
+--]]
+
+local BackdropTemplatePolyfillMixin = {};
+
+function BackdropTemplatePolyfillMixin:OnBackdropLoaded()
+	if not self.backdropInfo then
+		return;
+	end
+
+	if not self.backdropInfo.edgeFile and not self.backdropInfo.bgFile then
+		self.backdropInfo = nil;
+		return;
+	end
+
+	self:ApplyBackdrop();
+
+	-- Use of ColorMixin.GetRGB below is to enable compatibility with any
+	-- Color-like tables (as in, those that just provide r/g/b fields)
+	-- without actually including a GetRGB method.
+
+	if self.backdropColor then
+		local r, g, b = ColorMixin.GetRGB(self.backdropColor);
+		self:SetBackdropColor(r, g, b, self.backdropColorAlpha or 1);
+	end
+
+	if self.backdropBorderColor then
+		local r, g, b = ColorMixin.GetRGB(self.backdropBorderColor);
+		self:SetBackdropBorderColor(r, g, b, self.backdropBorderColorAlpha or 1);
+	end
+
+	if self.backdropBorderBlendMode then
+		self:SetBackdropBorderBlendMode(self.backdropBorderBlendMode);
+	end
+end
+
+function BackdropTemplatePolyfillMixin:OnBackdropSizeChanged()
+	if self.backdropInfo then
+		self:SetupTextureCoordinates();
+	end
+end
+
+function BackdropTemplatePolyfillMixin:ApplyBackdrop()
+	-- The SetBackdrop call will implicitly reset the background and border
+	-- texture vertex colors to white, consistent across all client versions.
+
+	self:SetBackdrop(self.backdropInfo);
+end
+
+function BackdropTemplatePolyfillMixin:ClearBackdrop()
+	self:SetBackdrop(nil);
+	self.backdropInfo = nil;
+end
+
+function BackdropTemplatePolyfillMixin:GetEdgeSize()
+	-- The below will indeed error if there's no backdrop assigned; this is
+	-- consistent with how it works on 9.x clients.
+
+	return self.backdropInfo.edgeSize or 39;
+end
+
+function BackdropTemplatePolyfillMixin:HasBackdropInfo(backdropInfo)
+	return self.backdropInfo == backdropInfo;
+end
+
+function BackdropTemplatePolyfillMixin:SetBorderBlendMode()
+	-- The pre-9.x API doesn't support setting blend modes for backdrop
+	-- borders, so this is a no-op that just exists in case we ever assume
+	-- it exists.
+end
+
+function BackdropTemplatePolyfillMixin:SetupPieceVisuals()
+	-- Deliberate no-op as backdrop internals are handled C-side pre-9.x.
+end
+
+function BackdropTemplatePolyfillMixin:SetupTextureCoordinates()
+	-- Deliberate no-op as texture coordinates are handled C-side pre-9.x.
+end
+
+--[[
+	TRP3_BackdropTemplateMixin
+
+	Dummy mixin that either inherits the Blizzard BackdropTemplateMixin
+	for 9.x clients, or our polyfill one if otherwise unavailable.
+--]]
+
+TRP3_BackdropTemplateMixin = CreateFromMixins(BackdropTemplateMixin or BackdropTemplatePolyfillMixin);

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -291,17 +291,13 @@ function BackdropTemplatePolyfillMixin:OnBackdropLoaded()
 
 	self:ApplyBackdrop();
 
-	-- Use of ColorMixin.GetRGB below is to enable compatibility with any
-	-- Color-like tables (as in, those that just provide r/g/b fields)
-	-- without actually including a GetRGB method.
-
 	if self.backdropColor then
-		local r, g, b = ColorMixin.GetRGB(self.backdropColor);
+		local r, g, b = self.backdropColor:GetRGB();
 		self:SetBackdropColor(r, g, b, self.backdropColorAlpha or 1);
 	end
 
 	if self.backdropBorderColor then
-		local r, g, b = ColorMixin.GetRGB(self.backdropBorderColor);
+		local r, g, b = self.backdropBorderColor:GetRGB();
 		self:SetBackdropBorderColor(r, g, b, self.backdropBorderColorAlpha or 1);
 	end
 

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -74,6 +74,14 @@ TRP3_BACKDROP_TOOLTIP_0_24_5555 = {
 	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
 	tile     = true,
 	tileEdge = true,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_TOOLTIP_400_24_5555 = {
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
 	tileSize = 400,
 	edgeSize = 24,
 	insets   = { left = 5, right = 5, top = 5, bottom = 5 },

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -31,198 +31,198 @@
 TRP3_BACKDROP_COLOR_DARK = CreateColor(0.4, 0.4, 0.4);
 
 TRP3_BACKDROP_DIALOG_20_20_5555 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 20,
-    edgeSize = 20,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 20,
+	edgeSize = 20,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_PARTY_DIALOG_16_16_5555 = {
-    bgFile   = "Interface\\CHARACTERFRAME\\UI-Party-Background",
-    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 16,
-    edgeSize = 16,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\CHARACTERFRAME\\UI-Party-Background",
+	edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 16,
+	edgeSize = 16,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 400,
-    edgeSize = 24,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 400,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_TOOLTIP_0_16 = {
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    edgeSize = 16,
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	edgeSize = 16,
 };
 
 TRP3_BACKDROP_TOOLTIP_0_24 = {
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    edgeSize = 24,
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	edgeSize = 24,
 };
 
 TRP3_BACKDROP_TOOLTIP_415_16_3333 = {
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_380_16_3333 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 380,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 380,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 };
 
 TRP3_BACKDROP_MIXED_MARBLE_TOOLTIP_415_24_5555 = {
-    bgFile   = "Interface\\FrameGeneral\\UI-Background-Marble",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 24,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\FrameGeneral\\UI-Background-Marble",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_BANK_TOOLTIP_400_24_5555 = {
-    bgFile   = "Interface\\BankFrame\\Bank-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 400,
-    edgeSize = 24,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\BankFrame\\Bank-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 400,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_BANK_TOOLTIP_100_16_4222 = {
-    bgFile   = "Interface\\BankFrame\\Bank-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 100,
-    edgeSize = 16,
-    insets   = { left = 4, right = 2, top = 2, bottom = 2 },
+	bgFile   = "Interface\\BankFrame\\Bank-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 100,
+	edgeSize = 16,
+	insets   = { left = 4, right = 2, top = 2, bottom = 2 },
 };
 
 TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_3353 = {
-    bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 418,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 5, bottom = 3 },
+	bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 418,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 5, bottom = 3 },
 };
 
 TRP3_BACKDROP_ACHIEVEMENTS_32_64_5555 = {
-    edgeFile = "Interface\\AchievementFrame\\UI-Achievement-WoodBorder",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 32,
-    edgeSize = 64,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	edgeFile = "Interface\\AchievementFrame\\UI-Achievement-WoodBorder",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 32,
+	edgeSize = 64,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_3333 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_24_5555 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 24,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 16,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 16,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_5555 = {
-    bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    edgeSize = 16,
-    insets   = { left = 5, right = 5, top = 5, bottom = 3 },
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	edgeSize = 16,
+	insets   = { left = 5, right = 5, top = 5, bottom = 3 },
 };
 
 TRP3_BACKDROP_GOLD_DIALOG_0_26 = {
-    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Gold-Border",
-    edgeSize = 26,
+	edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Gold-Border",
+	edgeSize = 26,
 };
 
 TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_5353 = {
-    bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 418,
-    edgeSize = 16,
-    insets   = { left = 5, right = 3, top = 5, bottom = 3 },
+	bgFile   = "Interface\\TutorialFrame\\TutorialFrameBackground",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 418,
+	edgeSize = 16,
+	insets   = { left = 5, right = 3, top = 5, bottom = 3 },
 };
 
 TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_24_5555 = {
-    bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 24,
-    insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+	bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
 TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333 = {
-    bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
-    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-    tile     = true,
-    tileEdge = true,
-    tileSize = 415,
-    edgeSize = 16,
-    insets   = { left = 3, right = 3, top = 3, bottom = 3 },
+	bgFile   = "Interface\\AchievementFrame\\UI-Achievement-StatsBackground",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 16,
+	insets   = { left = 3, right = 3, top = 3, bottom = 3 },
 };
 
 --[[

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -50,8 +50,27 @@ TRP3_BACKDROP_MIXED_PARTY_DIALOG_16_16_5555 = {
 	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 
+TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_200_24_5555 = {
+	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 200,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
 TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555 = {
 	bgFile   = "Interface\\DialogFrame\\UI-DialogBox-Background",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 400,
+	edgeSize = 24,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_TOOLTIP_0_24_5555 = {
 	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
 	tile     = true,
 	tileEdge = true,
@@ -139,6 +158,16 @@ TRP3_BACKDROP_ACHIEVEMENTS_32_64_5555 = {
 	tileEdge = true,
 	tileSize = 32,
 	edgeSize = 64,
+	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
+};
+
+TRP3_BACKDROP_MIXED_PARCHMENT_TOOLTIP_415_16_5555 = {
+	bgFile   = "Interface\\AchievementFrame\\UI-Achievement-Parchment",
+	edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+	tile     = true,
+	tileEdge = true,
+	tileSize = 415,
+	edgeSize = 16,
 	insets   = { left = 5, right = 5, top = 5, bottom = 5 },
 };
 

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -21,6 +21,33 @@
 
 	<Script file="widgets.lua"/>
 
+	<!--
+		BackdropFrameTemplate
+
+		Provides a common method of handling 9.x style frame backdrops
+		across all client types.
+
+		For 9.x clients this transparently resolves to using the Blizzard
+		provided BackdropTemplateMixin; the usage of this template is
+		intended to remain identical to the API provided by this client.
+
+		For pre-9.x clients the original API functions for backdrop management
+		on frames are kept unaltered, with the only change being load-time
+		logic for translating 9.x style KeyValue pairs to the proper calls.
+
+		Frames that inherit this template should ensure that any OnLoad
+		or OnSizeChanged script handlers they install are affixed with the
+		inherit="prepend" attribute, or that the handlers themselves invoke
+		the OnBackdropLoaded/OnBackdropSizeChanged methods.
+	-->
+
+	<Frame name="TRP3_BackdropTemplate" mixin="TRP3_BackdropTemplateMixin" virtual="true">
+		<Scripts>
+			<OnLoad method="OnBackdropLoaded"/>
+			<OnSizeChanged method="OnBackdropSizeChanged"/>
+		</Scripts>
+	</Frame>
+
 	<!-- Common close button  -->
 	<Button name="TRP3_CloseButton" inherits="UIPanelCloseButton" virtual="true">
 		<Scripts>
@@ -1286,33 +1313,6 @@
 			<OnHide>
 				MSA_CloseDropDownMenus();
 			</OnHide>
-		</Scripts>
-	</Frame>
-
-	<!--
-		BackdropFrameTemplate
-
-		Provides a common method of handling 9.x style frame backdrops
-		across all client types.
-
-		For 9.x clients this transparently resolves to using the Blizzard
-		provided BackdropTemplateMixin; the usage of this template is
-		intended to remain identical to the API provided by this client.
-
-		For pre-9.x clients the original API functions for backdrop management
-		on frames are kept unaltered, with the only change being load-time
-		logic for translating 9.x style KeyValue pairs to the proper calls.
-
-		Frames that inherit this template should ensure that any OnLoad
-		or OnSizeChanged script handlers they install are affixed with the
-		inherit="prepend" attribute, or that the handlers themselves invoke
-		the OnBackdropLoaded/OnBackdropSizeChanged methods.
-	-->
-
-	<Frame name="TRP3_BackdropTemplate" mixin="TRP3_BackdropTemplateMixin" virtual="true">
-		<Scripts>
-			<OnLoad method="OnBackdropLoaded"/>
-			<OnSizeChanged method="OnBackdropSizeChanged"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -19,6 +19,8 @@
 		limitations under the License.
 	-->
 
+	<Script file="widgets.lua"/>
+
 	<!-- Common close button  -->
 	<Button name="TRP3_CloseButton" inherits="UIPanelCloseButton" virtual="true">
 		<Scripts>
@@ -208,23 +210,15 @@
 	</Slider>
 
 	<!-- A bordered frame with a title -->
-	<Frame name="TRP3_FieldSetFrame" virtual="true">
-		<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="16"/>
-			<TileSize val="380" />
-			<BackgroundInsets left="3" right="3" top="3" bottom="3" />
-		</Backdrop>
+	<Frame name="TRP3_FieldSetFrame" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_380_16_3333" type="global"/>
+		</KeyValues>
 		<Frames>
-			<Frame name="$parentCaptionPanel" parentKey="caption">
-				<Backdrop bgFile="Interface\BankFrame\Bank-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-					<EdgeSize val="16"/>
-					<TileSize>
-						<AbsValue val="100"/>
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="4" right="2" top="2" bottom="2"/>
-					</BackgroundInsets>
-				</Backdrop>
+			<Frame name="$parentCaptionPanel" parentKey="caption" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_BANK_TOOLTIP_100_16_4222" type="global"/>
+				</KeyValues>
 				<Size x="150" y="23"/>
 				<Layers>
 					<Layer level="OVERLAY">
@@ -673,12 +667,10 @@
 	</Frame>
 
 	<!-- More classic style hovered frame -->
-	<Frame name="TRP3_AltHoveredFrame" virtual="true">
-		<Backdrop edgeFile="Interface\DialogFrame\UI-DialogBox-Gold-Border">
-			<EdgeSize>
-				<AbsValue val="26"/>
-			</EdgeSize>
-		</Backdrop>
+	<Frame name="TRP3_AltHoveredFrame" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_GOLD_DIALOG_0_26" type="global"/>
+		</KeyValues>
 		<Size x="220" y="100"/>
 		<Layers>
 			<Layer level="BACKGROUND">
@@ -751,7 +743,7 @@
 			</Layer>
 		</Layers>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				SetClampedTextureRotation(self.ArrowLEFT, 270);
 				SetClampedTextureRotation(self.ArrowRIGHT, 90);
 			</OnLoad>
@@ -1294,6 +1286,33 @@
 			<OnHide>
 				MSA_CloseDropDownMenus();
 			</OnHide>
+		</Scripts>
+	</Frame>
+
+	<!--
+		BackdropFrameTemplate
+
+		Provides a common method of handling 9.x style frame backdrops
+		across all client types.
+
+		For 9.x clients this transparently resolves to using the Blizzard
+		provided BackdropTemplateMixin; the usage of this template is
+		intended to remain identical to the API provided by this client.
+
+		For pre-9.x clients the original API functions for backdrop management
+		on frames are kept unaltered, with the only change being load-time
+		logic for translating 9.x style KeyValue pairs to the proper calls.
+
+		Frames that inherit this template should ensure that any OnLoad
+		or OnSizeChanged script handlers they install are affixed with the
+		inherit="prepend" attribute, or that the handlers themselves invoke
+		the OnBackdropLoaded/OnBackdropSizeChanged methods.
+	-->
+
+	<Frame name="TRP3_BackdropTemplate" mixin="TRP3_BackdropTemplateMixin" virtual="true">
+		<Scripts>
+			<OnLoad method="OnBackdropLoaded"/>
+			<OnSizeChanged method="OnBackdropSizeChanged"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/modules/dashboard/StatusPanel.xml
+++ b/totalRP3/modules/dashboard/StatusPanel.xml
@@ -78,7 +78,7 @@
 			</Frame>
 		</Frames>
 		<Scripts>
-			<OnLoad method="OnLoad"/>
+			<OnLoad inherit="prepend" method="OnLoad"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/modules/dashboard/TabFrame.lua
+++ b/totalRP3/modules/dashboard/TabFrame.lua
@@ -36,12 +36,12 @@ local strhtml = TRP3_API.utils.str.toHTML;
 local UIFrame = TRP3_API.ui.frame;
 
 --- Creates an entry for a tab compatible for use with the ui.createTabFrame
----  function. This has an additional field (View) which is an instantiated
----  instance of the view class.
+--- function. This has an additional field (View) which is an instantiated
+--- instance of the view class.
 ---
----  @param viewClass The class to wrap and instantiate.
----  @param index The index of the tab. This is stored as the "value" of the entry.
----  @vararg any Arguments to pass to the viewClass constructor.
+--- @param viewClass The class to wrap and instantiate.
+--- @param index The index of the tab. This is stored as the "value" of the entry.
+--- @vararg any Arguments to pass to the viewClass constructor.
 local function createTabFromClass(index, viewClass, ...)
 	-- Use explicit indices here to make it clear on the structure.
 	return {
@@ -53,12 +53,16 @@ local function createTabFromClass(index, viewClass, ...)
 end
 
 --- Mixin attached to the TRP3_DashboardTabFrame template. Generally speaking
----  you'll need to implement OnLoad yourself and set "self.TabClasses" to
----  a table of TabView classes to be displayed in this widget, then call into
----  the OnLoad method afterward.
+--- you'll need to implement OnLoad yourself and set "self.TabClasses" to
+--- a table of TabView classes to be displayed in this widget, then call into
+--- the OnLoad method afterward.
 TRP3_DashboardTabFrameMixin = {};
 
 function TRP3_DashboardTabFrameMixin:OnLoad()
+	if self.OnBackdropLoaded then
+		self:OnBackdropLoaded();
+	end
+
 	-- Expect self.TabClasses to be a table. If it isn't, see above for what
 	-- you've gotta do.
 	Ellyb.Assertions.isType(self.TabClasses, "table", "self.TabClasses");
@@ -90,7 +94,7 @@ function TRP3_DashboardTabFrameMixin:OnLoad()
 end
 
 --- Called when the NAVIGATION_RESIZED event fires. Re-draws the content
----  frame to make it adjust to the new dimensions.
+--- frame to make it adjust to the new dimensions.
 function TRP3_DashboardTabFrameMixin:OnNavigationResized(width)
 	-- Resize the content frame and try to refresh it.
 	local htmlFrame = self.HTMLContent;
@@ -99,9 +103,9 @@ function TRP3_DashboardTabFrameMixin:OnNavigationResized(width)
 end
 
 --- Called when a tab in this frame has been selected. Updates the content
----  and notifies the view.
+--- and notifies the view.
 ---
----  @param index The index of the newly selected tab.
+--- @param index The index of the newly selected tab.
 function TRP3_DashboardTabFrameMixin:OnTabSelected(index)
 	local entry = self.tabs[index];
 	assert(entry, "invalid tab index");
@@ -123,7 +127,7 @@ function TRP3_DashboardTabFrameMixin:OnTabSelected(index)
 end
 
 --- Resets the font objects and colors associated with the HTML content
----  frame on the widget.
+--- frame on the widget.
 function TRP3_DashboardTabFrameMixin:ResetHTMLStyles()
 	local htmlFrame = self.HTMLContent;
 
@@ -138,36 +142,36 @@ function TRP3_DashboardTabFrameMixin:ResetHTMLStyles()
 end
 
 --- Convenience method that sets the text on the HTMLContent child widget
----  to that of the given text. The text is converted to HTML prior to display.
+--- to that of the given text. The text is converted to HTML prior to display.
 ---
----  @param text The unformatted source text string to display in the widget.
----              This will be converted to html prior to display.
+--- @param text The unformatted source text string to display in the widget.
+---             This will be converted to html prior to display.
 function TRP3_DashboardTabFrameMixin:SetHTMLFromText(text)
 	return self:SetHTML(strhtml(text));
 end
 
 --- Convenience method that sets the text on the HTMLContent child widget
----  to that of the given text. The text is assumed to be valid HTML.
+--- to that of the given text. The text is assumed to be valid HTML.
 ---
----  @param html The preformatted HTML string to display in the widget.
+--- @param html The preformatted HTML string to display in the widget.
 function TRP3_DashboardTabFrameMixin:SetHTML(html)
 	return self.HTMLContent:SetText(html);
 end
 
 --- Convenience method that registers a hyperlink handler on the HTMLContent
----  child widget. See that mixin for argument documentation.
+--- child widget. See that mixin for argument documentation.
 function TRP3_DashboardTabFrameMixin:RegisterHyperlink(...)
 	return self.HTMLContent:RegisterHyperlink(...);
 end
 
 --- Convenience method that unregisters a hyperlink handler on the HTMLContent
----  child widget. See that mixin for argument documentation.
+--- child widget. See that mixin for argument documentation.
 function TRP3_DashboardTabFrameMixin:UnregisterHyperlink(...)
 	return self.HTMLContent:UnregisterHyperlink(...);
 end
 
 --- Convenience method that unregisters all hyperlink handlers on the
----  HTMLContent child widget. See that mixin for argument documentation.
+--- HTMLContent child widget. See that mixin for argument documentation.
 function TRP3_DashboardTabFrameMixin:UnregisterAllHyperlinks(...)
 	return self.HTMLContent:UnregisterAllHyperlinks(...);
 end

--- a/totalRP3/modules/dashboard/TabFrame.xml
+++ b/totalRP3/modules/dashboard/TabFrame.xml
@@ -21,11 +21,10 @@
 	-->
 	<Script file="TabFrame.lua"/>
 
-	<Frame name="TRP3_DashboardTabFrame" mixin="TRP3_DashboardTabFrameMixin" virtual="true">
-		<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="16"/>
-			<BackgroundInsets left="5" right="5" top="5" bottom="3"/>
-		</Backdrop>
+	<Frame name="TRP3_DashboardTabFrame" mixin="TRP3_DashboardTabFrameMixin" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_5555" type="global"/>
+		</KeyValues>
 		<Frames>
 			<Frame parentKey="TabBar" frameLevel="1">
 				<Size x="400" y="30"/>
@@ -54,7 +53,7 @@
 			</ScrollFrame>
 		</Frames>
 		<Scripts>
-			<OnLoad method="OnLoad"/>
+			<OnLoad inherit="prepend" method="OnLoad"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/modules/dashboard/TabFrame.xml
+++ b/totalRP3/modules/dashboard/TabFrame.xml
@@ -53,7 +53,7 @@
 			</ScrollFrame>
 		</Frames>
 		<Scripts>
-			<OnLoad inherit="prepend" method="OnLoad"/>
+			<OnLoad method="OnLoad"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/modules/dashboard/dashboard.xml
+++ b/totalRP3/modules/dashboard/dashboard.xml
@@ -32,10 +32,10 @@
 	<Include file="StatusPanel.xml"/>
 
 	<!-- Dashboard -->
-	<Frame name="TRP3_Dashboard" hidden="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="16"/>
-		</Backdrop>
+	<Frame name="TRP3_Dashboard" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_16" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture file="Interface\ARCHEOLOGY\Arch-BookCompletedLeft">

--- a/totalRP3/modules/importer/importer.xml
+++ b/totalRP3/modules/importer/importer.xml
@@ -20,10 +20,10 @@
 
 	<Frame name="TRP3_ProfileImporterLine" inherits="TRP3_ProfileManagerLine" virtual="true" />
 
-	<Frame name="TRP3_ImporterTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize val="24"/>
-		</Backdrop>
+	<Frame name="TRP3_ImporterTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Anchors>
 			<Anchor point="TOPRIGHT" x="2" y="-28" />
 			<Anchor point="BOTTOMLEFT" x="2" y="0" />

--- a/totalRP3/modules/modules.xml
+++ b/totalRP3/modules/modules.xml
@@ -19,11 +19,10 @@
 	limitations under the License.
 -->
 
-	<Frame name="TRP3_ConfigurationModuleFrame" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" bgFile="Interface\DialogFrame\UI-DialogBox-Background" tile="true">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="200"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_ConfigurationModuleFrame" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Size x="0" y="60"/>
 		<Layers>
 			<Layer level="OVERLAY">
@@ -71,10 +70,10 @@
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_ConfigurationModule" parent="TRP3_MainFramePageContainer" hidden="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="24"/>
-		</Backdrop>
+	<Frame name="TRP3_ConfigurationModule" parent="TRP3_MainFramePageContainer" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString name="TRP3_ConfigurationModuleTitle" inherits="GameFontNormalHuge" justifyH="CENTER" text="[modules_settings]">

--- a/totalRP3/modules/modules.xml
+++ b/totalRP3/modules/modules.xml
@@ -21,7 +21,7 @@
 
 	<Frame name="TRP3_ConfigurationModuleFrame" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_200_24_5555" type="global"/>
 		</KeyValues>
 		<Size x="0" y="60"/>
 		<Layers>

--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -90,7 +90,7 @@
 
 	<Frame name="TRP3_RegisterAbout_Edit_Template3Frame" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_400_24_5555" type="global"/>
 		</KeyValues>
 		<Size x="0" y="105"/>
 		<Frames>
@@ -137,7 +137,7 @@
 	<!-- Register about template 2 frame -->
 	<Frame name="TRP3_RegisterAbout_Template2_Frame" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_400_24_5555" type="global"/>
 		</KeyValues>
 		<Frames>
 			<Frame name="$parentIcon" inherits="TRP3_SimpleIcon">
@@ -154,7 +154,7 @@
 	<!-- Register about template 2 edit frame -->
 	<Frame name="TRP3_RegisterAbout_Template2_Edit" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_400_24_5555" type="global"/>
 		</KeyValues>
 		<Size x="0" y="120"/>
 		<Frames>

--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -20,12 +20,11 @@
 -->
 
 	<!-- Toolbar -->
-	<Frame name="TRP3_TextToolbar" virtual="true">
+	<Frame name="TRP3_TextToolbar" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_24_5555" type="global"/>
+		</KeyValues>
 		<Size x="0" y="30"/>
-		<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString parentKey="title" inherits="GameFontNormal" justifyH="CENTER" text="[formatting_tool]">
@@ -89,11 +88,10 @@
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_RegisterAbout_Edit_Template3Frame" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_RegisterAbout_Edit_Template3Frame" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Size x="0" y="105"/>
 		<Frames>
 			<Button name="$parentIcon" inherits="TRP3_IconButton">
@@ -137,11 +135,10 @@
 	</Frame>
 
 	<!-- Register about template 2 frame -->
-	<Frame name="TRP3_RegisterAbout_Template2_Frame" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_RegisterAbout_Template2_Frame" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Frames>
 			<Frame name="$parentIcon" inherits="TRP3_SimpleIcon">
 				<Size x="50" y="50"/>
@@ -155,11 +152,10 @@
 	</Frame>
 
 	<!-- Register about template 2 edit frame -->
-	<Frame name="TRP3_RegisterAbout_Template2_Edit" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true" bgFile="Interface\DialogFrame\UI-DialogBox-Background">
-			<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_RegisterAbout_Template2_Edit" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Size x="0" y="120"/>
 		<Frames>
 			<Button name="$parentIcon" inherits="TRP3_IconButton">
@@ -216,11 +212,10 @@
 	</Frame>
 
 	<!-- Register characteristics panel -->
-	<Frame name="TRP3_RegisterAboutTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize val="24"/>
-			<BackgroundInsets bottom="5" left="5" right="5" top="5"/>
-		</Backdrop>
+	<Frame name="TRP3_RegisterAboutTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Frames>
 			<Frame name="TRP3_RegisterAbout_AboutPanel_Edit" setAllPoints="true">
 				<Frames>
@@ -297,11 +292,10 @@
 							</Frame>
 						</Frames>
 					</Frame>
-					<Frame name="TRP3_RegisterAbout_Edit_Template2">
-						<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-							<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-							<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-						</Backdrop>
+					<Frame name="TRP3_RegisterAbout_Edit_Template2" inherits="TRP3_BackdropTemplate">
+						<KeyValues>
+							<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_24_5555" type="global"/>
+						</KeyValues>
 						<Anchors>
 							<Anchor point="TOP" relativePoint="BOTTOM" relativeTo="TRP3_RegisterAbout_Edit_Toolbar" x="0" y="-5"/>
 							<Anchor point="BOTTOM" x="0" y="30"/>
@@ -417,11 +411,10 @@
 											<Anchor point="RIGHT" x="0" y="0"/>
 										</Anchors>
 										<Frames>
-											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_1">
-												<Backdrop bgFile="Interface\BankFrame\Bank-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-													<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-													<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-												</Backdrop>
+											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_1" inherits="TRP3_BackdropTemplate">
+												<KeyValues>
+													<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_BANK_TOOLTIP_400_24_5555" type="global"/>
+												</KeyValues>
 												<Anchors>
 													<Anchor point="TOPLEFT" x="0" y="-5"/>
 													<Anchor point="RIGHT" x="0" y="0"/>
@@ -448,11 +441,10 @@
 													</SimpleHTML>
 												</Frames>
 											</Frame>
-											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_2">
-												<Backdrop bgFile="Interface\BankFrame\Bank-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-													<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-													<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-												</Backdrop>
+											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_2" inherits="TRP3_BackdropTemplate">
+												<KeyValues>
+													<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_BANK_TOOLTIP_400_24_5555" type="global"/>
+												</KeyValues>
 												<Anchors>
 													<Anchor point="TOPLEFT" x="0" y="-5" relativePoint="BOTTOMLEFT" relativeTo="TRP3_RegisterAbout_AboutPanel_Template3_1"/>
 													<Anchor point="RIGHT" x="0" y="0"/>
@@ -479,11 +471,10 @@
 													</SimpleHTML>
 												</Frames>
 											</Frame>
-											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_3">
-												<Backdrop bgFile="Interface\BankFrame\Bank-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-													<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="400"/></TileSize>
-													<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-												</Backdrop>
+											<Frame name="TRP3_RegisterAbout_AboutPanel_Template3_3" inherits="TRP3_BackdropTemplate">
+												<KeyValues>
+													<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_BANK_TOOLTIP_400_24_5555" type="global"/>
+												</KeyValues>
 												<Anchors>
 													<Anchor point="TOPLEFT" x="0" y="-5" relativePoint="BOTTOMLEFT" relativeTo="TRP3_RegisterAbout_AboutPanel_Template3_2"/>
 													<Anchor point="RIGHT" x="0" y="0"/>
@@ -523,12 +514,11 @@
 								</Anchors>
 							</Button>
 							<!-- Music player -->
-							<Frame name="TRP3_RegisterAbout_AboutPanel_MusicPlayer">
+							<Frame name="TRP3_RegisterAbout_AboutPanel_MusicPlayer" inherits="TRP3_BackdropTemplate">
+								<KeyValues>
+									<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_MARBLE_TOOLTIP_415_24_5555" type="global"/>
+								</KeyValues>
 								<Size x="200" y="65"/>
-								<Backdrop bgFile="Interface\FrameGeneral\UI-Background-Marble" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-									<EdgeSize><AbsValue val="24"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-									<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-								</Backdrop>
 								<Anchors>
 									<Anchor point="BOTTOM" x="0" y="5"/>
 								</Anchors>

--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -90,7 +90,7 @@
 
 	<Frame name="TRP3_RegisterAbout_Edit_Template3Frame" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
 		</KeyValues>
 		<Size x="0" y="105"/>
 		<Frames>
@@ -137,7 +137,7 @@
 	<!-- Register about template 2 frame -->
 	<Frame name="TRP3_RegisterAbout_Template2_Frame" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
 		</KeyValues>
 		<Frames>
 			<Frame name="$parentIcon" inherits="TRP3_SimpleIcon">
@@ -154,7 +154,7 @@
 	<!-- Register about template 2 edit frame -->
 	<Frame name="TRP3_RegisterAbout_Template2_Edit" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
 		</KeyValues>
 		<Size x="0" y="120"/>
 		<Frames>
@@ -214,7 +214,7 @@
 	<!-- Register characteristics panel -->
 	<Frame name="TRP3_RegisterAboutTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
 		</KeyValues>
 		<Frames>
 			<Frame name="TRP3_RegisterAbout_AboutPanel_Edit" setAllPoints="true">

--- a/totalRP3/modules/register/characters/register_ui_characteristics.xml
+++ b/totalRP3/modules/register/characters/register_ui_characteristics.xml
@@ -70,11 +70,10 @@
 	</Frame>
 
 	<!-- Register characteristics psycho line jauge -->
-	<Frame name="TRP3_RegisterCharact_PsychoInfoLineJauge" virtual="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-Parchment" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize><AbsValue val="16"/></EdgeSize><TileSize><AbsValue val="415"/></TileSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_RegisterCharact_PsychoInfoLineJauge" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555" type="global"/>
+		</KeyValues>
 		<Size x="105" y="20"/>
 		<Layers>
 			<Layer level="OVERLAY">
@@ -384,10 +383,10 @@
 	</Frame>
 
 	<!-- Register characteristics panel -->
-	<Frame name="TRP3_RegisterCharactTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize val="24"/>
-		</Backdrop>
+	<Frame name="TRP3_RegisterCharactTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture file="Interface\SPELLBOOK\Spellbook-Page-1">

--- a/totalRP3/modules/register/characters/register_ui_characteristics.xml
+++ b/totalRP3/modules/register/characters/register_ui_characteristics.xml
@@ -72,7 +72,7 @@
 	<!-- Register characteristics psycho line jauge -->
 	<Frame name="TRP3_RegisterCharact_PsychoInfoLineJauge" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_5555" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_PARCHMENT_TOOLTIP_415_16_5555" type="global"/>
 		</KeyValues>
 		<Size x="105" y="20"/>
 		<Layers>

--- a/totalRP3/modules/register/characters/register_ui_misc.xml
+++ b/totalRP3/modules/register/characters/register_ui_misc.xml
@@ -76,10 +76,10 @@
 	</Button>
 
 	<!-- Register Peek panel -->
-	<Frame name="TRP3_RegisterMiscTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize val="24"/>
-		</Backdrop>
+	<Frame name="TRP3_RegisterMiscTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture file="Interface\SPELLBOOK\Spellbook-Page-1" setAllPoints="true">
@@ -237,7 +237,6 @@
 							</Frame>
 						</Frames>
 					</Frame>
-
 				</Frames>
 			</Frame>
 		</Frames>

--- a/totalRP3/modules/register/characters/register_ui_notes.xml
+++ b/totalRP3/modules/register/characters/register_ui_notes.xml
@@ -20,10 +20,10 @@
 -->
 
 	<!-- Register Notes panel -->
-	<Frame name="TRP3_RegisterNotesTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize val="24"/>
-		</Backdrop>
+	<Frame name="TRP3_RegisterNotesTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture parentKey="background" file="Interface\SPELLBOOK\Spellbook-Page-1" setAllPoints="true">

--- a/totalRP3/modules/register/companions/register_ui_companions_page.xml
+++ b/totalRP3/modules/register/companions/register_ui_companions_page.xml
@@ -20,11 +20,10 @@
 -->
 
 	<!-- Register characteristics panel -->
-	<Frame name="TRP3_CompanionsPageInformationTemplate" virtual="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-			<EdgeSize><AbsValue val="24"/></EdgeSize>
-			<BackgroundInsets><AbsInset left="5" right="5" top="5" bottom="5"/></BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_CompanionsPageInformationTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<Texture file="Interface\SPELLBOOK\Spellbook-Page-1">

--- a/totalRP3/modules/register/companions/register_ui_companions_page.xml
+++ b/totalRP3/modules/register/companions/register_ui_companions_page.xml
@@ -22,7 +22,7 @@
 	<!-- Register characteristics panel -->
 	<Frame name="TRP3_CompanionsPageInformationTemplate" virtual="true" inherits="TRP3_BackdropTemplate">
 		<KeyValues>
-			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24_5555" type="global"/>
 		</KeyValues>
 		<Layers>
 			<Layer level="BACKGROUND">

--- a/totalRP3/modules/register/companions/register_ui_companions_profiles.xml
+++ b/totalRP3/modules/register/companions/register_ui_companions_profiles.xml
@@ -19,6 +19,5 @@
 	limitations under the License.
 -->
 
-	<Frame name="TRP3_CompanionsProfiles" inherits="TRP3_ProfileManagerTemplate" hidden="true"/>
-
+	<Frame name="TRP3_CompanionsProfiles" parent="UIParent" inherits="TRP3_ProfileManagerTemplate" hidden="true"/>
 </Ui>

--- a/totalRP3/modules/register/companions/register_ui_companions_profiles.xml
+++ b/totalRP3/modules/register/companions/register_ui_companions_profiles.xml
@@ -19,5 +19,5 @@
 	limitations under the License.
 -->
 
-	<Frame name="TRP3_CompanionsProfiles" parent="UIParent" inherits="TRP3_ProfileManagerTemplate" hidden="true"/>
+	<Frame name="TRP3_CompanionsProfiles" inherits="TRP3_ProfileManagerTemplate" hidden="true"/>
 </Ui>

--- a/totalRP3/modules/register/filter/register_mature_filter.xml
+++ b/totalRP3/modules/register/filter/register_mature_filter.xml
@@ -17,19 +17,11 @@
 	limitations under the License.
 -->
 
-	<Frame name="TRP3_MatureFilterPopup" hidden="true">
-		<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<Color r="0.4" g="0.4" b="0.4"/>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_MatureFilterPopup" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_415_16_3333" type="global"/>
+			<KeyValue key="backdropColor" value="TRP3_BACKDROP_COLOR_DARK" type="global"/>
+		</KeyValues>
 		<Size x="420" y="400"/>
 		<Anchors>
 			<Anchor point="LEFT" x="0" y="0"/>
@@ -106,18 +98,10 @@
 
 
 	<!-- Mature dictionary browser line  -->
-	<Button name="TRP3_MatureDictionaryLine" virtual="true">
-		<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Button name="TRP3_MatureDictionaryLine" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="0" y="28"/>
 		<Anchors>
 			<Anchor point="LEFT" x="8" y="0"/>
@@ -151,7 +135,7 @@
 			</Frame>
 		</Frames>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				self:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 			</OnLoad>
 			<OnEnter>
@@ -166,18 +150,10 @@
 	</Button>
 
 	<!-- Mature dictionary editor  -->
-	<Frame name="TRP3_MatureDictionaryEditor" hidden="true">
-		<Backdrop bgFile="Interface\AchievementFrame\UI-Achievement-StatsBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="415"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="3" right="3" top="3" bottom="3"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="TRP3_MatureDictionaryEditor" hidden="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333" type="global"/>
+		</KeyValues>
 		<Size x="420" y="410"/>
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
@@ -203,16 +179,11 @@
 					<Slider parentKey="slider" inherits="TRP3_Scrollbar" />
 				</Frames>
 			</Frame>
-			<Frame parentKey="addNewWord">
+			<Frame parentKey="addNewWord" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_DIALOG_TOOLTIP_0_16_3333" type="global"/>
+				</KeyValues>
 				<Size x="0" y="60"/>
-				<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border" bgFile="Interface\DialogFrame\UI-DialogBox-Background" tile="true">
-					<EdgeSize>
-						<AbsValue val="16"/>
-					</EdgeSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" x="15" y="10"/>
 					<Anchor point="BOTTOMRIGHT" x="-15" y="10"/>

--- a/totalRP3/modules/register/main/register_ui_glance.xml
+++ b/totalRP3/modules/register/main/register_ui_glance.xml
@@ -41,12 +41,10 @@
 		</Scripts>
 	</Button>
 
-	<Frame name="TRP3_GlanceBarTemplate" hidden="true" frameStrata="MEDIUM" toplevel="true" enableMouse="true" virtual="true">
-		<Backdrop bgFile="Interface\TutorialFrame\TutorialFrameBackground" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize val="16" />
-			<TileSize val="418" />
-			<BackgroundInsets left="3" right="3" top="5" bottom="3"/>
-		</Backdrop>
+	<Frame name="TRP3_GlanceBarTemplate" hidden="true" frameStrata="MEDIUM" toplevel="true" enableMouse="true" virtual="true" inherits="TRP3_BackdropTemplate">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_3353" type="global"/>
+		</KeyValues>
 		<Size x="140" y="32" />
 		<Anchors>
 			<Anchor point="CENTER" relativePoint="CENTER" x="0" y="0" />
@@ -79,7 +77,7 @@
 			</Button>
 		</Frames>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				self:RegisterForDrag("LeftButton")
 			</OnLoad>
 			<OnDragStart>

--- a/totalRP3/modules/register/main/register_ui_list.xml
+++ b/totalRP3/modules/register/main/register_ui_list.xml
@@ -133,10 +133,10 @@
 
 	<Frame name="TRP3_RegisterList" hidden="true">
 		<Frames>
-			<Frame name="TRP3_RegisterListContainer" parentKey="Container">
-				<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-					<EdgeSize val="24"/>
-				</Backdrop>
+			<Frame name="TRP3_RegisterListContainer" parentKey="Container" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPLEFT" x="0" y="-30" />
 					<Anchor point="TOPRIGHT" x="2" y="-30" />

--- a/totalRP3/modules/targetframe/target_frame.xml
+++ b/totalRP3/modules/targetframe/target_frame.xml
@@ -39,7 +39,7 @@
 	<Frame name="TRP3_TargetFrameTemplate" toplevel="true" enableMouse="true" hidden="true" inherits="TRP3_FieldSetFrame" virtual="true">
 		<Size x="200" y="50" />
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				self:SetClampedToScreen(true);
 			</OnLoad>
 		</Scripts>

--- a/totalRP3/modules/toolbar/toolbar.xml
+++ b/totalRP3/modules/toolbar/toolbar.xml
@@ -32,36 +32,20 @@
 			</OnLoad>
 		</Scripts>
 		<Frames>
-			<Frame name="$parentContainer">
+			<Frame name="$parentContainer" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_DIALOG_20_20_5555" type="global"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOP" x="0" y="-18" />
 				</Anchors>
-				<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\DialogFrame\UI-DialogBox-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="20" />
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="20" />
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="5" right="5" top="5" bottom="5" />
-					</BackgroundInsets>
-				</Backdrop>
 			</Frame>
 			<!-- Cadre Titre -->
-			<Frame name="$parentTopFrame">
+			<Frame name="$parentTopFrame" inherits="TRP3_BackdropTemplate">
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_PARTY_DIALOG_16_16_5555" type="global"/>
+				</KeyValues>
 				<Size x="80" y="25" />
-				<Backdrop bgFile="Interface\CHARACTERFRAME\UI-Party-Background" edgeFile="Interface\DialogFrame\UI-DialogBox-Border" tile="true">
-					<EdgeSize>
-						<AbsValue val="16" />
-					</EdgeSize>
-					<TileSize>
-						<AbsValue val="16" />
-					</TileSize>
-					<BackgroundInsets>
-						<AbsInset left="5" right="5" top="5" bottom="5" />
-					</BackgroundInsets>
-				</Backdrop>
 				<Anchors>
 					<Anchor point="TOP" x="0" y="0" />
 				</Anchors>


### PR DESCRIPTION
This adds a new TRP3_BackdropTemplate frame template and associated mixin (TRP3_BackdropTemplateMixin) which, for 9.x clients will transparently mixin the Blizzard-provided BackdropMixin functions onto a given frame, and for older clients use a custom polyfill which mirrors the new API provided in 9.x.

Where possible the polyfill stays as close to the 9.x implementation as possible, but for things that can't be implemented a few no-op stub functions are provided.

All usages of <Backdrop> XML elements within TRP3 have been changed to now inherit the appropriate template and specify the expected KeyValue elements to configure their backdrops. All the backdrop info tables have been placed in the same file as the new backdrop implementation, with a naming scheme matching Blizzard's to avoid unnecessary bikeshedding.

This seems to all work fine ingame after doing testing; the various commits in this branch resolved issues as they came along and so far I _think_ everything is working as it did pre-9.0. The changes in this branch are also backwards compatible with 8.3.7, and so presumably work fine on Classic.

Note that our dependencies (Ellyb, MSA) aren't updated in this, and themselves have issues.