### PR TITLE
Slim down the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,26 +11,14 @@ Give us a clear and concise description of what the issue is.
 Give us a clear and concise description of what you expected to happen.
 
 ## Issue checklist
-Select the game version(s) that this issue occurs on.
+Please select any applicable options from the below list.
 
-> You can place an "x" inside the brackets for each option below to tick it.
+> You can replace the "[ ]" with "[x]" for each option below to tick it.
 
-- [ ] Retail
-- [ ] Classic
-
-Please confirm that you are running the latest version of the addon.
-
-> You can check the installed version of the addon by opening the "Addons" window in-game from the character selection screen or game menu and checking the version number shown in the tooltip of the "Total RP 3" entry in the list.
-
-> The latest version of the addon can be found on CurseForge for [Retail](http://curse.totalrp.com/) and [Classic](http://classic.totalrp.com/) game versions.
-
-- [ ] I am running the latest version of the addon as listed on the CurseForge project page.
-
-Please confirm whether or not the issue occurs only with Total RP 3 enabled.
-
+- [ ] The issue occurs with the [latest Retail version] of the addon.
+- [ ] The issue occurs with the [latest Classic version] of the addon.
 - [ ] The issue occurs with Total RP 3 as the only enabled addon.
-- [ ] The issue occurs only with other addon(s) enabled (please provide a list)
-
+- [ ] The issue occurs only with other addon(s) enabled (please provide a list).
 
 ## Steps to reproduce
 Give us a list of steps to reproduce the issue with.
@@ -41,12 +29,11 @@ Give us a list of steps to reproduce the issue with.
 4. See error
 
 ## Additional files
-Please attach any additional applicable files such as screenshots, error logs, or profile data files. Files can be dragged and dropped into this report to attach them for upload.
+Please attach any additional applicable files such as screenshots, [error logs], or [profile data files]. Files can be dragged and dropped into this report to attach them for upload.
 
-> If you don't see any errors, make sure that error reporting is enabled (`/console scriptErrors 1`) or install the [BugSack](https://www.curseforge.com/wow/addons/bugsack) addon.
+---
 
-> Profile data is stored in the `totalRP3.lua` file located in your [SavedVariables](https://github.com/Total-RP/Total-RP-3/wiki/Saved-Variables) folder.
-
-- [ ] I have attached screenshot(s) of the issue.
-- [ ] I have attached an error report of the issue.
-- [ ] I have attached my profile data file to reproduce the issue.
+[error logs]: https://www.curseforge.com/wow/addons/bugsack
+[profile data files]: https://github.com/Total-RP/Total-RP-3/wiki/Saved-Variables
+[latest Retail version]: https://www.curseforge.com/wow/addons/total-rp-3/files
+[latest Classic version]: https://www.curseforge.com/wow/addons/total-rp-3-classic/files


### PR DESCRIPTION
This removes a bit of the wordy cruft that may have been impacting peoples ability to correctly fill in - or leading people towards outright deleting the contents of - the issue template.

While we lose some of the verbosity in the instructions, this should be clear enough at a quick glance and requires a lot less reading for users to submit an issue, and if they're not sure then we can just provide those instructions as needed (or move them to the wiki).