### PR TITLE
Side anchors on the default profile warning

### DIFF
--- a/totalRP3/modules/register/characters/register_ui_main.xml
+++ b/totalRP3/modules/register/characters/register_ui_main.xml
@@ -96,6 +96,8 @@
 								<FontString name="TRP3_RegisterDefaultViewText" text="[text]" inherits="GameFontNormalLarge" justifyH="LEFT">
 									<Anchors>
 										<Anchor point="BOTTOM" relativePoint="CENTER" x="0" y="10"/>
+										<Anchor point="LEFT" x="10" y="0"/>
+										<Anchor point="RIGHT" x="-10" y="0"/>
 									</Anchors>
 									<Color r="1" g="1" b="1"/>
 								</FontString>


### PR DESCRIPTION
Added anchors to prevent the default profile warning translated text from overflowing

![Untitled](https://user-images.githubusercontent.com/17127080/96033438-5b84a100-0e60-11eb-8e5a-741f4724c8c0.png)
