### PR TITLE
Add Pronouns Preset to Additional Information

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -224,6 +224,7 @@ stds.wow = {
 		"CreateTextureMarkup",
 		"CreateVector2D",
 		"FCF_GetCurrentChatFrame",
+		"FindInTableIf",
 		"GameTooltip_AddNormalLine",
 		"GameTooltip_SetDefaultAnchor",
 		"GameTooltip_SetTitle",

--- a/totalRP3/modules/importer/MRP_API.lua
+++ b/totalRP3/modules/importer/MRP_API.lua
@@ -114,7 +114,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			});
 		end
 		if importedProfile.PN then
-			tinsert(profile.player.characteristics.PN, {
+			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 				VA = importedProfile.PN;
 				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";

--- a/totalRP3/modules/importer/MRP_API.lua
+++ b/totalRP3/modules/importer/MRP_API.lua
@@ -96,7 +96,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_MOTTO;
 				VA = "\"" .. importedProfile.MO .. "\"";
-				IC = "INV_Inscription_ScrollOfWisdom_01";
+				IC = TRP3_API.globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01";
 			});
 		end
 		if importedProfile.NI then
@@ -110,7 +110,14 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_HOUSE;
 				VA = importedProfile.NH;
-				IC = "inv_misc_kingsring1";
+				IC = TRP3_API.globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1";
+			});
+		end
+		if importedProfile.PN then
+			tinsert(profile.player.characteristics.PN, {
+				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
+				VA = importedProfile.PN;
+				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";
 			});
 		end
 		profile.player.character.CU = importedProfile.CU;

--- a/totalRP3/modules/importer/XRP_API.lua
+++ b/totalRP3/modules/importer/XRP_API.lua
@@ -101,7 +101,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_MOTTO;
 				VA = "\"" .. importedProfile.MO .. "\"";
-				IC = "INV_Inscription_ScrollOfWisdom_01";
+				IC = TRP3_API.globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01";
 			});
 		end
 		if importedProfile.NI then
@@ -115,7 +115,14 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_HOUSE;
 				VA = importedProfile.NH;
-				IC = "inv_misc_kingsring1";
+				IC = TRP3_API.globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1";
+			});
+		end
+		if importedProfile.PN then
+			tinsert(profile.player.characteristics.PN, {
+				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
+				VA = importedProfile.PN;
+				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";
 			});
 		end
 		profile.player.character.CU = importedProfile.CU;

--- a/totalRP3/modules/importer/XRP_API.lua
+++ b/totalRP3/modules/importer/XRP_API.lua
@@ -119,7 +119,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			});
 		end
 		if importedProfile.PN then
-			tinsert(profile.player.characteristics.PN, {
+			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 				VA = importedProfile.PN;
 				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -623,6 +623,11 @@ local MISC_PRESET = {
 		IC = "inv_jewelry_ring_14"
 	},
 	{
+		NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
+		VA = "",
+		IC = is_classic and "inv_scroll_08" or "vas_namechange"
+	},
+	{
 		NA = loc.REG_PLAYER_TRP2_TATTOO,
 		VA = "",
 		IC = is_classic and "INV_Potion_65" or "INV_Inscription_inkblack01"

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -89,6 +89,7 @@ local CONFIG_CHARACT_TITLE = "tooltip_char_title";
 local CONFIG_CHARACT_NOTIF = "tooltip_char_notif";
 local CONFIG_CHARACT_CURRENT = "tooltip_char_current";
 local CONFIG_CHARACT_OOC = "tooltip_char_ooc";
+local CONFIG_CHARACT_PRONOUNS = "tooltip_char_pronouns";
 local CONFIG_CHARACT_CURRENT_SIZE = "tooltip_char_current_size";
 local CONFIG_CHARACT_RELATION = "tooltip_char_relation";
 local CONFIG_CHARACT_SPACING = "tooltip_char_spacing";
@@ -184,6 +185,10 @@ end
 
 local function showMoreInformation()
 	return getConfigValue(CONFIG_CHARACT_OOC);
+end
+
+local function showPronouns()
+	return getConfigValue(CONFIG_CHARACT_PRONOUNS);
 end
 
 local function getCurrentMaxSize()
@@ -412,10 +417,11 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	local player = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetID)
 
 	local FIELDS_TO_CROP = {
-		TITLE = 150,
-		NAME  = 100,
-		RACE  = 50,
-		CLASS = 50,
+		TITLE    = 150,
+		NAME     = 100,
+		RACE     = 50,
+		CLASS    = 50,
+		PRONOUNS = 20,
 	}
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -597,6 +603,26 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	end
 
 	tooltipBuilder:AddSpace();
+
+	--
+	-- Pronouns
+	--
+
+	if showPronouns() then
+		local miscInfo = info.characteristics.MI;
+		local miscIndex = miscInfo and FindInTableIf(miscInfo, function(struct)
+			return struct.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
+		end);
+
+		if miscIndex then
+			local pronouns = miscInfo[miscIndex];
+			local leftText = pronouns.NA;
+			local rightText = crop(pronouns.VA, FIELDS_TO_CROP.PRONOUNS);
+			local lineText = string.format("%1$s: |cffff9900%2$s|r", leftText, rightText);
+
+			tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize(), true);
+		end
+	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Target
@@ -1224,6 +1250,7 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_CHARACT_NOTIF, true);
 	registerConfigKey(CONFIG_CHARACT_CURRENT, true);
 	registerConfigKey(CONFIG_CHARACT_OOC, true);
+	registerConfigKey(CONFIG_CHARACT_PRONOUNS, true);
 	registerConfigKey(CONFIG_CHARACT_CURRENT_SIZE, 140);
 	registerConfigKey(CONFIG_CHARACT_RELATION, true);
 	registerConfigKey(CONFIG_CHARACT_SPACING, true);
@@ -1403,6 +1430,11 @@ local function onModuleInit()
 				inherit = "TRP3_ConfigCheck",
 				title = loc.DB_STATUS_CURRENTLY_OOC,
 				configKey = CONFIG_CHARACT_OOC,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_TOOLTIP_PRONOUNS,
+				configKey = CONFIG_CHARACT_PRONOUNS,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -24,7 +24,7 @@ local Globals = TRP3_API.globals;
 local module = AddOn_TotalRP3.MSP or {};
 module.log = module.log or Ellyb.Logger("MSP");
 
-module.TOOLTIP_FIELDS = {"CO", "IC", "PX", "RC", "RS", "TR", "LC"};
+module.TOOLTIP_FIELDS = {"CO", "IC", "PX", "RC", "RS", "TR", "LC", "PN"};
 module.REQUEST_FIELDS = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "MU", "PE", "PS", "RS", "LC", "PN"};
 
 -- Registry of known serializers/deserializers by name.

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -24,10 +24,8 @@ local Globals = TRP3_API.globals;
 local module = AddOn_TotalRP3.MSP or {};
 module.log = module.log or Ellyb.Logger("MSP");
 
--- TODO: Work on this some more. We're centralising this thing.
 module.TOOLTIP_FIELDS = {"CO", "IC", "PX", "RC", "RS", "TR", "LC"};
-module.REQUEST_FIELDS = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "MU", "PE", "PS", "RS", "LC"};
-module.REQUEST_FIELDS_MIN = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "LC"};
+module.REQUEST_FIELDS = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "MU", "PE", "PS", "RS", "LC", "PN"};
 
 -- Registry of known serializers/deserializers by name.
 local serializers = {};

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -285,7 +285,7 @@ local function onStart()
 			icon = Globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1",
 		},
 		NI = {  -- Nickname
-			text = loc.REG_PLAYER_MSP_NIC,
+			text = loc.REG_PLAYER_MSP_NICK,
 			icon = "Ability_Hunter_BeastCall",
 		},
 		PN = {  -- Pronouns

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -19,6 +19,15 @@
 --- limitations under the License.
 ----------------------------------------------------------------------------------
 
+local function GetOrCreateTable(t, key)
+	if t[key] ~= nil then
+		return t[key];
+	end
+
+	t[key] = {};
+	return t[key];
+end
+
 local function onStart()
 	local loc = TRP3_API.loc;
 
@@ -135,6 +144,8 @@ local function onStart()
 					msp.my['NH'] = miscData.VA;
 				elseif miscData.NA == loc.REG_PLAYER_MSP_NICK then
 					msp.my['NI'] = miscData.VA;
+				elseif miscData.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS then
+					msp.my['PN'] = miscData.VA;
 				end
 			end
 		end
@@ -193,7 +204,7 @@ local function onStart()
 	local SUPPORTED_FIELDS = {
 		"VA", "NA", "NH", "NI", "NT", "RA", "CU", "FR", "FC", "PX", "RC",
 		"IC", "CO", "PE", "HH", "AG", "AE", "HB", "AH", "AW", "MO", "DE",
-		"HI", "TR", "MU", "RS", "PS"
+		"HI", "TR", "MU", "RS", "PS", "PN"
 	};
 
 	local CHARACTERISTICS_FIELDS = {
@@ -261,6 +272,48 @@ local function onStart()
 			TI = title,
 			TX = text,
 		};
+	end
+
+	local MISC_INFO_FIELDS = {
+		MO = {  -- Motto
+			text = loc.REG_PLAYER_MSP_MOTTO,
+			icon = Globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01",
+			formatter = function(value) return string.format([["%s"]], value); end,
+		},
+		NH = {  -- House Name
+			text = loc.REG_PLAYER_MSP_HOUSE,
+			icon = Globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1",
+		},
+		NI = {  -- Nickname
+			text = loc.REG_PLAYER_MSP_NIC,
+			icon = "Ability_Hunter_BeastCall",
+		},
+		PN = {  -- Pronouns
+			text = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
+			icon = Globals.is_classic and "inv_scroll_08" or "vas_namechange",
+		},
+	};
+
+	local function updateMiscInfoField(profile, field, value)
+		local fieldInfo = MISC_INFO_FIELDS[field];
+
+		if not field then
+			return;
+		end
+
+		local miscInfo  = GetOrCreateTable(profile.characteristics, "MI");
+		local miscIndex = FindInTableIf(miscInfo, function(miscStruct) return miscStruct.NA == fieldInfo.text; end);
+
+		if value then
+			local miscStruct = GetOrCreateTable(miscInfo, miscIndex or #miscInfo + 1);
+			table.wipe(miscStruct);
+
+			miscStruct.NA = fieldInfo.text;
+			miscStruct.IC = fieldInfo.icon;
+			miscStruct.VA = fieldInfo.formatter and fieldInfo.formatter(value) or value;
+		elseif miscIndex then
+			table.remove(miscInfo, miscIndex);
+		end
 	end
 
 	local outstandingHelloRequests = {};
@@ -427,87 +480,8 @@ local function onStart()
 							end
 							profile.misc[MISC_FIELDS[field]] = value;
 						end
-					elseif field == "MO" then
-						if not profile.characteristics.MI then
-							profile.characteristics.MI = {};
-						end
-						local index = #profile.characteristics.MI + 1;
-						for miscIndex, miscStructure in pairs(profile.characteristics.MI) do
-							if miscStructure.NA == loc.REG_PLAYER_MSP_MOTTO then
-								index = miscIndex;
-								break;
-							end
-						end
-						if not profile.characteristics.MI[index] then
-							if value then
-								profile.characteristics.MI[index] = {};
-							end
-						else
-							if value then
-								wipe(profile.characteristics.MI[index]);
-							else
-								tremove(profile.characteristics.MI, index);
-							end
-						end
-						if value then
-							profile.characteristics.MI[index].NA = loc.REG_PLAYER_MSP_MOTTO;
-							profile.characteristics.MI[index].VA = "\"" .. value .. "\"";
-							profile.characteristics.MI[index].IC = "INV_Inscription_ScrollOfWisdom_01";
-						end
-					elseif field == "NH" then
-						if not profile.characteristics.MI then
-							profile.characteristics.MI = {};
-						end
-						local index = #profile.characteristics.MI + 1;
-						for miscIndex, miscStructure in pairs(profile.characteristics.MI) do
-							if miscStructure.NA == loc.REG_PLAYER_MSP_HOUSE then
-								index = miscIndex;
-								break;
-							end
-						end
-						if not profile.characteristics.MI[index] then
-							if value then
-								profile.characteristics.MI[index] = {};
-							end
-						else
-							if value then
-								wipe(profile.characteristics.MI[index]);
-							else
-								tremove(profile.characteristics.MI, index);
-							end
-						end
-						if value then
-							profile.characteristics.MI[index].NA = loc.REG_PLAYER_MSP_HOUSE;
-							profile.characteristics.MI[index].VA = value;
-							profile.characteristics.MI[index].IC = "inv_misc_kingsring1";
-						end
-					elseif field == "NI" then
-						if not profile.characteristics.MI then
-							profile.characteristics.MI = {};
-						end
-						local index = #profile.characteristics.MI + 1;
-						for miscIndex, miscStructure in pairs(profile.characteristics.MI) do
-							if miscStructure.NA == loc.REG_PLAYER_MSP_NICK then
-								index = miscIndex;
-								break;
-							end
-						end
-						if not profile.characteristics.MI[index] then
-							if value then
-								profile.characteristics.MI[index] = {};
-							end
-						else
-							if value then
-								wipe(profile.characteristics.MI[index]);
-							else
-								tremove(profile.characteristics.MI, index);
-							end
-						end
-						if value then
-							profile.characteristics.MI[index].NA = loc.REG_PLAYER_MSP_NICK;
-							profile.characteristics.MI[index].VA = value;
-							profile.characteristics.MI[index].IC = "Ability_Hunter_BeastCall";
-						end
+					elseif MISC_INFO_FIELDS[field] then
+						updateMiscInfoField(profile, field, value);
 					end
 				end
 			end

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1454,6 +1454,7 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
+	CO_TOOLTIP_PRONOUNS = "Show pronouns",
 	REG_PLAYER_MISC_PRESET_PRONOUNS = "Pronouns",
 
 };

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1427,11 +1427,6 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 
 ]],
 
-	------------------------------------------------------------------------------------------------
-	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
-	--- THEN MOVE IT UP ONCE IMPORTED
-	------------------------------------------------------------------------------------------------
-
 	BINDING_NAME_TRP3_OPEN_TARGET_PROFILE = "Open target profile",
 	BINDING_NAME_TRP3_TOGGLE_CHARACTER_STATUS = "Toggle character status",
 	WHATS_NEW_24_2 =  [[# Changelog version 2.1
@@ -1453,6 +1448,14 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 - Potential fix for the guide channel being swapped with the xtensionxtooltip2 channel.
 
 ]],
+
+	------------------------------------------------------------------------------------------------
+	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
+	--- THEN MOVE IT UP ONCE IMPORTED
+	------------------------------------------------------------------------------------------------
+
+	REG_PLAYER_MISC_PRESET_PRONOUNS = "Pronouns",
+
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
This implements full support for the pronouns field as a new preset in the additional information section and has been tested with basic TRP and MSP comms. The preset is mapped to the new `PN` field in MSP.

Included is also a small set of bugfixes for invalid icons being used in Classic when receiving other info fields such as the house name.

I couldn't think of an icon any more perfect than this, quite frankly - the only other option was Yet Another Generic Scroll:

![Behold His Majesty](https://wow.tools/casc/preview/chash?buildconfig=2a3eb630d9dd9cc6ce3df1dfed171b06&cdnconfig=ae7a03a3475bae8072f8047d71ff289b&filename=interface%2Ficons%2Fvas_namechange.blp&contenthash=f31fef069298db34c3fc1594e253ee01)

Screenshot of the new preset in the dropdown:
![New preset in editor dropdown](https://user-images.githubusercontent.com/287102/105786662-6da0d000-5f75-11eb-8770-d99265c5d76d.png)

Screenshot of the new preset in action:
![New preset in viewer](https://user-images.githubusercontent.com/287102/105786673-70032a00-5f75-11eb-89fa-2fbae41a8bfd.png)

Screenshot showing receipt of the `PN` field via MSP on a separate account:
![Receipt of PN field via MSP](https://user-images.githubusercontent.com/287102/105786677-72658400-5f75-11eb-8790-0af801f486e2.png)
