### PR TITLE
Fix empty names in received MI fields from MSP

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -315,7 +315,7 @@ local function onStart()
 			local miscStruct = GetOrCreateTable(miscInfo, miscIndex or #miscInfo + 1);
 			table.wipe(miscStruct);
 
-			miscStruct.NA = fieldInfo.text;
+			miscStruct.NA = fieldInfo.localizedText;
 			miscStruct.IC = fieldInfo.icon;
 			miscStruct.VA = fieldInfo.formatter and fieldInfo.formatter(value) or value;
 		elseif miscIndex then


### PR DESCRIPTION
When I made the change to check both localized and english texts I forgot to update this one use of the old field name, which resulted in all MI fields received to have no name text associated - which would then lead to a bunch of duplicate copies of such fields since the matching requires the name to be present.