### PR TITLE
Sanitizing % character in popups

### DIFF
--- a/totalRP3/core/impl/popup.lua
+++ b/totalRP3/core/impl/popup.lua
@@ -199,6 +199,7 @@ function TRP3_API.popup.showAlertPopup(text)
 end
 
 function TRP3_API.popup.showConfirmPopup(text, onAccept, onCancel)
+	text = string.gsub(text, "%%", "%%%%");
 	StaticPopupDialogs["TRP3_CONFIRM"].text = POPUP_HEAD..text.."\n\n";
 	StaticPopupDialogs["TRP3_CONFIRM"].trp3onAccept = onAccept;
 	StaticPopupDialogs["TRP3_CONFIRM"].trp3onCancel = onCancel;
@@ -210,6 +211,7 @@ function TRP3_API.popup.showConfirmPopup(text, onAccept, onCancel)
 end
 
 function TRP3_API.popup.showYesNoPopup(text, onAccept, onCancel)
+	text = string.gsub(text, "%%", "%%%%");
 	StaticPopupDialogs["TRP3_YES_NO"].text = POPUP_HEAD..text.."\n\n";
 	StaticPopupDialogs["TRP3_YES_NO"].trp3onAccept = onAccept;
 	StaticPopupDialogs["TRP3_YES_NO"].trp3onCancel = onCancel;
@@ -221,6 +223,7 @@ function TRP3_API.popup.showYesNoPopup(text, onAccept, onCancel)
 end
 
 function TRP3_API.popup.showCustomYesNoPopup(text, yesText, noText, onAccept, onCancel)
+	text = string.gsub(text, "%%", "%%%%");
 	StaticPopupDialogs["TRP3_YES_NO_CUSTOM"].button1 = yesText;
 	StaticPopupDialogs["TRP3_YES_NO_CUSTOM"].button2 = noText;
 	StaticPopupDialogs["TRP3_YES_NO_CUSTOM"].text = text;
@@ -234,6 +237,7 @@ function TRP3_API.popup.showCustomYesNoPopup(text, yesText, noText, onAccept, on
 end
 
 function TRP3_API.popup.showTextInputPopup(text, onAccept, onCancel, default)
+	text = string.gsub(text, "%%", "%%%%");
 	StaticPopupDialogs["TRP3_INPUT_TEXT"].text = POPUP_HEAD..text.."\n\n";
 	StaticPopupDialogs["TRP3_INPUT_TEXT"].trp3onAccept = onAccept;
 	StaticPopupDialogs["TRP3_INPUT_TEXT"].trp3onCancel = onCancel;
@@ -247,6 +251,7 @@ function TRP3_API.popup.showTextInputPopup(text, onAccept, onCancel, default)
 end
 
 function TRP3_API.popup.showNumberInputPopup(text, onAccept, onCancel, default)
+	text = string.gsub(text, "%%", "%%%%");
 	StaticPopupDialogs["TRP3_INPUT_NUMBER"].text = POPUP_HEAD..text.."\n\n";
 	StaticPopupDialogs["TRP3_INPUT_NUMBER"].trp3onAccept = onAccept;
 	StaticPopupDialogs["TRP3_INPUT_NUMBER"].trp3onCancel = onCancel;


### PR DESCRIPTION
There's a forced call to format in StaticPopup_Show which bugs out if the popup text has a % character in it, which can happen out of our control if someone names a profile or Extended creation with a %. Doubling the % character before putting it in the popup ensures this issue doesn't happen.