### PR TITLE
Fix initialization of default profile LC field

### DIFF
--- a/totalRP3/modules/dashboard/dashboard.lua
+++ b/totalRP3/modules/dashboard/dashboard.lua
@@ -54,7 +54,7 @@ getDefaultProfile().player.character = {
 	v = 1,
 	RP = TRP3_Enums.ROLEPLAY_STATUS.IN_CHARACTER,
 	XP = TRP3_Enums.ROLEPLAY_EXPERIENCE.EXPERIENCED,
-	LC = TRP3_Configuration["AddonLocale"] or GetLocale(),
+	LC = GetLocale(),
 }
 
 local function incrementCharacterVernum()
@@ -160,6 +160,11 @@ local function profileSelected(profileID)
 end
 
 TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
+	-- Update default LC field once addon configuration has loaded. We'll
+	-- assume this is _very_ early in setup and won't increment the vernum.
+
+	getDefaultProfile().player.character.LC = TRP3_Configuration["AddonLocale"] or GetLocale();
+
 	-- Register slash command for IC/OOC status control.
 	TRP3_API.slash.registerCommand({
 		id = "status",


### PR DESCRIPTION
Fixes #485.

The LC field was reading the TRP3_Configuration table in the main body of the script before it's loaded - this works silently because the config code (unhelpfully) defaults the table to an empty one, leading to slient bugs such as this.

LC initialization now defaults to client locale initially and is then updated once WORKFLOW_ON_LOADED fires. We don't increment the vernum of the default profile and assume this is called early enough that no one will have possibly noticed the LC field changing as a result.