### PR TITLE
Fix profile backgrounds

### DIFF
--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -124,6 +124,7 @@ local draftData;
 local function setBkg(frame, bkg)
 	local backdrop = frame:GetBackdrop();
 	backdrop.bgFile = getTiledBackground(bkg or 1);
+	backdrop.tile = false; -- We want it to stretch, not tile.
 	frame:SetBackdrop(backdrop);
 end
 
@@ -227,6 +228,7 @@ local function showTemplate2(dataTab)
 		local text = _G[frame:GetName().."Text"];
 		local backdrop = frame:GetBackdrop();
 		backdrop.bgFile = getTiledBackground(frameTab.BK or 1);
+		backdrop.tile = false;
 		frame:SetBackdrop(backdrop);
 		setupIconButton(icon, frameTab.IC or Globals.icons.default);
 


### PR DESCRIPTION
These were being tiled at an abnormally small size instead of being stretched due to the base backdrop definition having a tiled background now. Setting the tile property to false fixes this.