### PR TITLE
Fix alphabetical order in character map scan

### DIFF
--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapPin.lua
@@ -101,7 +101,7 @@ function TRP3_PlayerMapPinMixin:Decorate(displayData)
 	self.tooltipLine = displayData.playerName;
 	self.categoryName = displayData.categoryName;
 	self.categoryPriority = displayData.categoryPriority;
-	self.sortName = displayData.playerName;
+	self.sortName = displayData.playerName:gsub("|T.-|t", ""):gsub("|c%x%x%x%x%x%x%x%x","");
 
 	if displayData.iconColor then
 		self.Texture:SetVertexColor(displayData.iconColor:GetRGBA());


### PR DESCRIPTION
When scanning for characters on the map, the icon and color tags are included in the name to use for sorting purposes, causing the order to be messed up. Removing both fixes the issue.

![](https://user-images.githubusercontent.com/17127080/99007645-e979a780-2544-11eb-9f08-bf945577706e.png)
