### PR TITLE
Handle bad names in Player name/realm constructor

### DIFF
--- a/totalRP3/core/Models/Player.lua
+++ b/totalRP3/core/Models/Player.lua
@@ -227,9 +227,9 @@ end
 --- @param realm string|nil The server of the player, default to the server of the current user
 --- @return Player
 function Player.static.CreateFromNameAndRealm(name, realm)
-	if not realm or realm == "" then
-		realm = TRP3_API.globals.player_realm_id
-	end
+	name = (name ~= "") and name or UNKNOWNOBJECT;
+	realm = (realm ~= "") and realm or TRP3_API.globals.player_realm_id;
+
 	return Player.static.CreateFromCharacterID(name .. "-" .. realm)
 end
 

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -728,7 +728,7 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	-- Make sure we have a unitID formatted as "Player-Realm"
 	unitID = unitInfoToID(character, realm);
 	---@type Player
-	local player = AddOn_TotalRP3.Player.static.CreateFromGUID(GUID)
+	local player = AddOn_TotalRP3.Player.static.CreateFromNameAndRealm(character, realm);
 
 	-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 	if realm == Globals.player_realm_id or getConfigValue(CONFIG_REMOVE_REALM) then


### PR DESCRIPTION
Something about the chat history module in Tukui causes it to sometimes feed in nil names.

In such a case - or those where the character name is empty - we'll now default it to the UNKNOWNOBJECT globalstring ("Unknown").