### PR TITLE
Pin luacheck workflow step to @v1 tag

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Luacheck
-        uses: nebularg/actions-luacheck@44fc699 # TODO: Pin to @v1 when a new tag after v1.0.0 is made.
+        uses: nebularg/actions-luacheck@v1
         with:
           args:     --no-color -q
           annotate: warning


### PR DESCRIPTION
The annotation support got its own tag (v1.1) so this shouldn't need to reference a specific commit anymore.