### PR TITLE
Exit edit mode on Misc/Notes tabs

### DIFF
--- a/totalRP3/modules/register/characters/register_misc.lua
+++ b/totalRP3/modules/register/characters/register_misc.lua
@@ -418,6 +418,7 @@ local function showMiscTab()
 	local context = getCurrentContext();
 	assert(context, "No context for page player_main !");
 	assert(context.profile, "No profile in context");
+	context.isEditMode = false;
 	TRP3_RegisterMisc:Show();
 	displayPeek(context);
 	displayRPStyle(context);

--- a/totalRP3/modules/register/characters/register_notes.lua
+++ b/totalRP3/modules/register/characters/register_notes.lua
@@ -93,6 +93,7 @@ local function showNotesTab()
 	local context = getCurrentContext();
 	assert(context, "No context for page player_main !");
 	assert(context.profile, "No profile in context");
+	context.isEditMode = false;
 	TRP3_ProfileReportButton:Hide();
 	displayNotes(context);
 	TRP3_RegisterNotes:Show();


### PR DESCRIPTION
Entering edit mode on the "About" tab and the navigating to either the "Miscellaneous" or "Notes" tabs would prompt the user about losing unsaved changes. Accepting this prompt would change the tab, but showing these tab pages wouldn't clear the edit flag - thus causing users to be re-prompted each time they changed tabs.