### PR TITLE
Allow PR branch check step to fail

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           message:      Warning - This pull request is targeting master.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
       - uses: actions/setup-python@v2
       - uses: actions/setup-ruby@v1


### PR DESCRIPTION
PRs that are submitted from forked repositories run the actions within the fork instead of our repository, and so don't have permissions to access the resources required to post comments within the PR or so it seems.

As we're mostly using this step as an internal warning only, we can allow it to fail and just apply due diligence **for now** when checking external PRs. Long term maybe something else can be thought up.