### PR TITLE
Prevent double-receipt of profile comms via MSP

### DIFF
--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -528,7 +528,7 @@ TRP3_API.slash.registerCommand({
 		end
 
 		sendQuery(characterToOpen);
-		msp:Request(characterToOpen, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
+		TRP3_API.r.sendMSPQuery(characterToOpen);
 		-- If we already have a profile for that user in the registry, we open it and reset the name (so it doesn't try to open again afterwards)
 		if characterToOpen == TRP3_API.globals.player_id or (isUnitIDKnown(characterToOpen) and hasProfile(characterToOpen)) then
 			TRP3_API.navigation.openMainFrame();

--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -45,7 +45,6 @@ local getCompanionData = TRP3_API.companions.player.getCompanionData;
 local saveCompanionInformation = TRP3_API.companions.register.saveInformation;
 local getConfigValue = TRP3_API.configuration.getValue;
 local displayMessage = TRP3_API.utils.message.displayMessage;
-local msp = _G.msp;
 
 
 -- WoW imports

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -263,8 +263,16 @@ local function onStart()
 		};
 	end
 
+	local outstandingHelloRequests = {};
+
 	tinsert(msp.callback.received, function(senderID)
 		local data = msp.char[senderID].field;
+
+		if outstandingHelloRequests[senderID] then
+			outstandingHelloRequests[senderID] = nil;
+			TRP3_API.r.sendMSPQuery(senderID);
+		end
+
 		if not isIgnored(senderID) and data.VA:sub(1, 8) ~= "TotalRP3" then
 			local profile, character = getProfileForSender(senderID);
 			if not profile.characteristics then
@@ -512,23 +520,41 @@ local function onStart()
 		end
 	end);
 
-	local function requestInformation(targetID, targetMode)
-		if not targetID then return end
-		local data = msp.char[targetID].field;
-		if targetID and targetMode == TYPE_CHARACTER
-		and targetID ~= Globals.player_id
-		and not isIgnored(targetID)
-		and data.VA:sub(1, 8) ~= "TotalRP3"
-		then
-			msp:Request(targetID, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
+	local function requestInformation(name, targetMode)
+		if not name or name == Globals.player_id or isIgnored(name) then
+			return;
+		elseif targetMode and targetMode ~= TYPE_CHARACTER then
+			return;
+		end
+
+		local data = msp.char[name].field;
+
+		if string.find(data.VA, "TotalRP3") then
+			return;
+		end
+
+		-- Quick hack to fix the "double request" issue with our comms;
+		-- previously it would be possible for requests to be sent via both
+		-- TRP and MSP protocols. If this occurred at the same time, we
+		-- effectively ended up doubling the comms needlessly in the worst
+		-- case scenario.
+		--
+		-- To work around this, if we've not seen a unit (they have no VA
+		-- field) we first send a "hello" request for just that field and
+		-- mark the receiver in an outstanding requests table. When a response
+		-- is received, we then re-send the request only if we're sure that
+		-- the user is _not_ running TRP3.
+
+		if data.VA == "" then
+			outstandingHelloRequests[name] = true;
+			msp:Request(name, { "VA" });
+		else
+			outstandingHelloRequests[name] = false;
+			msp:Request(name, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
 		end
 	end
 
-	TRP3_API.r.sendMSPQuery = function(name)
-		-- This function has never had the checks that the above does. Whether
-		-- it should or not should be revisited in the future.
-		msp:Request(name, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
-	end
+	TRP3_API.r.sendMSPQuery = requestInformation;
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Init


### PR DESCRIPTION
This fixes the initial double-request of profiles via both the TRP and MSP protocols when mousing over units or opening them in via the /trp3 open command.

Before, we'd send a request out to the other player via both protocols at once. The MSP layer has logic that causes it to ignore responses received by people running TRP, however that doesn't change the fact that we've still asked them for their entire profile - so we end up receiving (in the worst case) twice as much data as actually needed.

To fix this a small change is made so that all MSP requests go through a single, previously unused, function. When a request is sent via this path it first checks if we've received the players' VA field and, if not, will first issue a request _solely_ for that field.

Upon receiving a response we then consult the table to know if this was a "hello" request and, if so, re-request the full data from the other player if they're not running TRP.

This adds a bit of latency to initial MSP comms however in brief testing yesterday this was unnoticeable.