### PR TITLE
Change all usages of safeMatch to string.find

### DIFF
--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -29,7 +29,6 @@ TRP3_API.profile = {};
 local Globals, Events, Utils = TRP3_API.globals, TRP3_API.events, TRP3_API.utils;
 local loc = TRP3_API.loc;
 local unitIDToInfo = Utils.str.unitIDToInfo;
-local safeMatch = Utils.str.safeMatch;
 local strsplit, tinsert, pairs, type, assert, _G, table, tostring, error, wipe = strsplit, tinsert, pairs, type, assert, _G, table, tostring, error, wipe;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
 local handleMouseWheel = TRP3_API.ui.list.handleMouseWheel;
@@ -248,7 +247,7 @@ local function uiInitProfileList()
 	local defaultProfileID = getConfigValue("default_profile_id");
 	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManagerSearch:GetText());
 	for profileID, _ in pairs(profiles) do
-		if profileID ~= defaultProfileID and (not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower())) then
+		if profileID ~= defaultProfileID and (not profileSearch or string.find(profiles[profileID].profileName:lower(), profileSearch:lower(), 1, true)) then
 			tinsert(profileListID, profileID);
 		end
 	end

--- a/totalRP3/modules/register/companions/register_companions_profiles.lua
+++ b/totalRP3/modules/register/companions/register_companions_profiles.lua
@@ -26,7 +26,6 @@ local Ellyb = Ellyb(...);
 local Globals, loc, Utils, Events = TRP3_API.globals, TRP3_API.loc, TRP3_API.utils, TRP3_API.events;
 local tinsert, _G, pairs, type, tostring = tinsert, _G, pairs, type, tostring;
 local tsize = Utils.table.size;
-local safeMatch = Utils.str.safeMatch;
 local unregisterMenu = TRP3_API.navigation.menu.unregisterMenu;
 local isMenuRegistered, rebuildMenu = TRP3_API.navigation.menu.isMenuRegistered, TRP3_API.navigation.menu.rebuildMenu;
 local registerMenu, selectMenu, openMainFrame = TRP3_API.navigation.menu.registerMenu, TRP3_API.navigation.menu.selectMenu, TRP3_API.navigation.openMainFrame;
@@ -246,7 +245,7 @@ function uiInitProfileList()
 	local profiles = getProfiles();
 	local profileSearch = Utils.str.emptyToNil(TRP3_CompanionsProfilesSearch:GetText());
 	for profileID, _ in pairs(profiles) do
-		if not profileSearch or safeMatch(profiles[profileID].profileName:lower(), profileSearch:lower()) then
+		if not profileSearch or string.find(profiles[profileID].profileName:lower(), profileSearch:lower(), 1, true) then
 			tinsert(profileListID, profileID);
 		end
 	end

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -54,7 +54,6 @@ local checkGlanceActivation = TRP3_API.register.checkGlanceActivation;
 local getCompanionProfiles = TRP3_API.companions.register.getProfiles;
 local getRelationColors = TRP3_API.register.relation.getRelationColors;
 local getCompanionNameFromSpellID = TRP3_API.companions.getCompanionNameFromSpellID;
-local safeMatch = TRP3_API.utils.str.safeMatch;
 local unitIDIsFilteredForMatureContent = TRP3_API.register.unitIDIsFilteredForMatureContent;
 local profileIDISFilteredForMatureContent = TRP3_API.register.profileIDISFilteredForMatureContent;
 local tContains = tContains;
@@ -382,14 +381,14 @@ local function getCharacterLines()
 			-- Defines if at least one character is conform to the search criteria
 			for unitID, _ in pairs(profile.link or Globals.empty) do
 				local unitName, unitRealm = unitIDToInfo(unitID);
-				if safeMatch(unitName:lower(), nameSearch) then
+				if string.find(unitName:lower(), nameSearch, 1, true) then
 					nameIsConform = true;
 				end
 				if unitRealm == Globals.player_realm_id or tContains(GetAutoCompleteRealms(), unitRealm) then
 					realmIsConform = true;
 				end
 				local characterData = AddOn_TotalRP3.Directory.getCharacterDataForCharacterId(unitID);
-				if characterData and characterData.guild and safeMatch(characterData.guild:lower(), guildSearch) then
+				if characterData and characterData.guild and string.find(characterData.guild:lower(), guildSearch, 1, true) then
 					guildIsConform = true;
 				end
 				local currentNotes = TRP3_API.profile.getPlayerCurrentProfile().notes or {};
@@ -398,7 +397,7 @@ local function getCharacterLines()
 				end
 			end
 			local completeName = getCompleteName(profile.characteristics or {}, "", true);
-			if not nameIsConform and safeMatch(completeName:lower(), nameSearch) then
+			if not nameIsConform and string.find(completeName:lower(), nameSearch, 1, true) then
 				nameIsConform = true;
 			end
 
@@ -653,10 +652,10 @@ local function getCompanionLines()
 		if typeSearch:len() > 0 or masterSearch:len() > 0 then
 			for companionFullID, _ in pairs(profile.links) do
 				local masterID, companionID = companionIDToInfo(companionFullID);
-				if safeMatch(companionID:lower(), typeSearch) then
+				if string.find(companionID:lower(), typeSearch, 1, true) then
 					typeIsConform = true;
 				end
-				if safeMatch(masterID:lower(), masterSearch) then
+				if string.find(masterID:lower(), masterSearch, 1, true) then
 					masterIsConform = true;
 				end
 			end
@@ -666,7 +665,7 @@ local function getCompanionLines()
 		if profile.data and profile.data.NA then
 			companionName = profile.data.NA;
 		end
-		if nameSearch:len() ~= 0 and profile.data and profile.data.NA and safeMatch(profile.data.NA:lower(), nameSearch) then
+		if nameSearch:len() ~= 0 and profile.data and profile.data.NA and string.find(profile.data.NA:lower(), nameSearch, 1, true) then
 			nameIsConform = true;
 		end
 

--- a/totalRP3/resources/imageList-classic.lua
+++ b/totalRP3/resources/imageList-classic.lua
@@ -3202,7 +3202,6 @@ local IMAGES = {
 };
 
 local pairs, tinsert = pairs, tinsert;
-local safeMatch = TRP3_API.utils.str.safeMatch;
 local size = #IMAGES;
 
 function TRP3_API.utils.resources.getImageListSize()
@@ -3216,7 +3215,7 @@ function TRP3_API.utils.resources.getImageList(filter)
 	filter = filter:lower();
 	local newList = {};
 	for _, image in pairs(IMAGES) do
-		if safeMatch(image.url:lower(), filter) then
+		if string.find(image.url:lower(), filter, 1, true) then
 			tinsert(newList, image);
 		end
 	end


### PR DESCRIPTION
This changes all our search functionality to no longer behave oddly in cases where the user accidentally creates an invalid (or even valid) Lua pattern while searching for things like player profiles.

Odds are users won't care or even know about Lua patterns, and plain text search is _probably_ what they really wanted.