### PR TITLE
Fixed OOC detection with Russian declension system

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -372,11 +372,14 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 	local OOCTempPatternEnd = "TRP3ETEMPOOC"
 	local SpeechTempPatternStart = "TRP3BTEMPSPEECH"
 	local SpeechTempPatternEnd = "TRP3ETEMPSPEECH"
+	local RussianDeclensionStart = "TRP3BTEMPRUSSIAN"
+	local RussianDeclensionEnd = "TRP3ETEMPRUSSIAN"
 
 	local LinkDetectionPattern = "(%|H.-%|h.-|h)"
 	local EmoteTempDetectionPattern = EmoteTempPatternStart .. ".-" .. EmoteTempPatternEnd
 	local OOCTempDetectionPattern = OOCTempPatternStart .. ".-" .. OOCTempPatternEnd
 	local SpeechTempDetectionPattern = SpeechTempPatternStart .. ".-" .. SpeechTempPatternEnd
+	local RussianDeclensionDetectionPattern = RussianDeclensionStart .. "(.)(.-)" .. RussianDeclensionEnd
 
 	-- Emote/OOC/Speech replacement
 	if configDoEmoteDetection() and message:find(configEmoteDetectionPattern()) then
@@ -402,6 +405,12 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 	end
 
 	if configDoOOCDetection() and message:find(configOOCDetectionPattern()) then
+
+		-- Wrapping Russian declension in a temporary pattern
+		message = message:gsub("|3%-(.)%((.-)%)", function(declension, content)
+			return RussianDeclensionStart .. declension .. content .. RussianDeclensionEnd;
+		end);
+
 		-- Wrapping patterns in a temporary pattern
 		local OOCColor = configOOCDetectionColor();
 		message = message:gsub(configOOCDetectionPattern(), function(content)
@@ -419,6 +428,12 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		if (message:find(OOCTempDetectionPattern)) then
 			message = message:gsub(OOCTempDetectionPattern, function(content)
 				return OOCColor:WrapTextInColorCode(content):gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "") .. NPCEmoteChatString;
+			end);
+		end
+
+		if (message:find(RussianDeclensionDetectionPattern)) then
+			message = message:gsub(RussianDeclensionDetectionPattern, function(declension, content)
+				return "|3-" .. declension .. "(" .. content .. ")";
 			end);
 		end
 	end

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -352,6 +352,22 @@ TRP3_API.utils.getCharacterInfoTab = getCharacterInfoTab;
 -- Emote and OOC detection
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
+-- For links exception
+local EmoteTempPatternStart = "TRP3BTMPEMOTE"
+local EmoteTempPatternEnd = "TRP3ETEMPEMOTE"
+local OOCTempPatternStart = "TRP3BTEMPOOC"
+local OOCTempPatternEnd = "TRP3ETEMPOOC"
+local SpeechTempPatternStart = "TRP3BTEMPSPEECH"
+local SpeechTempPatternEnd = "TRP3ETEMPSPEECH"
+local RussianDeclensionStart = "TRP3BTEMPRUSSIAN"
+local RussianDeclensionEnd = "TRP3ETEMPRUSSIAN"
+
+local LinkDetectionPattern = "(%|H.-%|h.-|h)"
+local EmoteTempDetectionPattern = EmoteTempPatternStart .. ".-" .. EmoteTempPatternEnd
+local OOCTempDetectionPattern = OOCTempPatternStart .. ".-" .. OOCTempPatternEnd
+local SpeechTempDetectionPattern = SpeechTempPatternStart .. ".-" .. SpeechTempPatternEnd
+local RussianDeclensionDetectionPattern = RussianDeclensionStart .. "(.)(.-)" .. RussianDeclensionEnd
+
 ---@param message string
 ---@param NPCEmoteChatColor Color
 local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
@@ -365,22 +381,6 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		NPCEmoteChatString = NPCEmoteChatColor:GetColorCodeStartSequence();
 	end
 
-	-- For links exception
-	local EmoteTempPatternStart = "TRP3BTMPEMOTE"
-	local EmoteTempPatternEnd = "TRP3ETEMPEMOTE"
-	local OOCTempPatternStart = "TRP3BTEMPOOC"
-	local OOCTempPatternEnd = "TRP3ETEMPOOC"
-	local SpeechTempPatternStart = "TRP3BTEMPSPEECH"
-	local SpeechTempPatternEnd = "TRP3ETEMPSPEECH"
-	local RussianDeclensionStart = "TRP3BTEMPRUSSIAN"
-	local RussianDeclensionEnd = "TRP3ETEMPRUSSIAN"
-
-	local LinkDetectionPattern = "(%|H.-%|h.-|h)"
-	local EmoteTempDetectionPattern = EmoteTempPatternStart .. ".-" .. EmoteTempPatternEnd
-	local OOCTempDetectionPattern = OOCTempPatternStart .. ".-" .. OOCTempPatternEnd
-	local SpeechTempDetectionPattern = SpeechTempPatternStart .. ".-" .. SpeechTempPatternEnd
-	local RussianDeclensionDetectionPattern = RussianDeclensionStart .. "(.)(.-)" .. RussianDeclensionEnd
-
 	-- Emote/OOC/Speech replacement
 	if configDoEmoteDetection() and message:find(configEmoteDetectionPattern()) then
 		-- Wrapping patterns in a temporary pattern
@@ -390,18 +390,14 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		end);
 
 		-- Removing temporary patterns from links
-		if (message:find(LinkDetectionPattern)) then
-			message = message:gsub(LinkDetectionPattern, function(content)
-				return content:gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "");
-			end);
-		end
+		message = message:gsub(LinkDetectionPattern, function(content)
+			return content:gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "");
+		end);
 
 		-- Replacing temporary patterns by color wrap
-		if (message:find(EmoteTempDetectionPattern)) then
-			message = message:gsub(EmoteTempDetectionPattern, function(content)
-				return chatColor:WrapTextInColorCode(content):gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "") .. NPCEmoteChatString;
-			end);
-		end
+		message = message:gsub(EmoteTempDetectionPattern, function(content)
+			return chatColor:WrapTextInColorCode(content):gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "") .. NPCEmoteChatString;
+		end);
 	end
 
 	if configDoOOCDetection() and message:find(configOOCDetectionPattern()) then
@@ -418,24 +414,16 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		end);
 
 		-- Removing temporary patterns from links
-		if (message:find(LinkDetectionPattern)) then
-			message = message:gsub(LinkDetectionPattern, function(content)
-				return content:gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "");
-			end);
-		end
+		message = message:gsub(LinkDetectionPattern, function(content)
+			return content:gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "");
+		end);
 
 		-- Replacing temporary patterns by color wrap
-		if (message:find(OOCTempDetectionPattern)) then
-			message = message:gsub(OOCTempDetectionPattern, function(content)
-				return OOCColor:WrapTextInColorCode(content):gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "") .. NPCEmoteChatString;
-			end);
-		end
+		message = message:gsub(OOCTempDetectionPattern, function(content)
+			return OOCColor:WrapTextInColorCode(content):gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "") .. NPCEmoteChatString;
+		end);
 
-		if (message:find(RussianDeclensionDetectionPattern)) then
-			message = message:gsub(RussianDeclensionDetectionPattern, function(declension, content)
-				return "|3-" .. declension .. "(" .. content .. ")";
-			end);
-		end
+		message = message:gsub(RussianDeclensionDetectionPattern, "|3-%1(%2)");
 	end
 
 	-- Only apply speech detections on emotes (excluding NPC non-emote speech)
@@ -447,18 +435,14 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		end);
 
 		-- Removing temporary patterns from links
-		if (message:find(LinkDetectionPattern)) then
-			message = message:gsub(LinkDetectionPattern, function(content)
-				return content:gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "");
-			end);
-		end
+		message = message:gsub(LinkDetectionPattern, function(content)
+			return content:gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "");
+		end);
 
 		-- Replacing temporary patterns by color wrap
-		if (message:find(SpeechTempDetectionPattern)) then
-			message = message:gsub(SpeechTempDetectionPattern, function(content)
-				return chatColor:WrapTextInColorCode(content):gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "") .. NPCEmoteChatString;
-			end);
-		end
+		message = message:gsub(SpeechTempDetectionPattern, function(content)
+			return chatColor:WrapTextInColorCode(content):gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "") .. NPCEmoteChatString;
+		end);
 	end
 
 	return message;


### PR DESCRIPTION
Long story short, the Russian declension system uses `|3-X( ... )` as a pattern to know where and how to apply it. TRP3 matches the parentheses of this pattern when doing OOC detection, inserts the color code, thus breaking the pattern in the process.

So, to counter this, I am replacing the pattern before the OOC detection and putting it back together afterwards. We need to keep track of what declension is being used as there are multiple possible (from my experience, at least 1 to 4 are used).

*There's also a bunch of minor fixes for stuff Meo complained about, like removing useless find or moving patterns outside of the function >:(*