### PR TITLE
Fixing inconsistencies with chat links format

### DIFF
--- a/totalRP3/modules/ChatLinks/ChatLinks.lua
+++ b/totalRP3/modules/ChatLinks/ChatLinks.lua
@@ -124,13 +124,13 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		"CHAT_MSG_CHANNEL"
 	};
 
-	local FORMATTED_LINK_FORMAT = "|Htotalrp3:%s:%s|h%s|h|r";
+	local FORMATTED_LINK_FORMAT = "|Htotalrp3:%s:%s|h%s|h";
 	local function generateFormattedLink(text, playerName)
 		Ellyb.Assertions.isType(text, "string", "text");
 		Ellyb.Assertions.isType(playerName, "string", "playerName");
 
-		local formattedName = LINK_COLOR:WrapTextInColorCode(strconcat("[", text, "]"));
-		return format(FORMATTED_LINK_FORMAT, playerName, text, formattedName);
+		local formattedName = strconcat("[", text, "]");
+		return LINK_COLOR:WrapTextInColorCode(format(FORMATTED_LINK_FORMAT, playerName, text, formattedName));
 	end
 
 	-- MessageEventFilter to look for Total RP 3 chat links and format the message accordingly


### PR DESCRIPTION
- There was an extra |r in the chat link format, which would not be noticed outside of very specific circumstances (like linking an Extended item in an NPC speech.
- When colouring hyperlinks, Blizzard defaults to placing the colour tags around the entire hyperlink instead of only the displayed name. To ensure proper compatibility with other addons modifying the chat, TRP3 chat links have been modified to follow the same principle. This fixes a conflict between ElvUI player name colouring and TRP3: Extended item link when the item name contains the player name.