### PR TITLE
Default profile ( #122 )

### DIFF
--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -242,27 +242,25 @@ end
 -- Refresh list display
 local function uiInitProfileList()
 	wipe(profileListID);
+	local defaultProfileID = getConfigValue("default_profile_id");
 	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManagerSearch:GetText());
 	for profileID, _ in pairs(profiles) do
-		if not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower()) then
+		if profileID ~= defaultProfileID and not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower()) then
 			tinsert(profileListID, profileID);
 		end
 	end
 
-	local size = #profileListID;
-	TRP3_ProfileManagerListEmpty:Hide();
-	if size == 0 then
-		TRP3_ProfileManagerListEmpty:Show();
-	--local defaultProfileID = getConfigValue("default_profile_id");
-	--for profileID, _ in pairs(profiles) do
-	--	if profileID ~= defaultProfileID then
-	--		tinsert(profileListID, profileID);
-	--	end
-	end
-
 	table.sort(profileListID, profileSortingByProfileName);
 
-	--tinsert(profileListID, 1, defaultProfileID);
+	local size = #profileListID;
+	TRP3_ProfileManagerListEmpty:Hide();
+	if profileSearch then
+		if size == 0 then
+			TRP3_ProfileManagerListEmpty:Show();
+		end
+	else
+		tinsert(profileListID, 1, defaultProfileID);
+	end
 	initList(TRP3_ProfileManagerList, profileListID, TRP3_ProfileManagerListSlider);
 end
 

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -450,7 +450,7 @@ function TRP3_API.profile.init()
 	TRP3_API.configuration.registerConfigKey("default_profile_id", "");
 
 	-- Creating the default profile
-	if getConfigValue("default_profile_id") == "" then
+	if getConfigValue("default_profile_id") == "" or not profiles[getConfigValue("default_profile_id")] then
 		TRP3_API.configuration.setValue("default_profile_id", createProfile(loc.PR_DEFAULT_PROFILE_NAME));
 	else
 		updateDefaultProfile();

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -248,7 +248,7 @@ local function uiInitProfileList()
 	local defaultProfileID = getConfigValue("default_profile_id");
 	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManagerSearch:GetText());
 	for profileID, _ in pairs(profiles) do
-		if profileID ~= defaultProfileID and not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower()) then
+		if profileID ~= defaultProfileID and (not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower())) then
 			tinsert(profileListID, profileID);
 		end
 	end

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -174,8 +174,11 @@ end
 TRP3_API.profile.getPlayerCurrentProfile = getPlayerCurrentProfile;
 
 local function updateDefaultProfile()
-	local profileCharacteristics = profiles[getConfigValue("default_profile_id")].player.characteristics;
+	local profileDefault = profiles[getConfigValue("default_profile_id")];
+	-- Updating profile name in case of addon locale change
+	profileDefault.profileName = loc.PR_DEFAULT_PROFILE_NAME;
 
+	local profileCharacteristics = profileDefault.player.characteristics;
 	profileCharacteristics.v = profileCharacteristics.v + 1;
 	profileCharacteristics.RA = Globals.player_race_loc;
 	profileCharacteristics.CL = Globals.player_class_loc;

--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -702,6 +702,17 @@ local function tabBar_setTabVisible(tabGroup, index, isVisible)
 	tabGroup:Redraw();
 end
 
+local function tabBar_setAllTabsVisible(tabGroup, isVisible)
+	for index=1, #tabGroup.tabs do
+		if isVisible then
+			tabGroup.tabs[index]:Show();
+		else
+			tabGroup.tabs[index]:Hide();
+		end
+	end
+	tabGroup:Redraw();
+end
+
 local function tabBar_selectTab(tabGroup, index)
 	assert(tabGroup.tabs[index], "Tab index out of bound.");
 	assert(tabGroup.tabs[index]:IsShown(), "Try to select a hidden tab.");
@@ -741,6 +752,7 @@ function TRP3_API.ui.frame.createTabPanel(tabBar, data, callback, confirmCallbac
 	tabGroup.Size = tabBar_size;
 	tabGroup.SetTabVisible = tabBar_setTabVisible;
 	tabGroup.SelectTab = tabBar_selectTab;
+	tabGroup.SetAllTabsVisible = tabBar_setAllTabsVisible;
 	tabGroup:Redraw();
 
 	return tabGroup;

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -722,9 +722,9 @@ function TRP3_API.register.init()
 	profiles = TRP3_Register.profiles;
 	characters = TRP3_Register.character;
 
-	TRP3_RegisterDefaultViewText:SetText("Create a new profile\nor link to an existing one in Profiles\nto edit your character's information.");
+	TRP3_RegisterDefaultViewText:SetText(loc.PR_DEFAULT_PROFILE_WARNING);
 	TRP3_RegisterDefaultViewText:SetJustifyH("CENTER");
-	TRP3_RegisterDefaultViewCreateProfile:SetText("Create Profile");
+	TRP3_RegisterDefaultViewCreateProfile:SetText(loc.PR_CREATE_PROFILE);
 	TRP3_RegisterDefaultViewCreateProfile:SetScript("OnClick", function()
 		showTextInputPopup(loc.PR_PROFILEMANAGER_CREATE_POPUP,
 			function(newName)

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -49,10 +49,12 @@ local assert, tostring, wipe, pairs, tinsert = assert, tostring, wipe, pairs, ti
 local registerMenu, selectMenu = TRP3_API.navigation.menu.registerMenu, TRP3_API.navigation.menu.selectMenu;
 local registerPage, setPage = TRP3_API.navigation.page.registerPage, TRP3_API.navigation.page.setPage;
 local getCurrentContext, getCurrentPageID = TRP3_API.navigation.page.getCurrentContext, TRP3_API.navigation.page.getCurrentPageID;
+local getPlayerCurrentProfileID, isProfileNameAvailable, createProfile, selectProfile = TRP3_API.profile.getPlayerCurrentProfileID, TRP3_API.profile.isProfileNameAvailable, TRP3_API.profile.createProfile, TRP3_API.profile.selectProfile;
 local showCharacteristicsTab, showAboutTab, showMiscTab, showNotesTab;
 local get = TRP3_API.profile.getData;
 local type = type;
-local showAlertPopup = TRP3_API.popup.showAlertPopup;
+local showAlertPopup, showTextInputPopup = TRP3_API.popup.showAlertPopup, TRP3_API.popup.showTextInputPopup;
+local toast = TRP3_API.ui.tooltip.toast;
 
 -- Saved variables references
 local profiles, characters;
@@ -510,6 +512,7 @@ local function createTabBar()
 			TRP3_RegisterAbout:Hide();
 			TRP3_RegisterMisc:Hide();
 			TRP3_RegisterNotes:Hide();
+			TRP3_RegisterDefault:Hide();
 			if value == 1 then
 				showCharacteristicsTab();
 			elseif value == 2 then
@@ -535,10 +538,31 @@ local function createTabBar()
 	TRP3_API.register.player.tabGroup = tabGroup;
 end
 
+local function showDefaultTab()
+	TRP3_RegisterCharact:Hide();
+	TRP3_RegisterAbout:Hide();
+	TRP3_RegisterMisc:Hide();
+	TRP3_RegisterNotes:Hide();
+	TRP3_ProfileReportButton:Hide();
+
+	tabGroup:SetAllTabsVisible(false);
+
+	TRP3_RegisterDefault:Show();
+
+	tabGroup.current = 0;	-- To avoid unwanted behaviour
+	getCurrentContext().isEditMode = false;
+	TRP3_API.events.fireEvent(TRP3_API.events.NAVIGATION_TUTORIAL_REFRESH, "player_main");
+end
+
 local function showTabs()
 	local context = getCurrentContext();
 	assert(context, "No context for page player_main !");
-	tabGroup:SelectTab(1);
+	if not context.isPlayer or getPlayerCurrentProfileID() ~= getConfigValue("default_profile_id") then
+		tabGroup:SetAllTabsVisible(true);
+		tabGroup:SelectTab(1);
+	else
+		showDefaultTab();
+	end
 end
 
 function TRP3_API.register.ui.getSelectedTabIndex()
@@ -697,6 +721,27 @@ function TRP3_API.register.init()
 	end
 	profiles = TRP3_Register.profiles;
 	characters = TRP3_Register.character;
+
+	TRP3_RegisterDefaultViewText:SetText("Create a new profile\nor link to an existing one in Profiles\nto edit your character's information.");
+	TRP3_RegisterDefaultViewText:SetJustifyH("CENTER");
+	TRP3_RegisterDefaultViewCreateProfile:SetText("Create Profile");
+	TRP3_RegisterDefaultViewCreateProfile:SetScript("OnClick", function()
+		showTextInputPopup(loc.PR_PROFILEMANAGER_CREATE_POPUP,
+			function(newName)
+				if newName and #newName ~= 0 then
+					if not isProfileNameAvailable(newName) then
+						toast(loc.PR_PROFILEMANAGER_ALREADY_IN_USE:format(Utils.str.color("r")..newName.."|r"), 3);
+					else
+						selectProfile(createProfile(newName));
+						tabGroup:SetAllTabsVisible(true);
+						tabGroup:SelectTab(1);
+					end
+				end
+			end,
+			nil,
+			Globals.player_realm .. " - " .. Globals.player
+		);
+	end);
 
 	-- Listen to the mouse over event
 	Utils.event.registerHandler("UPDATE_MOUSEOVER_UNIT", onMouseOver);

--- a/totalRP3/modules/register/characters/register_notes.lua
+++ b/totalRP3/modules/register/characters/register_notes.lua
@@ -34,6 +34,7 @@ local stEtN = TRP3_API.utils.str.emptyToNil;
 local GetCurrentUser = AddOn_TotalRP3.Player.GetCurrentUser;
 local getPlayerCurrentProfile = TRP3_API.profile.getPlayerCurrentProfile;
 local getPlayerCurrentProfileID = TRP3_API.profile.getPlayerCurrentProfileID;
+local getConfigValue = TRP3_API.configuration.getValue;
 
 local NOTES_ICON = Ellyb.Icon(Globals.is_classic and "INV_Scroll_02" or "Inv_misc_scrollunrolled03b");
 
@@ -127,7 +128,7 @@ function TRP3_API.register.inits.notesInit()
 			configText = loc.REG_NOTES_PROFILE,
 			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
 			condition = function(_, unitID)
-				return unitID == Globals.player_id or (isUnitIDKnown(unitID) and hasProfile(unitID));
+				return (unitID == Globals.player_id and getPlayerCurrentProfileID() ~= getConfigValue("default_profile_id")) or (isUnitIDKnown(unitID) and hasProfile(unitID));
 			end,
 			onClick = function(unitID)
 				openMainFrame();

--- a/totalRP3/modules/register/characters/register_ui_main.xml
+++ b/totalRP3/modules/register/characters/register_ui_main.xml
@@ -64,6 +64,54 @@
 					<Anchor point="BOTTOMLEFT" x="2" y="0" />
 				</Anchors>
 			</Frame>
+			<Frame name="TRP3_RegisterDefault" inherits="TRP3_BackdropTemplate" frameLevel="2">
+				<Anchors>
+					<Anchor point="TOPRIGHT" x="2" y="-28" />
+					<Anchor point="BOTTOMLEFT" x="2" y="0" />
+				</Anchors>
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="TRP3_BACKDROP_TOOLTIP_0_24" type="global"/>
+				</KeyValues>
+				<Layers>
+					<Layer level="BACKGROUND">
+						<Texture file="Interface\SPELLBOOK\Spellbook-Page-1">
+							<Anchors>
+								<Anchor point="TOPRIGHT" x="-5" y="-2"/>
+								<Anchor point="BOTTOMRIGHT" x="-5" y="-2"/>
+								<Anchor point="LEFT" x="5" y="0"/>
+							</Anchors>
+							<TexCoords left="0.07" right="1" top="0" bottom="0.975" />
+						</Texture>
+					</Layer>
+				</Layers>
+				<Frames>
+					<Frame name="TRP3_RegisterDefaultView">
+						<Anchors>
+							<Anchor point="TOPLEFT" x="10" y="-20"/>
+							<Anchor point="TOPRIGHT" x="-10" y="-20"/>
+							<Anchor point="BOTTOM" x="0" y="10"/>
+						</Anchors>
+						<Layers>
+							<Layer level="OVERLAY">
+								<FontString name="TRP3_RegisterDefaultViewText" text="[text]" inherits="GameFontNormalLarge" justifyH="LEFT">
+									<Anchors>
+										<Anchor point="BOTTOM" relativePoint="CENTER" x="0" y="10"/>
+									</Anchors>
+									<Color r="1" g="1" b="1"/>
+								</FontString>
+							</Layer>
+						</Layers>
+						<Frames>
+							<Button name="TRP3_RegisterDefaultViewCreateProfile" inherits="TRP3_CommonButton">
+								<Size x="150" y="20"/>
+								<Anchors>
+									<Anchor point="TOP" relativePoint="CENTER" x="0" y="-10"/>
+								</Anchors>
+							</Button>
+						</Frames>
+					</Frame>
+				</Frames>
+			</Frame>
 			<Button name="TRP3_ProfileReportButton">
 				<Size x="30" y="30" />
 				<Anchors>

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1405,7 +1405,8 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
-
+	PR_DEFAULT_PROFILE_NAME = "Default profile",
+	PR_DEFAULT_PROFILE_WARNING = "Create a new profile\nor link to an existing one in Profiles\nto edit your character's information.",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
As discussed in the ticket, unlinked characters will now be linked to a single default profile instead of having a new one created for every character. This profile is currently always shown first in the list (could be put in last position, I just feel like a fixed position is better than it being in the alphabetical sorting) and its basic data is automatically updated depending on the character.

Actions have been hidden for this profile, as well as tab buttons in the profile details window. In the latter, if the default profile is selected, a message warns to create a new profile (with a button for this directly underneath) or link to an existing one. Creating a new profile there will automatically select it (I'm unsure if this behaviour should also be replicated in the Profiles list window, I think it should but importing a profile cannot currently be done on the selected profile - could also be something to look into) and move to the details of the new profile.

As notes are currently a tab in the profile details, their dedicated button has been disabled in the player's target frame if the default profile is selected, but I'll think it over. Extended features (inventory, bags, quest log) will work as with any other profile.

Points still to consider: Do we want to show more on the details tab? Would we use this opportunity to look at #179 (This might be tricky with new characters all tied to the default one)?

Last point: Will have to take this PR into account for #415 so that the default profile is hidden during a search.