### PR TITLE
Updating context after creating profile from default page

### DIFF
--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -733,6 +733,7 @@ function TRP3_API.register.init()
 						toast(loc.PR_PROFILEMANAGER_ALREADY_IN_USE:format(Utils.str.color("r")..newName.."|r"), 3);
 					else
 						selectProfile(createProfile(newName));
+						getCurrentContext().profile = get("player");
 						tabGroup:SetAllTabsVisible(true);
 						tabGroup:SelectTab(1);
 					end


### PR DESCRIPTION
The context wasn't updated after creating the profile from the default page warning, causing refresh issues when trying to edit the profile immediately afterwards. This should fix the problem.