### PR TITLE
Added safeguard for WIM

### DIFF
--- a/totalRP3/modules/chatframe/prat.lua
+++ b/totalRP3/modules/chatframe/prat.lua
@@ -77,8 +77,8 @@ local function onStart()
 
 			if disabledByOOC() then return end;
 
-			-- If the message has no GUID (system?) we don't have anything to do with this
-			if not message.GUID then return end;
+			-- If the message has no GUID (system?) or an invalid GUID (WIM >:( ) we don't have anything to do with this
+			if not message.GUID or not C_PlayerInfo.GUIDIsPlayer(message.GUID) then return end;
 
 			-- Do not do any modification if the channel is not handled by TRP3 or customizations has been disabled
 			-- for that channel in the settings


### PR DESCRIPTION
WIM sends fake GUID for history messages. We don't do that here, so we're checking that the GUID belongs to a player before applying name customisation. Needs to be tested.

_I'm doing it straight from Github fite me._