### PR TITLE
Some more tooltip fixes

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -195,7 +195,8 @@ local function showSpacing()
 end
 
 local function fadeOutEnabled()
-	return not getConfigValue(CONFIG_NO_FADE_OUT);
+	return true; -- TEMPORARY WORKAROUND
+	--return not getConfigValue(CONFIG_NO_FADE_OUT);
 end
 
 local function getCurrentMaxLines()

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1058,7 +1058,8 @@ local function show(targetType, targetID, targetMode)
 					placeTooltipOnCursor(ui_CharacterTT);
 				else
 					if getAnchoredFrame() == GameTooltip and getConfigValue(CONFIG_CHARACT_HIDE_ORIGINAL) then
-						GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);
+						ui_CharacterTT:SetOwner(UIParent, "ANCHOR_NONE");
+						ui_CharacterTT:SetPoint(GameTooltip:GetPoint(1));
 					else
 						ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
 					end


### PR DESCRIPTION
- Instead of resetting the TRP3 tooltip to the default position, we get the GameTooltip anchor and apply it instead. This should fix mispositioning of the tooltip for ElvUI users among other things.
- As a temporary measure to reduce confusion with the tooltip not showing up when mousing over unitframes, the fadeout on tooltip is forced. The actual behaviour causing the issue will be investigated further during the week.