### PR TITLE
Force dropdowns to avoid AddNewbieTip in 9.x

### DIFF
--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -163,7 +163,8 @@ local function openDropDown(anchoredFrame, values, callback, space, addCancel)
 				else
 					info.text = text;
 					info.isTitle = false;
-					info.tooltipOnButton = tooltipText ~= nil;
+					-- 9.x: tooltipOnButton is required. Keeping old behaviour for Classic.
+					info.tooltipOnButton = not is_classic or tooltipText ~= nil;
 					info.tooltipTitle = text;
 					info.tooltipText = tooltipText;
 					if type(value) == "table" then


### PR DESCRIPTION
This function was deprecated in BFA and has since been removed, but MSA hasn't fixed this in its own code yet. This can be tested by mousing over some dropdown buttons - for instance the template dropdown in the profile editor.

Forcing the tooltipOnButton field of the info to true in 9.x clients will force MSA to take a branch that avoids using the removed function for now.