### PR TITLE
Validate unit tokens in GameTooltip:SetUnit hook

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1160,8 +1160,8 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		end
 	end);
 	hooksecurefunc(GameTooltip, "SetUnit", function()
-		if select(2, GameTooltip:GetUnit()) then
-			local _, unitID = GameTooltip:GetUnit();
+		local _, unitID = GameTooltip:GetUnit();
+		if unitID then
 			local targetID, targetMode = getUnitID(unitID);
 			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, unitID);
 		end

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1160,7 +1160,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		end
 	end);
 	hooksecurefunc(GameTooltip, "SetUnit", function()
-		if GameTooltip:GetUnit() then
+		if select(2, GameTooltip:GetUnit()) then
 			local _, unitID = GameTooltip:GetUnit();
 			local targetID, targetMode = getUnitID(unitID);
 			Events.fireEvent(Events.MOUSE_OVER_CHANGED, targetID, targetMode, unitID);


### PR DESCRIPTION
This should prevent the nil errors with various API functions that expect given unit tokens to be strings, such as UnitIsBattlePetCompanion.

![image](https://user-images.githubusercontent.com/287102/99507513-5d6be380-297b-11eb-870b-a8ef0f39fece.png)
