### PR TITLE
Tags adjustments

### DIFF
--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -790,7 +790,7 @@ local IMAGE_PATTERN = [[{img%:([^:]+)%:([^:]+)%:([^:}]+)%:?([^:}]*)%}]];
 local IMAGE_TAG = [[</P><img src="%s" width="%s" height="%s" align="%s"/><P>]];
 
 -- Convert the given text by his HTML representation
-Utils.str.toHTML = function(text, noColor)
+Utils.str.toHTML = function(text, noColor, noBrackets)
 
 	local linkColor = "|cff00ff00";
 	if noColor then
@@ -909,8 +909,12 @@ Utils.str.toHTML = function(text, noColor)
 		line = line:gsub("%[(.-)%]%((.-)%)",
 			"<a href=\"%2\">" .. linkColor .. "[%1]|r</a>");
 
+		local linkText = "[%2]"
+		if noBrackets then
+			linkText = "%2"
+		end
 		line = line:gsub("{link%*(.-)%*(.-)}",
-			"<a href=\"%1\">" .. linkColor .. "[%2]|r</a>");
+			"<a href=\"%1\">" .. linkColor .. linkText .. "|r</a>");
 
 		line = line:gsub("{twitter%*(.-)%*(.-)}",
 			"<a href=\"twitter%1\">|cff61AAEE%2|r</a>");

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -909,6 +909,9 @@ Utils.str.toHTML = function(text, noColor, noBrackets)
 		line = line:gsub("%[(.-)%]%((.-)%)",
 			"<a href=\"%2\">" .. linkColor .. "[%1]|r</a>");
 
+		line = line:gsub("{link%*(.-)%*({icon%:.-})}",
+			"<a href=\"%1\">" .. linkColor .. "%2|r</a>");
+
 		local linkText = "[%2]"
 		if noBrackets then
 			linkText = "%2"


### PR DESCRIPTION
First change is needed for adjustments to the objective tracker in Extended, it's an option to omit brackets around links (lets us show the Campaign/Quest names without brackets around them.
Second change is to allow icons to be used as "text" for links. Ultimately better parsing would be nice, but that's talk for another day.