### PR TITLE
Check unlocalized MI field names

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -611,7 +611,8 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	if showPronouns() then
 		local miscInfo = info.characteristics.MI;
 		local miscIndex = miscInfo and FindInTableIf(miscInfo, function(struct)
-			return struct.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
+			return struct.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS
+				or struct.NA == "Pronouns";
 		end);
 
 		if miscIndex then

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -138,13 +138,13 @@ local function onStart()
 		msp.my['NI'] = nil;
 		if dataTab.MI then
 			for _, miscData in pairs(dataTab.MI) do
-				if miscData.NA == loc.REG_PLAYER_MSP_MOTTO then
+				if miscData.NA == loc.REG_PLAYER_MSP_MOTTO or miscData.NA == "Motto" then
 					msp.my['MO'] = miscData.VA;
-				elseif miscData.NA == loc.REG_PLAYER_MSP_HOUSE then
+				elseif miscData.NA == loc.REG_PLAYER_MSP_HOUSE or miscData.NA == "House name" then
 					msp.my['NH'] = miscData.VA;
-				elseif miscData.NA == loc.REG_PLAYER_MSP_NICK then
+				elseif miscData.NA == loc.REG_PLAYER_MSP_NICK or miscData.NA == "Nickname" then
 					msp.my['NI'] = miscData.VA;
-				elseif miscData.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS then
+				elseif miscData.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS or miscData.NA == "Pronouns" then
 					msp.my['PN'] = miscData.VA;
 				end
 			end
@@ -276,20 +276,24 @@ local function onStart()
 
 	local MISC_INFO_FIELDS = {
 		MO = {  -- Motto
-			text = loc.REG_PLAYER_MSP_MOTTO,
+			localizedText = loc.REG_PLAYER_MSP_MOTTO,
+			englishText = "Motto",
 			icon = Globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01",
 			formatter = function(value) return string.format([["%s"]], value); end,
 		},
 		NH = {  -- House Name
-			text = loc.REG_PLAYER_MSP_HOUSE,
+			localizedText = loc.REG_PLAYER_MSP_HOUSE,
+			englishText = "House name",
 			icon = Globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1",
 		},
 		NI = {  -- Nickname
-			text = loc.REG_PLAYER_MSP_NICK,
+			localizedText = loc.REG_PLAYER_MSP_NICK,
+			englishText = "Nickname",
 			icon = "Ability_Hunter_BeastCall",
 		},
 		PN = {  -- Pronouns
-			text = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
+			localizedText = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
+			englishText = "Pronouns",
 			icon = Globals.is_classic and "inv_scroll_08" or "vas_namechange",
 		},
 	};
@@ -302,7 +306,10 @@ local function onStart()
 		end
 
 		local miscInfo  = GetOrCreateTable(profile.characteristics, "MI");
-		local miscIndex = FindInTableIf(miscInfo, function(miscStruct) return miscStruct.NA == fieldInfo.text; end);
+		local miscIndex = FindInTableIf(miscInfo, function(miscStruct)
+			return miscStruct.NA == fieldInfo.localizedText
+				or miscStruct.NA == fieldInfo.englishText;
+		end);
 
 		if value then
 			local miscStruct = GetOrCreateTable(miscInfo, miscIndex or #miscInfo + 1);

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -136,6 +136,7 @@ local function onStart()
 		msp.my['MO'] = nil;
 		msp.my['NH'] = nil;
 		msp.my['NI'] = nil;
+		msp.my['PN'] = nil;
 		if dataTab.MI then
 			for _, miscData in pairs(dataTab.MI) do
 				if miscData.NA == loc.REG_PLAYER_MSP_MOTTO or miscData.NA == "Motto" then


### PR DESCRIPTION
This resolves potential edge cases where localizations change for any MI fields like nicknames or pronouns. If we launch an update with no localization for the "Pronouns" info preset, people will embed that into their profiles and - if a later update then changes the string - the original could for non-english locales no longer correctly transmit the original Pronouns field info.

This is a bit of a quick hack. Ideally we'd store the preset ID in the MI stuff, but for now we'll just check for both english and localized strings.

Additionally one extra issue where `msp.my["PN"]` wasn't being nil'd out was fixed, so removing your pronouns won't leave it in there for the rest of the session.