### PR TITLE
Improve handling of improper case in /trp3 open

### DIFF
--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -498,14 +498,13 @@ TRP3_API.slash.registerCommand({
 				characterToOpen = Utils.str.getUnitID(characterToOpen:lower());
 			else
 				-- Capitalizing first letter of the name/realm, just in case someone is lazy.
-
 				local name, realm = AddOn_Chomp.NameSplitRealm(characterToOpen);
 
-				if not name then
-					displayMessage(loc.PR_SLASH_OPEN_EXAMPLE);
-					return;
-				end
+				-- If the split fails due to the user only giving a name then
+				-- neither a name/realm will be returned; in this case we'll
+				-- assume the input is name-only and use the current realm.
 
+				name  = name or characterToOpen;
 				realm = realm or TRP3_API.globals.player_realm_id;
 
 				name  = string.gsub(name, "^%l", string.upper);

--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -497,9 +497,21 @@ TRP3_API.slash.registerCommand({
 				-- If we typed a unit token we resolve it
 				characterToOpen = Utils.str.getUnitID(characterToOpen:lower());
 			else
-				-- Capitalizing first letter of the name, just in case someone is lazy.
-				-- We don't have a solution for "I'm lazy but need someone from another realm" yet.
-				characterToOpen = characterToOpen:gsub("^%l", string.upper);
+				-- Capitalizing first letter of the name/realm, just in case someone is lazy.
+
+				local name, realm = AddOn_Chomp.NameSplitRealm(characterToOpen);
+
+				if not name then
+					displayMessage(loc.PR_SLASH_OPEN_EXAMPLE);
+					return;
+				end
+
+				realm = realm or TRP3_API.globals.player_realm_id;
+
+				name  = string.gsub(name, "^%l", string.upper);
+				realm = string.gsub(realm, "^%l", string.upper);
+
+				characterToOpen = AddOn_Chomp.NameMergedRealm(name, realm);
 			end
 
 			-- If no realm has been entered, we use the player's realm automatically
@@ -537,9 +549,14 @@ TRP3_API.slash.registerCommand({
 
 -- Event for the "/trp3 open" command
 Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(unitID, _, dataType)
-	if unitID == characterToOpen and (not dataType or dataType == "character") then
+	if AddOn_Chomp.InsensitiveStringEquals(characterToOpen, unitID)
+		and (not dataType or dataType == "character") then
+		-- Use the unitID when opening the UI as it will be precisely what's
+		-- in the register, whereas characterToOpen might have incorrect
+		-- casing if, for example, the user typed the name in all-caps.
+
 		TRP3_API.navigation.openMainFrame();
-		TRP3_API.register.openPageByUnitID(characterToOpen);
+		TRP3_API.register.openPageByUnitID(unitID);
 		if commandOpeningTimerHandle then
 			commandOpeningTimerHandle:Cancel();
 		end


### PR DESCRIPTION
Because `/trp3 open trptestcharb-turalyon` not working was throwing me for a loop...

Before, we'd only attempt to uppercase the first letter of the name and wouldn't try to case-correct the realm. Similarly upon receiving new register data we would check if the sender (which will be case-correct) against a possibly-incorrect user input, and if these didn't match the UI wouldn't open.

The new logic fixes the above issues by attempting to case-correct both the requested player name and their realm separately. If the user still manages to screw this up (by typing the whole thing in caps), then when register data is updated we'll now do a case-insensitive comparison against the sender and open the UI based on that identifier rather than the user input.

Note that this requires a newer Chimp version which isn't included in this PR yet due to it needing to be merged into master there. As it's not urgent, 9.0.2?