### PR TITLE
Fix nil indexing of characteristics in tooltip

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -609,7 +609,8 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	--
 
 	if showPronouns() then
-		local miscInfo = info.characteristics.MI;
+		local characteristics = info.characteristics;
+		local miscInfo = characteristics and info.characteristics.MI;
 		local miscIndex = miscInfo and FindInTableIf(miscInfo, function(struct)
 			return struct.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 		end);

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -610,7 +610,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 
 	if showPronouns() then
 		local characteristics = info.characteristics;
-		local miscInfo = characteristics and info.characteristics.MI;
+		local miscInfo = characteristics and characteristics.MI;
 		local miscIndex = miscInfo and FindInTableIf(miscInfo, function(struct)
 			return struct.NA == loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 		end);


### PR DESCRIPTION
This was introduced by the pronouns field; found randomly when I was in SW on Classic. Seems rare enough since I hadn't noticed it up to this point, but hey - lucky us.