### PR TITLE
Fix T3 icons for incoming MSP profiles

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -420,10 +420,10 @@ local function onStart()
 								profile.about.T3 = {};
 							end
 							if not profile.about.T3.HI then
-								profile.about.T3.HI = {BK = 1, IC = "INV_Misc_Book_17"};
+								profile.about.T3.HI = {BK = 1, IC = "INV_Misc_Book_12"};
 							end
 							if not profile.about.T3.PH then
-								profile.about.T3.PH = {BK = 1, IC = "Ability_Warrior_StrengthOfArms"};
+								profile.about.T3.PH = {BK = 1, IC = Globals.is_classic and "spell_holy_fistofjustice" or "Ability_Warrior_StrengthOfArms"};
 							end
 							profile.about.T3[ABOUT_FIELDS[field]].TX = value;
 							if profile.about.read ~= false then


### PR DESCRIPTION
Profiles we receive from MSP have incorrect icons associated with the T3 description template for Classic, resulting in green squares.