### PR TITLE
Added search bar in own profiles lists ( #35 )

### DIFF
--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -29,6 +29,7 @@ TRP3_API.profile = {};
 local Globals, Events, Utils = TRP3_API.globals, TRP3_API.events, TRP3_API.utils;
 local loc = TRP3_API.loc;
 local unitIDToInfo = Utils.str.unitIDToInfo;
+local safeMatch = Utils.str.safeMatch;
 local strsplit, tinsert, pairs, type, assert, _G, table, tostring, error, wipe = strsplit, tinsert, pairs, type, assert, _G, table, tostring, error, wipe;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
 local handleMouseWheel = TRP3_API.ui.list.handleMouseWheel;
@@ -40,6 +41,7 @@ local playUISound = TRP3_API.ui.misc.playUISound;
 local playAnimation = TRP3_API.ui.misc.playAnimation;
 local displayMessage = TRP3_API.utils.message.displayMessage;
 local getPlayerCurrentProfile;
+local tsize = Utils.table.size;
 
 -- Saved variables references
 local profiles, character, characters;
@@ -223,10 +225,21 @@ end
 -- Refresh list display
 local function uiInitProfileList()
 	wipe(profileListID);
+	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManagerSearch:GetText());
 	for profileID, _ in pairs(profiles) do
-		tinsert(profileListID, profileID);
+		if not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower()) then
+			tinsert(profileListID, profileID);
+		end
 	end
+
+	local size = tsize(profileListID);
+	TRP3_ProfileManagerListEmpty:Hide();
+	if size == 0 then
+		TRP3_ProfileManagerListEmpty:Show();
+	end
+
 	table.sort(profileListID, profileSortingByProfileName);
+
 	initList(TRP3_ProfileManagerList, profileListID, TRP3_ProfileManagerListSlider);
 end
 
@@ -473,9 +486,13 @@ function TRP3_API.profile.init()
 
 	--Localization
 	TRP3_ProfileManagerAdd:SetText(loc.PR_CREATE_PROFILE);
+	TRP3_ProfileManagerListEmpty:SetText(loc.PR_PROFILEMANAGER_EMPTY);
 
 	TRP3_ProfileManagerInfo:Show();
 	setTooltipForSameFrame(TRP3_ProfileManagerInfo, "RIGHT", 0, 0, loc.PR_EXPORT_IMPORT_TITLE, loc.PR_EXPORT_IMPORT_HELP);
+
+	TRP3_ProfileManagerSearch:SetScript("OnEnterPressed", uiInitProfileList);
+	TRP3_ProfileManagerSearchText:SetText(loc.PR_PROFILEMANAGER_SEARCH_PROFILE);
 
 	registerPage({
 		id = "player_profiles",

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -41,7 +41,6 @@ local playUISound = TRP3_API.ui.misc.playUISound;
 local playAnimation = TRP3_API.ui.misc.playAnimation;
 local displayMessage = TRP3_API.utils.message.displayMessage;
 local getPlayerCurrentProfile;
-local tsize = Utils.table.size;
 
 -- Saved variables references
 local profiles, character, characters;

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -232,7 +232,7 @@ local function uiInitProfileList()
 		end
 	end
 
-	local size = tsize(profileListID);
+	local size = #profileListID;
 	TRP3_ProfileManagerListEmpty:Hide();
 	if size == 0 then
 		TRP3_ProfileManagerListEmpty:Show();

--- a/totalRP3/core/ui/profiles.xml
+++ b/totalRP3/core/ui/profiles.xml
@@ -217,6 +217,12 @@
 							<Anchor point="BOTTOMRIGHT" relativePoint="TOPRIGHT" relativeTo="$parentList" x="3" y="8" />
 						</Anchors>
 					</Button>
+					<EditBox name="$parentSearch" inherits="TRP3_TitledEditBox">
+						<Size x="125" y="18" />
+						<Anchors>
+							<Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT" relativeTo="$parentList" x="10" y="8" />
+						</Anchors>
+					</EditBox>
 				</Frames>
 			</Frame>
 		</Frames>

--- a/totalRP3/core/ui/profiles.xml
+++ b/totalRP3/core/ui/profiles.xml
@@ -220,7 +220,7 @@
 					<EditBox name="$parentSearch" inherits="TRP3_TitledEditBox">
 						<Size x="125" y="18" />
 						<Anchors>
-							<Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT" relativeTo="$parentList" x="10" y="8" />
+							<Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT" relativeTo="$parentList" x="10" y="5" />
 						</Anchors>
 					</EditBox>
 				</Frames>

--- a/totalRP3/modules/register/companions/register_companions_profiles.lua
+++ b/totalRP3/modules/register/companions/register_companions_profiles.lua
@@ -251,7 +251,7 @@ function uiInitProfileList()
 		end
 	end
 
-	local size = tsize(profileListID);
+	local size = #profileListID;
 	TRP3_CompanionsProfilesListEmpty:Hide();
 	if size == 0 then
 		if not profileSearch then

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1405,6 +1405,8 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
+	PR_PROFILEMANAGER_SEARCH_PROFILE = "Search profile",
+	PR_PROFILEMANAGER_EMPTY = "No matching profile",
 
 };
 

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1406,7 +1406,7 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	------------------------------------------------------------------------------------------------
 
 	PR_PROFILEMANAGER_SEARCH_PROFILE = "Search profile",
-	PR_PROFILEMANAGER_EMPTY = "No matching profile",
+	PR_PROFILEMANAGER_EMPTY = "No profiles found",
 
 };
 


### PR DESCRIPTION
A search bar was added in both character and companion profiles lists. Not much to say, it behaves the same way as the directory search bar does (search on enter, safe match on the lower strings). Added an empty text for character profiles list and adapted the companion one depending on whether a search is active or not.

No reliance on new code and no breaking changes so dev targeted.