### PR TITLE
Update links from Curse to CurseForge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Total RP 3 is the brand new roleplay add-on from the creators of Total RP 1 and 2!
 
-Download on [Curse].
+Download on [CurseForge].
 
 Are you having an issue with Total RP 3? Check the [F.A.Q] and our [troubleshooting page]!  
 
@@ -48,19 +48,19 @@ Also, Total RP 3 is a fully modular add-on. So even if it will greatly expand in
 
 ## Total RP 3 modules spotlight
 
-### [Total RP 3: Extended](https://mods.curse.com/addons/wow/total-rp-3-extended), by Kajisensei & Ellypse
+### [Total RP 3: Extended](https://www.curseforge.com/wow/addons/total-rp-3-extended), by Kajisensei & Ellypse
 
 This awesome module brings the new creation system. Create items, readable documents, campaigns with quests, customized NPCs and dialogs, loots. Use the inventory system to show items you are wearing and inspect other players' inventory. Create stashes that other players will be able to inspect. Trade items with other players safely thanks to our security level system that allows you to define authorizations per item and be sure you won't suddenly shout weird stuff because of a cursed item!
 
-### [Total RP 3: KuiNameplates module](https://mods.curse.com/addons/wow/total-rp-3-kuinameplates-module), by Ellypse
+### [Total RP 3: KuiNameplates module](https://www.curseforge.com/wow/addons/total-rp-3-kuinameplates-module), by Ellypse
 
-This module adds several customizations to [KuiNameplates](https://mods.curse.com/addons/wow/kuinameplates) like displaying colored full RP names in the nameplates of players, customize pet names and even hide nameplates of non-RP players!
+This module adds several customizations to [KuiNameplates](https://www.curseforge.com/wow/addons/kuinameplates) like displaying colored full RP names in the nameplates of players, customize pet names and even hide nameplates of non-RP players!
 
-### [TRP3 Currently Frame](https://mods.curse.com/addons/wow/trp3-currently-frame), by tammymg
+### [TRP3 Currently Frame](https://www.curseforge.com/wow/addons/trp3-currently-frame), by tammymg
 
 Adds a standalone frame to your UI that displays your "Currently" text and allows you to edit it easily.
 
-[Curse]: http://curse.totalrp3.info
+[CurseForge]: http://curse.totalrp3.info
 [Discord]: http://discord.totalrp3.info
 [myth's guide]: http://tinyurl.com/myths-trp3-guide
 


### PR DESCRIPTION
Curse site doesn't work anymore, it's transitioned to Curseforge.

Self-explanatory commit. Nothing major, and feel free to close it and do it yourself as I suspect it was planned as-is but I just happened to be "first".