### PR TITLE
Tooltip fixes

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1109,7 +1109,7 @@ local function onUpdate(self, elapsed)
 	if (self.TimeSinceLastUpdate > getFadeTime()) then
 		self.TimeSinceLastUpdate = 0;
 		if self.target and self.targetType and not self.isFading then
-			if self.target ~= getUnitID(self.targetType) then
+			if self.target ~= getUnitID(self.targetType) or not getUnitID("mouseover") then
 				self.isFading = true;
 				self.target = nil;
 				if fadeOutEnabled() then
@@ -1127,7 +1127,7 @@ local function onUpdateCompanion(self, elapsed)
 	if (self.TimeSinceLastUpdate > getFadeTime()) then
 		self.TimeSinceLastUpdate = 0;
 		if self.target and self.targetType and not self.isFading then
-			if self.target ~= getUnitID(self.targetType) then
+			if self.target ~= getUnitID(self.targetType) or not getUnitID("mouseover") then
 				self.isFading = true;
 				self.target = nil;
 				if fadeOutEnabled() then

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1147,19 +1147,25 @@ end
 TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	-- Listen to the mouse over event
 	Utils.event.registerHandler("UPDATE_MOUSEOVER_UNIT", function()
+		-- The event UPDATE_MOUSEOVER_UNIT is fired even when there is no unit on tooltip
+		-- But there is a target on mouseover (maintaining ALT on spell buttons)
+		-- So we need to check that we have indeed a unit before displaying our tooltip.
 		if GameTooltip:GetUnit() then
 			local targetID, targetMode = getUnitID("mouseover");
 			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, "mouseover");
 		end
 	end);
 	hooksecurefunc(GameTooltip, "SetUnit", function()
-		-- The event UPDATE_MOUSEOVER_UNIT is fired even when there is no unit on tooltip
-		-- But there is a target on mouseover (maintaining ALT on spell buttons)
-		-- So we need to check that we have indeed a unit before displaying our tooltip.
 		if GameTooltip:GetUnit() then
 			local _, unitID = GameTooltip:GetUnit();
 			local targetID, targetMode = getUnitID(unitID);
 			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, unitID);
+		end
+	end);
+	GameTooltip:HookScript("OnShow", function()
+		if not GameTooltip:GetUnit() then
+			ui_CharacterTT:Hide();
+			ui_CompanionTT:Hide();
 		end
 	end);
 end);

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1147,12 +1147,19 @@ end
 TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	-- Listen to the mouse over event
 	Utils.event.registerHandler("UPDATE_MOUSEOVER_UNIT", function()
+		if GameTooltip:GetUnit() then
+			local targetID, targetMode = getUnitID("mouseover");
+			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, "mouseover");
+		end
+	end);
+	hooksecurefunc(GameTooltip, "SetUnit", function()
 		-- The event UPDATE_MOUSEOVER_UNIT is fired even when there is no unit on tooltip
 		-- But there is a target on mouseover (maintaining ALT on spell buttons)
 		-- So we need to check that we have indeed a unit before displaying our tooltip.
 		if GameTooltip:GetUnit() then
-			local targetID, targetMode = getUnitID("mouseover");
-			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode);
+			local _, unitID = GameTooltip:GetUnit();
+			local targetID, targetMode = getUnitID(unitID);
+			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, unitID);
 		end
 	end);
 end);
@@ -1164,8 +1171,8 @@ local function onModuleInit()
 	isPlayerIC = TRP3_API.dashboard.isPlayerIC;
 	unitIDIsFilteredForMatureContent = TRP3_API.register.unitIDIsFilteredForMatureContent;
 
-	Events.listenToEvent(Events.MOUSE_OVER_CHANGED, function(targetID, targetMode)
-		show("mouseover", targetID, targetMode);
+	Events.listenToEvent(Events.MOUSE_OVER_CHANGED, function(targetID, targetMode, unitID)
+		show(unitID, targetID, targetMode);
 	end);
 
 	Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(unitID, _, _)

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1056,7 +1056,11 @@ local function show(targetType, targetID, targetMode)
 					GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);
 					placeTooltipOnCursor(ui_CharacterTT);
 				else
-					ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
+					if getAnchoredFrame() == GameTooltip and getConfigValue(CONFIG_CHARACT_HIDE_ORIGINAL) then
+						GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);
+					else
+						ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
+					end
 				end
 
 				ui_CharacterTT:SetBackdropBorderColor(1, 1, 1);


### PR DESCRIPTION
This PR should fix the following issues:
- Default tooltip still showing up when hovering different parts of a unit frame, despite the "Hide original tooltip" setting being on.
- TRP tooltip being offset from the original tooltip position.
- Brief overlap when hovering a spell or item very quickly after a character.