### PR TITLE
Refactor all Classic checks for icons

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -277,6 +277,7 @@ stds.wow = {
 		"GetCursorPosition",
 		"GetCVar",
 		"GetDefaultLanguage",
+		"GetFileIDFromPath",
 		"GetGuildInfo",
 		"GetInventoryItemTexture",
 		"GetInventorySlotInfo",

--- a/totalRP3/core/impl/ProfilesChatLinksModule.lua
+++ b/totalRP3/core/impl/ProfilesChatLinksModule.lua
@@ -30,7 +30,6 @@ local YELLOW = Ellyb.ColorManager.YELLOW;
 -- Total RP 3 imports
 local loc = TRP3_API.loc;
 local tcopy = TRP3_API.utils.table.copy;
-local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local Events = TRP3_API.events;
 
@@ -70,7 +69,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			customColor = TRP3_API.Ellyb.Color(info.characteristics.CH);
 		end
 
-		tooltipLines:SetTitle(customColor(Utils.str.icon(info.characteristics.IC or Globals.icons.profile_default, 20) .. " " .. TRP3_API.register.getCompleteName(info.characteristics, profile.profileName, true)));
+		tooltipLines:SetTitle(customColor(Utils.str.icon(info.characteristics.IC or TRP3_InterfaceIcons.ProfileDefault, 20) .. " " .. TRP3_API.register.getCompleteName(info.characteristics, profile.profileName, true)));
 
 		if info.characteristics.FT then
 			tooltipLines:AddLine("< " .. info.characteristics.FT .. " >", TRP3_API.Ellyb.ColorManager.ORANGE);

--- a/totalRP3/core/impl/globals.lua
+++ b/totalRP3/core/impl/globals.lua
@@ -78,12 +78,6 @@ TRP3_API.globals = {
 		MSP = "msp",
 	},
 
-	icons = {
-		default = "INV_Misc_QuestionMark",
-		unknown = "INV_Misc_QuestionMark",
-		profile_default = "INV_Misc_GroupLooking",
-	},
-
 	is_classic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC,
 
 	-- Profile Constants

--- a/totalRP3/core/impl/popup.lua
+++ b/totalRP3/core/impl/popup.lua
@@ -37,7 +37,7 @@ local TRP3_Enums = AddOn_TotalRP3.Enums;
 local GetNumPets, GetPetInfoByIndex;
 local GetMountIDs, GetMountInfoByID, GetMountInfoExtraByID;
 
-if is_classic then
+if TRP3_API.globals.is_classic then
 	GetNumPets = function() return 0 end;
 	GetPetInfoByIndex = function() return end;
 	GetMountIDs = function() return {} end;

--- a/totalRP3/core/impl/popup.lua
+++ b/totalRP3/core/impl/popup.lua
@@ -31,7 +31,6 @@ local setTooltipForFrame, setTooltipForSameFrame = TRP3_API.ui.tooltip.setToolti
 local getIconList, getIconListSize, getImageList, getImageListSize, getMusicList, getMusicListSize;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
 local max = math.max;
-local is_classic = TRP3_API.globals.is_classic;
 local TRP3_Enums = AddOn_TotalRP3.Enums;
 
 -- Classic proofing
@@ -658,8 +657,7 @@ local function initCompanionBrowser()
 
 	TRP3_CompanionBrowserFilterBox:SetScript("OnTextChanged", filteredCompanionBrowser);
 	TRP3_CompanionBrowserClose:SetScript("OnClick", onCompanionClose);
-	setTooltipForSameFrame(TRP3_CompanionBrowserFilterHelp, "TOPLEFT", 0, 0,
-		is_classic and "|TInterface\\ICONS\\Ability_Druid_CatForm:25|t " or "|TInterface\\ICONS\\icon_petfamily_beast:25|t " .. loc.UI_COMPANION_BROWSER_HELP ,loc.UI_COMPANION_BROWSER_HELP_TT);
+	setTooltipForSameFrame(TRP3_CompanionBrowserFilterHelp, "TOPLEFT", 0, 0, loc.UI_COMPANION_BROWSER_HELP ,loc.UI_COMPANION_BROWSER_HELP_TT);
 
 	TRP3_CompanionBrowserFilterBoxText:SetText(loc.UI_FILTER);
 end
@@ -959,7 +957,7 @@ function TRP3_ColorButtonLoad(self)
 			_G[self:GetName() .. "SwatchBg"]:SetColorTexture(red / 255, green / 255, blue / 255);
 			_G[self:GetName() .. "SwatchBgHighlight"]:SetVertexColor(red / 255, green / 255, blue / 255);
 		else
-			_G[self:GetName() .. "SwatchBg"]:SetTexture(is_classic and "Interface\\ICONS\\INV_Misc_Gear_01" or "Interface\\ICONS\\icon_petfamily_mechanical");
+			_G[self:GetName() .. "SwatchBg"]:SetTexture([[interface\icons\]] .. TRP3_InterfaceIcons.Gears);
 			_G[self:GetName() .. "SwatchBgHighlight"]:SetVertexColor(1.0, 1.0, 1.0);
 		end
 		if self.onSelection then

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -206,7 +206,7 @@ local function decorateProfileList(widget, index)
 		_G[widget:GetName().."Current"]:Hide();
 	end
 
-	setupIconButton(_G[widget:GetName().."Icon"], dataTab.IC or Globals.icons.profile_default);
+	setupIconButton(_G[widget:GetName().."Icon"], dataTab.IC or TRP3_InterfaceIcons.ProfileDefault);
 	_G[widget:GetName().."Name"]:SetText(mainText);
 	Ellyb.Tooltips.getTooltip(widget):SetTitle(mainText);
 

--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -132,7 +132,7 @@ local function rollDice(diceString)
 		total = total + modifierValue;
 
 		local modifierString = (modifierValue == 0) and "" or format("%+d", modifierValue); -- we add a + to positive modifiers and don't render a 0 value
-		Utils.message.displayMessage(loc.DICE_ROLL:format(Utils.str.icon(TRP3_API.globals.is_classic and "inv_enchant_shardglowingsmall" or "inv_misc_dice_02", 20), num, diceCount, modifierString, total));
+		Utils.message.displayMessage(loc.DICE_ROLL:format(Utils.str.icon(TRP3_InterfaceIcons.DiceRoll, 20), num, diceCount, modifierString, total));
 		sendDiceRoll({c = num, d = diceCount, t = total, m = modifierValue});
 		return total;
 	end
@@ -152,7 +152,7 @@ function TRP3_API.slash.rollDices(...)
 		i = index;
 	end
 
-	local totalMessage = loc.DICE_TOTAL:format(Utils.str.icon(TRP3_API.globals.is_classic and "inv_enchant_shardglowingsmall" or "inv_misc_dice_01", 20), total);
+	local totalMessage = loc.DICE_TOTAL:format(Utils.str.icon(TRP3_InterfaceIcons.DiceRoll, 20), total);
 	if i > 1 then
 		Utils.message.displayMessage(totalMessage);
 		sendDiceRoll({t = total});
@@ -182,9 +182,9 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			if type(arg) == "table" then
 				if arg.c and arg.d and arg.t then
 					local modifierString = (arg.m == 0) and "" or format("%+d", arg.m); -- we add a + to positive modifiers and don't render a 0 value
-					Utils.message.displayMessage(loc.DICE_ROLL_T:format(Utils.str.icon(TRP3_API.globals.is_classic and "inv_enchant_shardglowingsmall" or "inv_misc_dice_02", 20), sender, arg.c, arg.d, modifierString, arg.t));
+					Utils.message.displayMessage(loc.DICE_ROLL_T:format(Utils.str.icon(TRP3_InterfaceIcons.DiceRoll, 20), sender, arg.c, arg.d, modifierString, arg.t));
 				elseif arg.t then
-					local totalMessage = loc.DICE_TOTAL_T:format(Utils.str.icon(TRP3_API.globals.is_classic and "inv_enchant_shardglowingsmall" or "inv_misc_dice_01", 20), sender, arg.t);
+					local totalMessage = loc.DICE_TOTAL_T:format(Utils.str.icon(TRP3_InterfaceIcons.DiceRoll, 20), sender, arg.t);
 					Utils.message.displayMessage(totalMessage);
 				end
 				Utils.music.playSoundID(36629, "SFX", sender);

--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -44,7 +44,6 @@ local shiftDown = IsShiftKeyDown;
 local UnitIsPlayer = UnitIsPlayer;
 local getUnitID = TRP3_API.utils.str.getUnitID;
 local numberToHexa = TRP3_API.utils.color.numberToHexa;
-local is_classic = globals.is_classic;
 local TRP3_Enums = AddOn_TotalRP3.Enums;
 
 local CONFIG_UI_SOUNDS = "ui_sounds";
@@ -763,106 +762,11 @@ end
 -- Textures tools
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local unitTexture = {
-	Human = {
-		is_classic and "Ability_Warrior_Revenge" or "Achievement_Character_Human_Male",
-		is_classic and "INV_Misc_Head_Human_02" or "Achievement_Character_Human_Female",
-	},
-	Gnome = {
-		is_classic and "INV_Misc_Head_Gnome_01" or "Achievement_Character_Gnome_Male",
-		is_classic and "INV_Misc_Head_Gnome_02" or "Achievement_Character_Gnome_Female",
-	},
-	Scourge = {
-		is_classic and "INV_Misc_Head_Undead_01" or "Achievement_Character_Undead_Male",
-		is_classic and "INV_Misc_Head_Undead_02" or "Achievement_Character_Undead_Female",
-	},
-	NightElf = {
-		is_classic and "Ability_Ambush" or "Achievement_Character_Nightelf_Male",
-		"Achievement_Character_Nightelf_Female",
-	},
-	Dwarf = {
-		"Achievement_Character_Dwarf_Male",
-		is_classic and "INV_Misc_Head_Dwarf_02" or "Achievement_Character_Dwarf_Female",
-	},
-	Draenei = {
-		"Achievement_Character_Draenei_Male",
-		"Achievement_Character_Draenei_Female",
-	},
-	Orc = {
-		is_classic and "Ability_Warrior_WarCry" or "Achievement_Character_Orc_Male",
-		is_classic and "INV_Misc_Head_Orc_02" or "Achievement_Character_Orc_Female",
-	},
-	BloodElf = {
-		"Achievement_Character_Bloodelf_Male",
-		"Achievement_Character_Bloodelf_Female",
-	},
-	Troll = {
-		"Achievement_Character_Troll_Male",
-		is_classic and "INV_Misc_Head_Troll_02" or "Achievement_Character_Troll_Female",
-	},
-	Tauren = {
-		is_classic and "Spell_Holy_BlessingOfStamina" or "Achievement_Character_Tauren_Male",
-		is_classic and "INV_Misc_Head_Tauren_02" or "Achievement_Character_Tauren_Female",
-	},
-	Worgen = {
-		"achievement_worganhead",
-		"Ability_Racial_Viciousness",
-	},
-	Goblin = {
-		"Ability_Racial_RocketJump",
-		"Ability_Racial_RocketJump",
-	},
-	Pandaren = {
-		"Achievement_Guild_ClassyPanda",
-		"Achievement_Character_Pandaren_Female",
-	},
-	Nightborne = {
-		"Ability_Racial_DispelIllusions",
-		"Ability_Racial_Masquerade",
-	},
-	LightforgedDraenei = {
-		"Ability_Racial_FinalVerdict",
-		"Achievement_AlliedRace_LightforgedDraenei",
-	},
-	VoidElf = {
-		"Ability_Racial_EntropicEmbrace",
-		"Ability_Racial_PreturnaturalCalm",
-	},
-	HighmountainTauren = {
-		"Ability_Racial_BullRush",
-		"Achievement_AlliedRace_HighmountainTauren",
-	},
-	MagharOrc = {
-		"ACHIEVEMENT_CHARACTER_ORC_MALE_BRN",
-		"ACHIEVEMENT_CHARACTER_ORC_FEMALE_BRN"
-	},
-	DarkIronDwarf = {
-		"Ability_Racial_Fireblood",
-		"ability_racial_foregedinFlames"
-	},
-	KulTiran = {
-		"Achievement_Boss_Zuldazar_Manceroy_Mestrah",
-		"Ability_racial_childofthesea"
-	},
-	ZandalariTroll = {
-		"INV_ZandalariMaleHead",
-		"INV_ZandalariFemaleHead"
-	},
-	Mechagnome = {
-		"Ability_racial_hyperorganiclightoriginator",
-		"Inv_plate_mechagnome_c_01helm"
-	},
-	Vulpera = {
-		"Ability_racial_nosefortrouble",
-		"Ability_racial_nosefortrouble"
-	}
-};
-
 TRP3_API.ui.misc.getUnitTexture = function(race, gender)
-	if unitTexture[race] and unitTexture[race][gender - 1] then
-		return unitTexture[race][gender - 1];
-	end
-	return globals.icons.default;
+	local raceToken = race;
+	local genderToken = (gender == 2) and "Female" or "Male";
+
+	return TRP3_InterfaceIcons[raceToken .. genderToken] or TRP3_InterfaceIcons.Default;
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -368,7 +368,7 @@ end
 
 -- Return an texture text tag based on the given icon url and size. Nil safe.
 function Utils.str.icon(iconPath, iconSize)
-	iconPath = iconPath or Globals.icons.default;
+	iconPath = iconPath or TRP3_InterfaceIcons.Default;
 	return Utils.str.texture(Utils.getIconTexture(iconPath), iconSize);
 end
 

--- a/totalRP3/core/ui/browsers/PetBrowser.xml
+++ b/totalRP3/core/ui/browsers/PetBrowser.xml
@@ -25,7 +25,7 @@
 		<HitRectInsets left="-2" right="-2" top="-2" bottom="-2"/>
 		<Layers>
 			<Layer level="BORDER">
-				<Texture parentKey="Icon" file="Interface\Icons\Temp">
+				<Texture parentKey="Icon" file="Interface\ICONS\INV_Misc_QuestionMark">
 					<Anchors>
 						<Anchor point="TOPLEFT" x="-2" y="2"/>
 						<Anchor point="BOTTOMRIGHT" x="2" y="-2"/>

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -314,7 +314,7 @@
 				</Texture>
 			</Layer>
 			<Layer level="BORDER">
-				<Texture name="$parentIcon" file="Interface\ICONS\pet_type_beast" hidden="true">
+				<Texture name="$parentIcon" file="Interface\ICONS\INV_Misc_QuestionMark" hidden="true">
 					<Size x="16" y="16"/>
 					<Anchors>
 						<Anchor point="LEFT" x="9" y="-2"/>

--- a/totalRP3/modules/Languages/Language.lua
+++ b/totalRP3/modules/Languages/Language.lua
@@ -17,10 +17,6 @@
 --- limitations under the License.
 ----------------------------------------------------------------------------------
 
----@type TRP3_API
-local _, TRP3_API = ...;
-local is_classic = TRP3_API.globals.is_classic;
-
 local Ellyb = Ellyb(...);
 local AddOn_TotalRP3 = AddOn_TotalRP3;
 
@@ -28,46 +24,45 @@ local Icon = Ellyb.Icon
 
 ---@type Icon[]
 local LANGUAGES_ICONS = {
-
 	-- Alliance
-	[35] = Icon("Inv_Misc_Tournaments_banner_Draenei"), -- Draenei
-	[2] = Icon(is_classic and "Spell_Arcane_TeleportMoonglade" or "Inv_Misc_Tournaments_banner_Nightelf"), -- Dranassian
-	[6] = Icon(is_classic and "Spell_Arcane_TeleportIronForge" or "Inv_Misc_Tournaments_banner_Dwarf"), -- Dwarvish
-	[7] = Icon(is_classic and "Spell_Arcane_TeleportStormWind" or "Inv_Misc_Tournaments_banner_Human"),-- Common
-	[13] = Icon(is_classic and "INV_Misc_EngGizmos_01" or "Inv_Misc_Tournaments_banner_Gnome"),-- Gnomish
+	[35] = Icon(TRP3_InterfaceIcons.LanguageDraenei), -- Draenei
+	[2] = Icon(TRP3_InterfaceIcons.LanguageDarnassian), -- Dranassian
+	[6] = Icon(TRP3_InterfaceIcons.LanguageDwarvish), -- Dwarvish
+	[7] = Icon(TRP3_InterfaceIcons.LanguageCommon),-- Common
+	[13] = Icon(TRP3_InterfaceIcons.LanguageGnomish),-- Gnomish
 
 	-- Horde
-	[1] = Icon(is_classic and "Spell_Arcane_TeleportOrgrimmar" or "Inv_Misc_Tournaments_banner_Orc"), -- Orcish
-	[33] = Icon(is_classic and "Spell_Arcane_TeleportUnderCity" or "Inv_Misc_Tournaments_banner_Scourge"), -- Forsaken
-	[3] = Icon(is_classic and "Spell_Arcane_TeleportThunderBluff" or "Inv_Misc_Tournaments_banner_Tauren"), -- Taurahe
-	[10] = Icon("Inv_Misc_Tournaments_banner_Bloodelf"), -- Thalassian
-	[14] = Icon(is_classic and "INV_Banner_01" or "Inv_Misc_Tournaments_banner_Troll"), -- Zandali
-	[40] = Icon("achievement_Goblinhead"), -- Goblin
+	[1] = Icon(TRP3_InterfaceIcons.LanguageOrcish), -- Orcish
+	[33] = Icon(TRP3_InterfaceIcons.LanguageForsaken), -- Forsaken
+	[3] = Icon(TRP3_InterfaceIcons.LanguageTaurahe), -- Taurahe
+	[10] = Icon(TRP3_InterfaceIcons.LanguageThalassian), -- Thalassian
+	[14] = Icon(TRP3_InterfaceIcons.LanguageZandali), -- Zandali
+	[40] = Icon(TRP3_InterfaceIcons.LanguageGoblin), -- Goblin
 
 	-- Pandaren (now neutral)
-	[42] = Icon("Achievement_Guild_ClassyPanda"),
+	[42] = Icon(TRP3_InterfaceIcons.LanguagePandaren),
 
 	-- Demon hunters
-	[8] = Icon("artifactability_havocdemonhunter_anguishofthedeceiver"),
+	[8] = Icon(TRP3_InterfaceIcons.LanguageDemonic),
 
 	-- Allied races
-	[181] = Icon("Achievement_AlliedRace_Nightborne"), -- Shalassian
+	[181] = Icon(TRP3_InterfaceIcons.LanguageShalassian), -- Shalassian
 
 	-- Funsies
-	[37] = Icon("inv_misc_punchcards_blue"), -- Gnome binary (Brewfest beer)
-	[38] = Icon("inv_misc_punchcards_blue"), -- Goblin binary (Brewfest beer)
-	[11] = Icon("ability_warrior_dragonroar"), -- Draconic (learned when opening the gates of AQ)
-	[180] = Icon("ability_druid_improvedmoonkinform"), -- Moonkin (seasonal event)
-	[12] = Icon("shaman_talent_elementalblast"), -- Kalimag (shaman?)
-	[179] = Icon("inv_pet_babymurlocs_blue"), -- Murloc (?)
-	[178] = Icon("spell_priest_voidform"), -- Shath'Yar (Shadow priests, Void Elves and Alliance Archbishops)
-	[9] = Icon("achievement_dungeon_ulduarraid_titan_01"), -- Titan
-	[36] = Icon("icon_petfamily_undead"), -- Zombie (in your head)
-	[168] = Icon("inv_pet_sprite_darter_hatchling"), -- Sprite (Faerie dragon)
+	[37] = Icon(TRP3_InterfaceIcons.LanguageGnomishBinary), -- Gnome binary (Brewfest beer)
+	[38] = Icon(TRP3_InterfaceIcons.LanguageGoblinBinary), -- Goblin binary (Brewfest beer)
+	[11] = Icon(TRP3_InterfaceIcons.LanguageDraconic), -- Draconic (learned when opening the gates of AQ)
+	[180] = Icon(TRP3_InterfaceIcons.LanguageMoonkin), -- Moonkin (seasonal event)
+	[12] = Icon(TRP3_InterfaceIcons.LanguageKalimag), -- Kalimag (shaman?)
+	[179] = Icon(TRP3_InterfaceIcons.LanguageNerglish), -- Murloc (?)
+	[178] = Icon(TRP3_InterfaceIcons.LanguageShathYar), -- Shath'Yar (Shadow priests, Void Elves and Alliance Archbishops)
+	[9] = Icon(TRP3_InterfaceIcons.LanguageTitan), -- Titan
+	[36] = Icon(TRP3_InterfaceIcons.LanguageZombie), -- Zombie (in your head)
+	[168] = Icon(TRP3_InterfaceIcons.LanguageSprite), -- Sprite (Faerie dragon)
 
 }
 
-local TEMP_ICON = Icon("INV_Misc_QuestionMark")
+local TEMP_ICON = Icon(TRP3_InterfaceIcons.Default)
 
 ---@class Language : Object
 local Language, _private = Ellyb.Class("Language")

--- a/totalRP3/modules/chatframe/languages.lua
+++ b/totalRP3/modules/chatframe/languages.lua
@@ -113,7 +113,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 
 	local languagesButton = {
 		id = "ww_trp3_languages",
-		icon = "spell_holy_silence",
+		icon = TRP3_InterfaceIcons.ToolbarLanguage,
 		configText = loc.TB_LANGUAGE,
 		onEnter = function(Uibutton)
 			refreshTooltip(Uibutton);
@@ -128,7 +128,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 				buttonStructure.currentLanguageID = currentLanguage:GetID();
 				buttonStructure.tooltip = loc.TB_LANGUAGE .. ": " .. currentLanguage:GetName();
 				buttonStructure.tooltipSub = Ellyb.Strings.clickInstruction(Ellyb.System.CLICKS.CLICK, loc.TB_LANGUAGES_TT);
-				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or "spell_holy_silence";
+				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
 		end,
 		onClick = function(Uibutton)

--- a/totalRP3/modules/dashboard/dashboard.lua
+++ b/totalRP3/modules/dashboard/dashboard.lua
@@ -39,7 +39,6 @@ local refreshTooltip, mainTooltip = TRP3_API.ui.tooltip.refresh, TRP3_MainToolti
 local registerMenu, registerPage = TRP3_API.navigation.menu.registerMenu, TRP3_API.navigation.page.registerPage;
 local setPage = TRP3_API.navigation.page.setPage;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
-local is_classic = Globals.is_classic;
 
 -- Total RP 3 imports
 local loc = TRP3_API.loc;
@@ -203,7 +202,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		local status3SubText = color("y")..loc.CM_L_CLICK..": "..color("w")..(loc.TB_GO_TO_MODE:format(color("o")..loc.TB_AFK_MODE..color("w"))).."\n"..color("y")..loc.CM_R_CLICK..": "..color("w")..(loc.TB_GO_TO_MODE:format(color("r")..loc.TB_DND_MODE..color("w")));
 		local Button_Status = {
 			id = "aa_trp3_c",
-			icon = "Ability_Rogue_MasterOfSubtlety",
+			icon = TRP3_InterfaceIcons.ModeNormal,
 			configText = loc.CO_TOOLBAR_CONTENT_STATUS,
 			onUpdate = function(Uibutton, buttonStructure)
 				updateToolbarButton(Uibutton, buttonStructure);
@@ -215,15 +214,15 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 				if UnitIsDND("player") then
 					buttonStructure.tooltip  = status1Text;
 					buttonStructure.tooltipSub  = status1SubText;
-					buttonStructure.icon = is_classic and "Ability_Warrior_Challange" or "Ability_Mage_IncantersAbsorbtion";
+					buttonStructure.icon = TRP3_InterfaceIcons.ModeDND;
 				elseif UnitIsAFK("player") then
 					buttonStructure.tooltip  = status2Text;
 					buttonStructure.tooltipSub  = status2SubText;
-					buttonStructure.icon = "Spell_Nature_Sleep";
+					buttonStructure.icon = TRP3_InterfaceIcons.ModeAFK;
 				else
 					buttonStructure.tooltip  = status3Text;
 					buttonStructure.tooltipSub  = status3SubText;
-					buttonStructure.icon = is_classic and "Ability_Stealth" or "Ability_Rogue_MasterOfSubtlety";
+					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
 			end,
 			onClick = function(_, _, button)
@@ -244,7 +243,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		TRP3_API.toolbar.toolbarAddButton(Button_Status);
 
 		-- Toolbar RP status
-		local RP_ICON, OOC_ICON = "spell_shadow_charm", is_classic and "Achievement_GuildPerk_EverybodysFriend" or "Inv_misc_grouplooking";
+		local RP_ICON, OOC_ICON = TRP3_InterfaceIcons.ToolbarStatusIC, TRP3_InterfaceIcons.ToolbarStatusOOC;
 		local rpTextOn = loc.TB_RPSTATUS_ON;
 		local rpTextOff = loc.TB_RPSTATUS_OFF;
 		local rpText2 = color("y")..loc.CM_L_CLICK..": "..color("w")..loc.TB_RPSTATUS_TO_ON;
@@ -254,7 +253,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 
 		local Button_RPStatus = {
 			id = "aa_trp3_rpstatus",
-			icon = "Inv_misc_grouplooking",
+			icon = OOC_ICON,
 			configText = loc.CO_TOOLBAR_CONTENT_RPSTATUS,
 			onEnter = function() end,
 			onUpdate = function(Uibutton, buttonStructure)
@@ -284,7 +283,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 					tinsert(dropdownItems,{loc.TB_SWITCH_PROFILE, nil});
 					local currentProfileID = getPlayerCurrentProfileID()
 					for key, value in pairs(list) do
-						local icon = value.player.characteristics.IC or Globals.icons.profile_default;
+						local icon = value.player.characteristics.IC or TRP3_InterfaceIcons.ProfileDefault;
 						if key == currentProfileID then
 							tinsert(dropdownItems,{"|Tinterface\\icons\\"..icon..":15|t|cff00ff00 "..value.profileName.."|r", nil});
 						else
@@ -306,8 +305,8 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 
 		if TRP3_API.globals.is_classic then
 			-- Show / hide helmet
-			local helmetOffIcon = Ellyb.Icon("spell_nature_invisibilty");
-			local helmetOnIcon = Ellyb.Icon("INV_Helmet_13");
+			local helmetOffIcon = Ellyb.Icon(TRP3_InterfaceIcons.ToolbarHelmetOff);
+			local helmetOnIcon = Ellyb.Icon(TRP3_InterfaceIcons.ToolbarHelmetOn);
 			local helmTextOn = loc.TB_SWITCH_HELM_ON;
 			local helmTextOff = loc.TB_SWITCH_HELM_OFF;
 			local helmText2 = Ellyb.Strings.clickInstruction(Ellyb.System.CLICKS.CLICK, loc.TB_SWITCH_HELM_1);
@@ -352,8 +351,8 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			TRP3_API.toolbar.toolbarAddButton(Button_Helmet);
 
 			-- Show/hide cloak
-			local cloakOnIcon = Ellyb.Icon("INV_Misc_Cape_18");
-			local cloakOffIcon = Ellyb.Icon("inv_misc_cape_20");
+			local cloakOnIcon = Ellyb.Icon(TRP3_InterfaceIcons.ToolbarCloakOff);
+			local cloakOffIcon = Ellyb.Icon(TRP3_InterfaceIcons.ToolbarCloakOn);
 			local capeTextOn =  loc.TB_SWITCH_CAPE_ON;
 			local capeTextOff = loc.TB_SWITCH_CAPE_OFF;
 			local capeText2 = Ellyb.Strings.clickInstruction(Ellyb.System.CLICKS.CLICK, loc.TB_SWITCH_CAPE_1);

--- a/totalRP3/modules/dashboard/npc_talk.lua
+++ b/totalRP3/modules/dashboard/npc_talk.lua
@@ -176,7 +176,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		-- Create a button for the toolbar to show/hide the NPC Talk frame
 		TRP3_API.toolbar.toolbarAddButton({
 			id = "bb_trp3_npctalk",
-			icon = TRP3_API.globals.is_classic and "Ability_Warrior_BattleShout" or "Ability_Warrior_CommandingShout",
+			icon = TRP3_InterfaceIcons.ToolbarNPCTalk,
 			configText = loc.NPC_TALK_TITLE,
 			tooltip = loc.NPC_TALK_TITLE,
 			tooltipSub = loc.NPC_TALK_BUTTON_TT,

--- a/totalRP3/modules/importer/MRP_API.lua
+++ b/totalRP3/modules/importer/MRP_API.lua
@@ -96,28 +96,28 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_MOTTO;
 				VA = "\"" .. importedProfile.MO .. "\"";
-				IC = TRP3_API.globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01";
+				IC = TRP3_InterfaceIcons.MiscInfoMotto;
 			});
 		end
 		if importedProfile.NI then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_NICK;
 				VA = importedProfile.NI;
-				IC = "Ability_Hunter_BeastCall";
+				IC = TRP3_InterfaceIcons.MiscInfoNickname;
 			});
 		end
 		if importedProfile.NH then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_HOUSE;
 				VA = importedProfile.NH;
-				IC = TRP3_API.globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1";
+				IC = TRP3_InterfaceIcons.MiscInfoHouse;
 			});
 		end
 		if importedProfile.PN then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 				VA = importedProfile.PN;
-				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";
+				IC = TRP3_InterfaceIcons.MiscInfoPronouns;
 			});
 		end
 		profile.player.character.CU = importedProfile.CU;

--- a/totalRP3/modules/importer/XRP_API.lua
+++ b/totalRP3/modules/importer/XRP_API.lua
@@ -101,28 +101,28 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_MOTTO;
 				VA = "\"" .. importedProfile.MO .. "\"";
-				IC = TRP3_API.globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01";
+				IC = TRP3_InterfaceIcons.MiscInfoMotto;
 			});
 		end
 		if importedProfile.NI then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_NICK;
 				VA = importedProfile.NI;
-				IC = "Ability_Hunter_BeastCall";
+				IC = TRP3_InterfaceIcons.MiscInfoNickname;
 			});
 		end
 		if importedProfile.NH then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MSP_HOUSE;
 				VA = importedProfile.NH;
-				IC = TRP3_API.globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1";
+				IC = TRP3_InterfaceIcons.MiscInfoHouse;
 			});
 		end
 		if importedProfile.PN then
 			tinsert(profile.player.characteristics.MI, {
 				NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS;
 				VA = importedProfile.PN;
-				IC = TRP3_API.globals.is_classic and "inv_scroll_08" or "vas_namechange";
+				IC = TRP3_InterfaceIcons.MiscInfoPronouns;
 			});
 		end
 		profile.player.character.CU = importedProfile.CU;

--- a/totalRP3/modules/importer/importer.lua
+++ b/totalRP3/modules/importer/importer.lua
@@ -24,7 +24,6 @@ local _, TRP3_API = ...;
 TRP3_API.importer = {};
 
 -- imports
-local Globals = TRP3_API.globals;
 local loc = TRP3_API.loc;
 local handleMouseWheel = TRP3_API.ui.list.handleMouseWheel;
 local initList = TRP3_API.ui.list.initList;
@@ -144,7 +143,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		widget.addOn = profiles[id];
 		_G[widget:GetName() .. "Count"]:SetText(profiles[id]);
 		_G[widget:GetName() .. "Name"]:SetText(profile.name);
-		setupIconButton(_G[widget:GetName() .. "Icon"], profile.info.icon or Globals.icons.profile_default);
+		setupIconButton(_G[widget:GetName() .. "Icon"], profile.info.icon or TRP3_InterfaceIcons.ProfileDefault);
 
 		local tooltip = "";
 

--- a/totalRP3/modules/map/MapScanner.lua
+++ b/totalRP3/modules/map/MapScanner.lua
@@ -28,7 +28,7 @@ local AddOn_TotalRP3 = AddOn_TotalRP3;
 local MapScanner, _private = Ellyb.Class("MapScanner");
 
 ---@type Icon
-MapScanner.scanIcon = Ellyb.Icon("Inv_misc_enggizmos_20");
+MapScanner.scanIcon = Ellyb.Icon(TRP3_InterfaceIcons.DefaultScanIcon);
 MapScanner.scanOptionText = UNKNOWN;
 MapScanner.scanTitle = UNKNOWN;
 MapScanner.duration = 3;

--- a/totalRP3/modules/map/WorldMapButton.lua
+++ b/totalRP3/modules/map/WorldMapButton.lua
@@ -27,7 +27,6 @@ local getConfigValue = TRP3_API.configuration.getValue;
 local setConfigValue = TRP3_API.configuration.setValue;
 local registerConfigKey = TRP3_API.configuration.registerConfigKey;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
-local is_classic = TRP3_API.globals.is_classic;
 --endregion
 
 --region Ellyb imports
@@ -44,8 +43,8 @@ local CONFIG_HIDE_BUTTON_IF_EMPTY = "HIDE_MAP_BUTTON_IF_EMPTY";
 ---@type Button
 local WorldMapButton = TRP3_WorldMapButton;
 
-local NORMAL_STATE_MAP_ICON = Ellyb.Icon(is_classic and "INV_Misc_Map_01" or "icon_treasuremap");
-local ON_COOLDOWN_STATE_MAP_ICON = Ellyb.Icon(is_classic and "Spell_Nature_TimeStop" or "ability_mage_timewarp")
+local NORMAL_STATE_MAP_ICON = Ellyb.Icon(TRP3_InterfaceIcons.ScanReady);
+local ON_COOLDOWN_STATE_MAP_ICON = Ellyb.Icon(TRP3_InterfaceIcons.ScanCooldown);
 
 --region Configuration
 Events.registerCallback(Events.WORKFLOW_ON_LOADED, function()

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
@@ -112,7 +112,7 @@ TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
 	---@type MapScanner
 	local playerMapScanner = AddOn_TotalRP3.MapScanner("playerScan")
 	-- Set scan display properties
-	playerMapScanner.scanIcon = Ellyb.Icon("Achievement_GuildPerk_EverybodysFriend")
+	playerMapScanner.scanIcon = Ellyb.Icon(TRP3_InterfaceIcons.PlayerScanIcon)
 	playerMapScanner.scanOptionText = loc.MAP_SCAN_CHAR;
 	playerMapScanner.scanTitle = loc.MAP_SCAN_CHAR_TITLE;
 	-- Indicate the name of the pin template to use with this scan.

--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -230,7 +230,7 @@ local function showTemplate2(dataTab)
 		backdrop.bgFile = getTiledBackground(frameTab.BK or 1);
 		backdrop.tile = false;
 		frame:SetBackdrop(backdrop);
-		setupIconButton(icon, frameTab.IC or Globals.icons.default);
+		setupIconButton(icon, frameTab.IC or TRP3_InterfaceIcons.Default);
 
 		setupHTMLFonts(text);
 		updateAboutTemplateFonts(text);
@@ -358,7 +358,7 @@ function refreshTemplate2EditDisplay()
 		frame.frameData = frameData;
 		_G[frame:GetName().."Bkg"]:SetSelectedIndex(frameData.BK or 1);
 		_G[frame:GetName().."TextScrollText"]:SetText(frameData.TX or "");
-		setupIconButton(_G[frame:GetName().."Icon"], frameData.IC or Globals.icons.default);
+		setupIconButton(_G[frame:GetName().."Icon"], frameData.IC or TRP3_InterfaceIcons.Default);
 		_G[frame:GetName().."Icon"]:SetScript("OnClick", function()
 			showIconBrowser(function(icon)
 				frame.frameData.IC = icon;
@@ -406,9 +406,9 @@ end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 local TEMPLATE3_MARGIN = 30;
-local TEMPLATE3_ICON_PHYSICAL = Globals.is_classic and "spell_holy_fistofjustice" or "Ability_Warrior_StrengthOfArms";
-local TEMPLATE3_ICON_PSYCHO = Globals.is_classic and "spell_holy_mindvision" or "Spell_Arcane_MindMastery";
-local TEMPLATE3_ICON_HISTORY = "INV_Misc_Book_12";
+local TEMPLATE3_ICON_PHYSICAL = TRP3_InterfaceIcons.PhysicalSection;
+local TEMPLATE3_ICON_PSYCHO = TRP3_InterfaceIcons.TraitSection;
+local TEMPLATE3_ICON_HISTORY = TRP3_InterfaceIcons.HistorySection;
 
 local function setTemplate3PhysBkg(bkg)
 	setBkg(TRP3_RegisterAbout_Edit_Template3_Phys, bkg);
@@ -904,7 +904,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 				end
 			end,
 			tooltip = loc.TF_PLAY_THEME,
-			icon = Globals.is_classic and "INV_Misc_Drum_01" or "inv_misc_drum_06"
+			icon = TRP3_InterfaceIcons.TargetPlayMusic,
 		});
 	end
 end);

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -599,37 +599,37 @@ local MISC_PRESET = {
 	{
 		NA = loc.REG_PLAYER_MSP_HOUSE,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_House,
+		IC = TRP3_InterfaceIcons.MiscInfoHouse,
 	},
 	{
 		NA = loc.REG_PLAYER_MSP_NICK,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Nickname,
+		IC = TRP3_InterfaceIcons.MiscInfoNickname,
 	},
 	{
 		NA = loc.REG_PLAYER_MSP_MOTTO,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Motto,
+		IC = TRP3_InterfaceIcons.MiscInfoMotto,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_TRAITS,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Traits,
+		IC = TRP3_InterfaceIcons.MiscInfoTraits,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_PIERCING,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Piercings,
+		IC = TRP3_InterfaceIcons.MiscInfoPiercings,
 	},
 	{
 		NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Pronouns,
+		IC = TRP3_InterfaceIcons.MiscInfoPronouns,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_TATTOO,
 		VA = "",
-		IC = TRP3_InterfaceIcons.MiscInfo_Tattoos,
+		IC = TRP3_InterfaceIcons.MiscInfoTattoos,
 	},
 	{
 		list = "|cff00ff00" .. loc.REG_PLAYER_ADD_NEW,
@@ -1548,8 +1548,8 @@ function TRP3_API.register.inits.characteristicsInit()
 	TRP3_RegisterCharact_Edit_FullTitleFieldText:SetText(loc.REG_PLAYER_FULLTITLE);
 	TRP3_RegisterCharact_CharactPanel_RegisterTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.DirectorySection, 25) .. " " .. loc.REG_PLAYER_REGISTER);
 	TRP3_RegisterCharact_CharactPanel_Edit_RegisterTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.DirectorySection, 25) .. " " .. loc.REG_PLAYER_REGISTER);
-	TRP3_RegisterCharact_CharactPanel_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitsSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
-	TRP3_RegisterCharact_CharactPanel_Edit_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitsSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
+	TRP3_RegisterCharact_CharactPanel_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
+	TRP3_RegisterCharact_CharactPanel_Edit_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
 	TRP3_RegisterCharact_CharactPanel_MiscTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.MiscInfoSection, 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
 	TRP3_RegisterCharact_CharactPanel_Edit_MiscTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.MiscInfoSection, 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
 	TRP3_RegisterCharact_Edit_RaceFieldText:SetText(loc.REG_PLAYER_RACE);

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -1421,7 +1421,7 @@ local function initStructures()
 			LT = loc.REG_PLAYER_PSYCHO_Acete,
 			RT = loc.REG_PLAYER_PSYCHO_Bonvivant,
 			LI = TRP3_InterfaceIcons.TraitAscetic,
-			RI = TRP3_InterfaceIcons.TraitBonViviant,
+			RI = TRP3_InterfaceIcons.TraitBonVivant,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Valeureux,

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -51,7 +51,6 @@ local ignoreID = TRP3_API.register.ignoreID;
 local buildZoneText = Utils.str.buildZoneText;
 local setupEditBoxesNavigation = TRP3_API.ui.frame.setupEditBoxesNavigation;
 local setupListBox = TRP3_API.ui.listbox.setupListBox;
-local is_classic = TRP3_API.globals.is_classic;
 
 local showIconBrowser = function(callback)
 	TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, nil, {callback});
@@ -297,7 +296,7 @@ local function setConsultDisplay(context)
 	local completeName = getCompleteName(dataTab, UNKNOWN);
 	TRP3_RegisterCharact_NamePanel_Name:SetText("|cff" .. (dataTab.CH or "ffffff") .. completeName);
 	TRP3_RegisterCharact_NamePanel_Title:SetText(dataTab.FT or "");
-	setupIconButton(TRP3_RegisterCharact_NamePanel_Icon, dataTab.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_RegisterCharact_NamePanel_Icon, dataTab.IC or TRP3_InterfaceIcons.ProfileDefault);
 
 	setBkg(dataTab.bkg or 1);
 
@@ -445,8 +444,8 @@ local function setConsultDisplay(context)
 			frame.LeftText:SetText(psychoStructure.LT or "");
 			frame.RightText:SetText(psychoStructure.RT or "");
 
-			frame.LeftIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.LI or Globals.icons.default));
-			frame.RightIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.RI or Globals.icons.default));
+			frame.LeftIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.LI or TRP3_InterfaceIcons.Default));
+			frame.RightIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.RI or TRP3_InterfaceIcons.Default));
 
 			frame.Bar:SetMinMaxValues(0, Globals.PSYCHO_MAX_VALUE_V2);
 
@@ -547,7 +546,7 @@ end
 
 local function onPlayerIconSelected(icon)
 	draftData.IC = icon;
-	setupIconButton(TRP3_RegisterCharact_Edit_NamePanel_Icon, draftData.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_RegisterCharact_Edit_NamePanel_Icon, draftData.IC or TRP3_InterfaceIcons.ProfileDefault);
 end
 
 local function onEyeColorSelected(red, green, blue)
@@ -573,7 +572,7 @@ local function onPsychoValueChanged(frame, value)
 end
 
 local function refreshEditIcon(frame)
-	setupIconButton(frame, frame.IC or Globals.icons.profile_default);
+	setupIconButton(frame, frame.IC or TRP3_InterfaceIcons.ProfileDefault);
 end
 
 local function onMiscDelete(self)
@@ -600,43 +599,43 @@ local MISC_PRESET = {
 	{
 		NA = loc.REG_PLAYER_MSP_HOUSE,
 		VA = "",
-		IC = is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1"
+		IC = TRP3_InterfaceIcons.MiscInfo_House,
 	},
 	{
 		NA = loc.REG_PLAYER_MSP_NICK,
 		VA = "",
-		IC = "Ability_Hunter_BeastCall"
+		IC = TRP3_InterfaceIcons.MiscInfo_Nickname,
 	},
 	{
 		NA = loc.REG_PLAYER_MSP_MOTTO,
 		VA = "",
-		IC = is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01"
+		IC = TRP3_InterfaceIcons.MiscInfo_Motto,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_TRAITS,
 		VA = "",
-		IC = "spell_shadow_mindsteal"
+		IC = TRP3_InterfaceIcons.MiscInfo_Traits,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_PIERCING,
 		VA = "",
-		IC = "inv_jewelry_ring_14"
+		IC = TRP3_InterfaceIcons.MiscInfo_Piercings,
 	},
 	{
 		NA = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
 		VA = "",
-		IC = is_classic and "inv_scroll_08" or "vas_namechange"
+		IC = TRP3_InterfaceIcons.MiscInfo_Pronouns,
 	},
 	{
 		NA = loc.REG_PLAYER_TRP2_TATTOO,
 		VA = "",
-		IC = is_classic and "INV_Potion_65" or "INV_Inscription_inkblack01"
+		IC = TRP3_InterfaceIcons.MiscInfo_Tattoos,
 	},
 	{
 		list = "|cff00ff00" .. loc.REG_PLAYER_ADD_NEW,
 		NA = loc.CM_NAME,
 		VA = loc.CM_VALUE,
-		IC = "INV_Misc_QuestionMark"
+		IC = TRP3_InterfaceIcons.Default,
 	},
 }
 
@@ -1024,7 +1023,7 @@ function setEditDisplay()
 		tcopy(draftData, dataTab);
 	end
 
-	setupIconButton(TRP3_RegisterCharact_Edit_NamePanel_Icon, draftData.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_RegisterCharact_Edit_NamePanel_Icon, draftData.IC or TRP3_InterfaceIcons.ProfileDefault);
 	TRP3_RegisterCharact_Edit_TitleField:SetText(draftData.TI or "");
 	TRP3_RegisterCharact_Edit_FirstField:SetText(draftData.FN or Globals.player);
 	TRP3_RegisterCharact_Edit_LastField:SetText(draftData.LN or "");
@@ -1069,12 +1068,12 @@ function setEditDisplay()
 		_G[frame:GetName() .. "Icon"]:SetScript("OnClick", function()
 			showIconBrowser(function(icon)
 				miscStructure.IC = icon;
-				setupIconButton(_G[frame:GetName() .. "Icon"], icon or Globals.icons.default);
+				setupIconButton(_G[frame:GetName() .. "Icon"], icon or TRP3_InterfaceIcons.Default);
 			end);
 		end);
 
 		frame.miscIndex = frameIndex;
-		_G[frame:GetName() .. "Icon"].IC = miscStructure.IC or Globals.icons.default;
+		_G[frame:GetName() .. "Icon"].IC = miscStructure.IC or TRP3_InterfaceIcons.Default;
 		_G[frame:GetName() .. "NameField"]:SetText(miscStructure.NA or loc.CM_NAME);
 		_G[frame:GetName() .. "ValueField"]:SetText(miscStructure.VA or loc.CM_VALUE);
 		refreshEditIcon(_G[frame:GetName() .. "Icon"]);
@@ -1142,14 +1141,14 @@ function setEditDisplay()
 		frame.CustomLeftIcon:SetScript("OnClick", function(self)
 			showIconBrowser(function(icon)
 				psychoStructure.LI = icon;
-				setupIconButton(self, icon or Globals.icons.default);
+				setupIconButton(self, icon or TRP3_InterfaceIcons.Default);
 			end);
 		end);
 
 		frame.CustomRightIcon:SetScript("OnClick", function(self)
 			showIconBrowser(function(icon)
 				psychoStructure.RI = icon;
-				setupIconButton(self, icon or Globals.icons.default);
+				setupIconButton(self, icon or TRP3_InterfaceIcons.Default);
 			end);
 		end);
 
@@ -1166,14 +1165,14 @@ function setEditDisplay()
 			frame.LeftText:SetText(preset.LT or "");
 			frame.RightText:SetText(preset.RT or "");
 
-			frame.LeftIcon:SetTexture("Interface\\ICONS\\" .. (preset.LI or Globals.icons.default));
-			frame.RightIcon:SetTexture("Interface\\ICONS\\" .. (preset.RI or Globals.icons.default));
+			frame.LeftIcon:SetTexture("Interface\\ICONS\\" .. (preset.LI or TRP3_InterfaceIcons.Default));
+			frame.RightIcon:SetTexture("Interface\\ICONS\\" .. (preset.RI or TRP3_InterfaceIcons.Default));
 		else
 			frame.CustomLeftField:SetText(psychoStructure.LT or "");
 			frame.CustomRightField:SetText(psychoStructure.RT or "");
 
-			frame.CustomLeftIcon.IC = psychoStructure.LI or Globals.icons.default;
-			frame.CustomRightIcon.IC = psychoStructure.RI or Globals.icons.default;
+			frame.CustomLeftIcon.IC = psychoStructure.LI or TRP3_InterfaceIcons.Default;
+			frame.CustomRightIcon.IC = psychoStructure.RI or TRP3_InterfaceIcons.Default;
 
 			refreshEditIcon(frame.CustomLeftIcon);
 			refreshEditIcon(frame.CustomRightIcon);
@@ -1359,76 +1358,76 @@ local function initStructures()
 	PSYCHO_PRESETS_UNKOWN = {
 		LT = loc.CM_UNKNOWN,
 		RT = loc.CM_UNKNOWN,
-		LI = "INV_Misc_QuestionMark",
-		RI = "INV_Misc_QuestionMark"
+		LI = TRP3_InterfaceIcons.Default,
+		RI = TRP3_InterfaceIcons.Default,
 	};
 
 	PSYCHO_PRESETS = {
 		{
 			LT = loc.REG_PLAYER_PSYCHO_CHAOTIC,
 			RT = loc.REG_PLAYER_PSYCHO_Loyal,
-			LI = is_classic and "Spell_Shadow_UnholyFrenzy" or "Ability_Rogue_WrongfullyAccused",
-			RI = is_classic and "Spell_Holy_RighteousFury" or "Ability_Paladin_SanctifiedWrath",
+			LI = TRP3_InterfaceIcons.TraitChaotic,
+			RI = TRP3_InterfaceIcons.TraitLoyal,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Chaste,
 			RT = loc.REG_PLAYER_PSYCHO_Luxurieux,
-			LI = "INV_Belt_27",
-			RI = "Spell_Shadow_SummonSuccubus",
+			LI = TRP3_InterfaceIcons.TraitChaste,
+			RI = TRP3_InterfaceIcons.TraitLustful,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Indulgent,
 			RT = loc.REG_PLAYER_PSYCHO_Rencunier,
-			LI = "INV_RoseBouquet01",
-			RI = "Ability_Hunter_SniperShot",
+			LI = TRP3_InterfaceIcons.TraitForgiving,
+			RI = TRP3_InterfaceIcons.TraitVindictive,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Genereux,
 			RT = loc.REG_PLAYER_PSYCHO_Egoiste,
-			LI = "INV_Misc_Gift_02",
-			RI = is_classic and "INV_Ingot_03" or "INV_Misc_Coin_02",
+			LI = TRP3_InterfaceIcons.TraitAltruistic,
+			RI = TRP3_InterfaceIcons.TraitSelfish,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Sincere,
 			RT = loc.REG_PLAYER_PSYCHO_Trompeur,
-			LI = is_classic and "Spell_Holy_AuraOfLight" or "INV_Misc_Toy_07",
-			RI = "Ability_Rogue_Disguise",
+			LI = TRP3_InterfaceIcons.TraitTruthful,
+			RI = TRP3_InterfaceIcons.TraitDeceitful,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Misericordieux,
 			RT = loc.REG_PLAYER_PSYCHO_Cruel,
-			LI = "INV_ValentinesCandySack",
-			RI = is_classic and "Ability_Rogue_Eviscerate" or "Ability_Warrior_Trauma",
+			LI = TRP3_InterfaceIcons.TraitGentle,
+			RI = TRP3_InterfaceIcons.TraitBrutal,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Pieux,
 			RT = loc.REG_PLAYER_PSYCHO_Rationnel,
-			LI = is_classic and "Spell_Holy_PowerInfusion" or "Spell_Holy_HolyGuidance",
-			RI = "INV_Gizmo_02",
+			LI = TRP3_InterfaceIcons.TraitSuperstitious,
+			RI = TRP3_InterfaceIcons.TraitRational,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Pragmatique,
 			RT = loc.REG_PLAYER_PSYCHO_Conciliant,
-			LI = is_classic and "Ability_Rogue_DualWeild" or "Ability_Rogue_HonorAmongstThieves",
-			RI = is_classic and "ACHIEVEMENT_GUILDPERK_HAVEGROUP WILLTRAVEL" or "INV_Misc_GroupNeedMore",
+			LI = TRP3_InterfaceIcons.TraitRenegade,
+			RI = TRP3_InterfaceIcons.TraitParagon,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Reflechi,
 			RT = loc.REG_PLAYER_PSYCHO_Impulsif,
-			LI = is_classic and "INV_Misc_PocketWatch_01" or "Spell_Shadow_Brainwash",
-			RI = is_classic and "SPELL_FIRE_INCINERATE" or "Achievement_BG_CaptureFlag_EOS",
+			LI = TRP3_InterfaceIcons.TraitCautious,
+			RI = TRP3_InterfaceIcons.TraitImpulsive,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Acete,
 			RT = loc.REG_PLAYER_PSYCHO_Bonvivant,
-			LI = is_classic and "INV_Misc_Coin_05" or "INV_Misc_Food_PineNut",
-			RI = is_classic and "INV_Misc_Coin_02" or "INV_Misc_Food_99",
+			LI = TRP3_InterfaceIcons.TraitAscetic,
+			RI = TRP3_InterfaceIcons.TraitBonViviant,
 		},
 		{
 			LT = loc.REG_PLAYER_PSYCHO_Valeureux,
 			RT = loc.REG_PLAYER_PSYCHO_Couard,
-			LI = is_classic and "Ability_Warrior_BattleShout" or "Ability_Paladin_BeaconofLight",
-			RI = "Ability_Druid_Cower",
+			LI = TRP3_InterfaceIcons.TraitValorous,
+			RI = TRP3_InterfaceIcons.TraitSpineless,
 		},
 	};
 
@@ -1547,13 +1546,12 @@ function TRP3_API.register.inits.characteristicsInit()
 	TRP3_RegisterCharact_Edit_FirstFieldText:SetText(loc.REG_PLAYER_FIRSTNAME);
 	TRP3_RegisterCharact_Edit_LastFieldText:SetText(loc.REG_PLAYER_LASTNAME);
 	TRP3_RegisterCharact_Edit_FullTitleFieldText:SetText(loc.REG_PLAYER_FULLTITLE);
-	TRP3_RegisterCharact_CharactPanel_RegisterTitle:SetText(Utils.str.icon("INV_Misc_Book_09", 25) .. " " .. loc.REG_PLAYER_REGISTER);
-	TRP3_RegisterCharact_CharactPanel_Edit_RegisterTitle:SetText(Utils.str.icon("INV_Misc_Book_09", 25) .. " " .. loc.REG_PLAYER_REGISTER);
-	local PSYCHO_ICON = is_classic and "Spell_Holy_MindSooth" or "Spell_Arcane_MindMastery";
-	TRP3_RegisterCharact_CharactPanel_PsychoTitle:SetText(Utils.str.icon(PSYCHO_ICON, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
-	TRP3_RegisterCharact_CharactPanel_Edit_PsychoTitle:SetText(Utils.str.icon(PSYCHO_ICON, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
-	TRP3_RegisterCharact_CharactPanel_MiscTitle:SetText(Utils.str.icon("INV_MISC_NOTE_06", 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
-	TRP3_RegisterCharact_CharactPanel_Edit_MiscTitle:SetText(Utils.str.icon("INV_MISC_NOTE_06", 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
+	TRP3_RegisterCharact_CharactPanel_RegisterTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.DirectorySection, 25) .. " " .. loc.REG_PLAYER_REGISTER);
+	TRP3_RegisterCharact_CharactPanel_Edit_RegisterTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.DirectorySection, 25) .. " " .. loc.REG_PLAYER_REGISTER);
+	TRP3_RegisterCharact_CharactPanel_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitsSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
+	TRP3_RegisterCharact_CharactPanel_Edit_PsychoTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.TraitsSection, 25) .. " " .. loc.REG_PLAYER_PSYCHO);
+	TRP3_RegisterCharact_CharactPanel_MiscTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.MiscInfoSection, 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
+	TRP3_RegisterCharact_CharactPanel_Edit_MiscTitle:SetText(Utils.str.icon(TRP3_InterfaceIcons.MiscInfoSection, 25) .. " " .. loc.REG_PLAYER_MORE_INFO);
 	TRP3_RegisterCharact_Edit_RaceFieldText:SetText(loc.REG_PLAYER_RACE);
 	TRP3_RegisterCharact_Edit_ClassFieldText:SetText(loc.REG_PLAYER_CLASS);
 	TRP3_RegisterCharact_Edit_AgeFieldText:SetText(loc.REG_PLAYER_AGE);

--- a/totalRP3/modules/register/characters/register_ignore.lua
+++ b/totalRP3/modules/register/characters/register_ignore.lua
@@ -30,7 +30,6 @@ local get, getPlayerCurrentProfile, hasProfile = TRP3_API.profile.getData, TRP3_
 local getProfile, getUnitID = TRP3_API.register.getProfile, TRP3_API.utils.str.getUnitID;
 local displayDropDown = TRP3_API.ui.listbox.displayDropDown;
 local characters, blockList = {}, {};
-local is_classic = Globals.is_classic;
 
 -- These functions gets replaced by the proper TRP3 one once the addon has finished loading
 local function getPlayerCompleteName()
@@ -48,13 +47,13 @@ local RELATIONS = Globals.RELATIONS;
 TRP3_API.register.relation = Globals.RELATIONS;
 
 local RELATIONS_TEXTURES = {
-	[RELATIONS.UNFRIENDLY] = "Ability_DualWield",
-	[RELATIONS.NONE] = "Ability_rogue_disguise",
-	[RELATIONS.NEUTRAL] = is_classic and "Ability_Hibernation" or "Achievement_Reputation_05",
-	[RELATIONS.BUSINESS] = is_classic and "INV_Misc_Coin_04" or "Achievement_Reputation_08",
-	[RELATIONS.FRIEND] = is_classic and "Spell_Holy_PrayerOfHealing" or "Achievement_Reputation_06",
-	[RELATIONS.LOVE] = "INV_ValentinesCandy",
-	[RELATIONS.FAMILY] = is_classic and "Spell_Holy_SpellWarding" or "Achievement_Reputation_07"
+	[RELATIONS.UNFRIENDLY] = TRP3_InterfaceIcons.RelationUnfriendly,
+	[RELATIONS.NONE] = TRP3_InterfaceIcons.RelationNone,
+	[RELATIONS.NEUTRAL] = TRP3_InterfaceIcons.RelationNeutral,
+	[RELATIONS.BUSINESS] = TRP3_InterfaceIcons.RelationBusiness,
+	[RELATIONS.FRIEND] = TRP3_InterfaceIcons.RelationFriend,
+	[RELATIONS.LOVE] = TRP3_InterfaceIcons.RelationLove,
+	[RELATIONS.FAMILY] = TRP3_InterfaceIcons.RelationFamily,
 }
 
 local function setRelation(profileID, relation)
@@ -238,7 +237,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			end,
 			tooltipSub = loc.TF_IGNORE_TT,
 			tooltip = loc.TF_IGNORE,
-			icon = is_classic and "SPELL_HOLY_SILENCE" or "Achievement_BG_interruptX_flagcapture_attempts_1game"
+			icon = TRP3_InterfaceIcons.TargetIgnoreCharacter,
 		});
 
 		TRP3_API.target.registerButton({

--- a/totalRP3/modules/register/characters/register_misc.lua
+++ b/totalRP3/modules/register/characters/register_misc.lua
@@ -201,7 +201,7 @@ end
 -- PEEK
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local GLANCE_NOT_USED_ICON = "INV_Misc_QuestionMark";
+local GLANCE_NOT_USED_ICON = TRP3_InterfaceIcons.Default;
 
 local function setupGlanceButton(button, active, icon, title, text, isMine)
 	button:Enable();
@@ -256,7 +256,7 @@ function TRP3_API.register.getGlanceIconTextures(dataTab, size)
 	for i=1, 5, 1 do
 		local index = tostring(i);
 		if dataTab[index] and dataTab[index].AC then
-			text = text .. "|TInterface\\ICONS\\".. (dataTab[index].IC or Globals.icons.default) .. ":" .. size .. "|t "
+			text = text .. "|TInterface\\ICONS\\".. (dataTab[index].IC or TRP3_InterfaceIcons.Default) .. ":" .. size .. "|t "
 		end
 	end
 	return text;

--- a/totalRP3/modules/register/characters/register_notes.lua
+++ b/totalRP3/modules/register/characters/register_notes.lua
@@ -36,8 +36,6 @@ local getPlayerCurrentProfile = TRP3_API.profile.getPlayerCurrentProfile;
 local getPlayerCurrentProfileID = TRP3_API.profile.getPlayerCurrentProfileID;
 local getConfigValue = TRP3_API.configuration.getValue;
 
-local NOTES_ICON = Ellyb.Icon(Globals.is_classic and "INV_Scroll_02" or "Inv_misc_scrollunrolled03b");
-
 local function displayNotes(context)
 
 	local profileID = context.profileID;
@@ -138,7 +136,7 @@ function TRP3_API.register.inits.notesInit()
 			end,
 			tooltip = loc.REG_NOTES_PROFILE,
 			tooltipSub = loc.REG_NOTES_PROFILE_TT,
-			icon = NOTES_ICON
+			icon = Ellyb.Icon(TRP3_InterfaceIcons.TargetNotes),
 		});
 	end)
 end

--- a/totalRP3/modules/register/companions/register_companions_page.lua
+++ b/totalRP3/modules/register/companions/register_companions_page.lua
@@ -173,7 +173,7 @@ end
 
 local function onPlayerIconSelected(icon)
 	draftData.IC = icon;
-	setupIconButton(TRP3_CompanionsPageInformationEdit_NamePanel_Icon, draftData.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_CompanionsPageInformationEdit_NamePanel_Icon, draftData.IC or TRP3_InterfaceIcons.ProfileDefault);
 end
 
 local function displayEdit()
@@ -189,7 +189,7 @@ local function displayEdit()
 		tcopy(draftData, dataTab);
 	end
 
-	setupIconButton(TRP3_CompanionsPageInformationEdit_NamePanel_Icon, draftData.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_CompanionsPageInformationEdit_NamePanel_Icon, draftData.IC or TRP3_InterfaceIcons.ProfileDefault);
 	TRP3_CompanionsPageInformationEdit_NamePanel_TitleField:SetText(draftData.TI or "");
 	TRP3_CompanionsPageInformationEdit_NamePanel_NameField:SetText(draftData.NA or Globals.player);
 	TRP3_CompanionsPageInformationEdit_About_BckField:SetSelectedIndex(draftData.BK or 1);
@@ -208,7 +208,7 @@ function displayConsult(context)
 
 	TRP3_CompanionsPageInformationConsult_NamePanel_Name:SetText("|cff" .. (dataTab.NH or "ffffff") .. (dataTab.NA or UNKNOWN));
 	TRP3_CompanionsPageInformationConsult_NamePanel_Title:SetText(dataTab.TI or "");
-	setupIconButton(TRP3_CompanionsPageInformationConsult_NamePanel_Icon, dataTab.IC or Globals.icons.profile_default);
+	setupIconButton(TRP3_CompanionsPageInformationConsult_NamePanel_Icon, dataTab.IC or TRP3_InterfaceIcons.ProfileDefault);
 
 	for i=1,5 do
 		local glanceData = (context.profile.PE or {})[tostring(i)] or {};
@@ -441,7 +441,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	setupFieldSet(TRP3_CompanionsPageInformationConsult_About, loc.REG_PLAYER_ABOUT, 150);
 	TRP3_CompanionsPageInformationConsult_About_Empty:SetText(loc.REG_PLAYER_ABOUT_EMPTY);
 	TRP3_CompanionsPageInformationConsult_NamePanel_EditButton:SetText(loc.CM_EDIT);
-	setupIconButton(TRP3_CompanionsPageInformationConsult_NamePanel_ActionButton, "icon_petfamily_mechanical");
+	setupIconButton(TRP3_CompanionsPageInformationConsult_NamePanel_ActionButton, TRP3_InterfaceIcons.Gears);
 	setTooltipForSameFrame(TRP3_CompanionsPageInformationConsult_NamePanel_ActionButton, "TOP", 0, 5, loc.CM_ACTIONS);
 	TRP3_CompanionsPageInformationConsult_NamePanel_ActionButton:SetScript("OnClick", onActionClick);
 
@@ -469,7 +469,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	for index=1,5,1 do
 		-- DISPLAY
 		local button = _G["TRP3_CompanionsPageInformationConsult_GlanceSlot" .. index];
-		button:SetDisabledTexture("Interface\\ICONS\\" .. Globals.icons.default);
+		button:SetDisabledTexture("Interface\\ICONS\\" .. TRP3_InterfaceIcons.Default);
 		button:GetDisabledTexture():SetDesaturated(1);
 		button:SetScript("OnClick", TRP3_API.register.glance.onGlanceSlotClick);
 		button:SetScript("OnDoubleClick", TRP3_API.register.glance.onGlanceDoubleClick);

--- a/totalRP3/modules/register/companions/register_companions_profiles.lua
+++ b/totalRP3/modules/register/companions/register_companions_profiles.lua
@@ -209,7 +209,7 @@ local function decorateProfileList(widget, index)
 	local dataTab = profile.data or {};
 	local mainText = profile.profileName;
 
-	setupIconButton(_G[widget:GetName().."Icon"], dataTab.IC or Globals.icons.profile_default);
+	setupIconButton(_G[widget:GetName().."Icon"], dataTab.IC or TRP3_InterfaceIcons.ProfileDefault);
 	_G[widget:GetName().."Name"]:SetText(mainText);
 
 	local listText = "";
@@ -608,14 +608,14 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 							buttonStructure.icon = profile.data.IC;
 						end
 					else
-						buttonStructure.icon = Globals.is_classic and "INV_Misc_Gear_01" or "icon_petfamily_mechanical";
+						buttonStructure.icon = TRP3_InterfaceIcons.Gears;
 						buttonStructure.tooltip = loc.REG_COMPANION_TF_NO;
 					end
 				else
 					if profile and profile.data and profile.data.IC then
 						buttonStructure.icon = profile.data.IC;
 					else
-						buttonStructure.icon = Globals.icons.unknown;
+						buttonStructure.icon = TRP3_InterfaceIcons.Unknown;
 					end
 					if profile and profile.data and profile.data.read == false then
 						buttonStructure.tooltipSub = loc.REG_TT_NOTIF;
@@ -655,10 +655,10 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 						if profile and profile.data and profile.data.IC then
 							buttonStructure.icon = profile.data.IC;
 						else
-							buttonStructure.icon = Globals.icons.unknown;
+							buttonStructure.icon = TRP3_InterfaceIcons.Unknown;
 						end
 					else
-						buttonStructure.icon = "ability_mount_charger";
+						buttonStructure.icon = TRP3_InterfaceIcons.TargetOpenMount;
 						buttonStructure.tooltipSub = "|cffffff00" .. loc.CM_CLICK .. ": |r" .. loc.REG_COMPANION_TF_BOUND_TO;
 						buttonStructure.tooltip = loc.PR_CO_MOUNT;
 					end
@@ -674,7 +674,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 					if profile and profile.data and profile.data.IC then
 						buttonStructure.icon = profile.data.IC;
 					else
-						buttonStructure.icon = Globals.icons.unknown;
+						buttonStructure.icon = TRP3_InterfaceIcons.Unknown;
 					end
 					if profile and profile.data and profile.data.read == false then
 						buttonStructure.tooltipSub = "|cff00ff00" .. loc.REG_TT_NOTIF .. "\n" .. buttonStructure.tooltipSub;

--- a/totalRP3/modules/register/filter/register_mature_filter.lua
+++ b/totalRP3/modules/register/filter/register_mature_filter.lua
@@ -584,7 +584,7 @@ local function onStart()
 			onClick = presentAddUnitToSafeListPopup,
 			tooltipSub = "|cffffff00" .. loc.CM_CLICK .. "|r: " .. loc.MATURE_FILTER_ADD_TO_SAFELIST_TT,
 			tooltip = loc.MATURE_FILTER_ADD_TO_SAFELIST,
-			icon = "INV_ValentinesCard02"
+			icon = TRP3_InterfaceIcons.TargetFlagMatureSafe,
 		});
 		-- Remove from safe list button
 		TRP3_API.target.registerButton({
@@ -605,7 +605,7 @@ local function onStart()
 			end,
 			tooltipSub = loc.MATURE_FILTER_REMOVE_FROM_SAFELIST_TT,
 			tooltip = loc.MATURE_FILTER_REMOVE_FROM_SAFELIST,
-			icon = TRP3_API.globals.is_classic and "INV_Scroll_07" or "INV_Inscription_ParchmentVar03"
+			icon = TRP3_InterfaceIcons.TargetFlagMatureUnsafe,
 		});
 
 		-- Manually flag player button
@@ -627,7 +627,7 @@ local function onStart()
 			end,
 			tooltipSub = loc.MATURE_FILTER_FLAG_PLAYER_TT,
 			tooltip = loc.MATURE_FILTER_FLAG_PLAYER,
-			icon = TRP3_API.globals.is_classic and "Ability_Hunter_SniperShot" or "Ability_Hunter_MasterMarksman"
+			icon = TRP3_InterfaceIcons.TargetFlagMature,
 		});
 	end
 

--- a/totalRP3/modules/register/main/AtFirstGlanceChatLinksModule.lua
+++ b/totalRP3/modules/register/main/AtFirstGlanceChatLinksModule.lua
@@ -24,7 +24,6 @@ local _, TRP3_API = ...;
 local loc = TRP3_API.loc;
 local tcopy = TRP3_API.utils.table.copy;
 local Utils = TRP3_API.utils;
-local Globals = TRP3_API.globals;
 local crop = TRP3_API.Ellyb.Strings.crop;
 local shouldCropTexts = TRP3_API.ui.tooltip.shouldCropTexts;
 
@@ -55,7 +54,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 
 		local glance = tooltipData.glanceTab;
 
-		local icon = Globals.icons.default;
+		local icon = TRP3_InterfaceIcons.Default;
 		if glance.IC and glance.IC:len() > 0 then
 			icon = glance.IC;
 		end

--- a/totalRP3/modules/register/main/RegisterPlayerChatLinksModule.lua
+++ b/totalRP3/modules/register/main/RegisterPlayerChatLinksModule.lua
@@ -27,7 +27,6 @@ local assert = assert;
 -- Total RP 3 imports
 local loc = TRP3_API.loc;
 local tcopy = TRP3_API.utils.table.copy;
-local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local Events = TRP3_API.events;
 
@@ -67,7 +66,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			customColor = TRP3_API.Ellyb.Color(profile.characteristics.CH);
 		end
 
-		tooltipLines:SetTitle(customColor(Utils.str.icon(profile.characteristics.IC or Globals.icons.profile_default, 20) .. " " .. TRP3_API.register.getCompleteName(profile.characteristics, profile.profileName, true)));
+		tooltipLines:SetTitle(customColor(Utils.str.icon(profile.characteristics.IC or TRP3_InterfaceIcons.ProfileDefault, 20) .. " " .. TRP3_API.register.getCompleteName(profile.characteristics, profile.profileName, true)));
 
 		if profile.characteristics and profile.characteristics.FT then
 			tooltipLines:AddLine("< " .. profile.characteristics.FT .. " >", TRP3_API.Ellyb.ColorManager.ORANGE);

--- a/totalRP3/modules/register/main/register_glance.lua
+++ b/totalRP3/modules/register/main/register_glance.lua
@@ -369,7 +369,7 @@ local function saveSlotPreset(glanceTab)
 	if glanceTab == nil then return end;
 	local presetTitle = glanceTab.TI or UNKNOWN;
 	local presetText = glanceTab.TX or "";
-	local presetIcon = glanceTab.IC or Globals.icons.unknown;
+	local presetIcon = glanceTab.IC or TRP3_InterfaceIcons.Unknown;
 	local presetID = Utils.str.id();
 
 	local icon = Utils.str.icon(presetIcon, 25) .. "\n|cff00ff00" .. presetTitle .. "|r";
@@ -413,7 +413,7 @@ local setupIconButton = TRP3_API.ui.frame.setupIconButton;
 local stEtN = Utils.str.emptyToNil;
 
 local function onIconSelected(icon)
-	icon = icon or Globals.icons.default;
+	icon = icon or TRP3_InterfaceIcons.Default;
 	setupIconButton(TRP3_AtFirstGlanceEditorIcon, icon);
 	TRP3_AtFirstGlanceEditorIcon.icon = icon;
 end
@@ -630,7 +630,7 @@ local function displayGlanceSlots()
 			button.data = glance;
 			button.glanceTab = glanceTab;
 
-			local icon = Globals.icons.default;
+			local icon = TRP3_InterfaceIcons.Default;
 
 			if glance and glance.AC then
 				button:SetAlpha(1);
@@ -658,7 +658,7 @@ end
 
 local function onGlanceDragStart(button)
 	if button.isCurrentMine and button.data then
-		SetCursor("Interface\\ICONS\\" .. (button.data.IC or Globals.icons.default));
+		SetCursor("Interface\\ICONS\\" .. (button.data.IC or TRP3_InterfaceIcons.Default));
 	end
 end
 TRP3_API.register.glance.onGlanceDragStart = onGlanceDragStart;

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -58,7 +58,6 @@ local unitIDIsFilteredForMatureContent = TRP3_API.register.unitIDIsFilteredForMa
 local profileIDISFilteredForMatureContent = TRP3_API.register.profileIDISFilteredForMatureContent;
 local tContains = tContains;
 local GetAutoCompleteRealms = GetAutoCompleteRealms;
-local is_classic = Globals.is_classic;
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Logic
@@ -102,7 +101,7 @@ local function openPage(profileID, unitID)
 			onSelected = function() setPage("player_main", pageContext ) end,
 			isChildOf = REGISTER_PAGE,
 			closeable = true,
-			icon = is_classic and "Interface\\ICONS\\INV_Helmet_20" or "Interface\\ICONS\\pet_type_humanoid",
+			icon = [[interface\icons\]] .. TRP3_InterfaceIcons.CharacterMenuItem,
 			pageContext = pageContext,
 		});
 		selectMenu(menuID);
@@ -135,7 +134,7 @@ local function openCompanionPage(profileID)
 			onSelected = function() setPage(TRP3_API.navigation.page.id.COMPANIONS_PAGE, {profile = profile, profileID = profileID, isPlayer = false}) end,
 			isChildOf = REGISTER_PAGE,
 			closeable = true,
-			icon = "Interface\\ICONS\\pet_type_beast",
+			icon = [[interface\icons\]] .. TRP3_InterfaceIcons.CompanionMenuItem,
 		});
 		selectMenu(currentlyOpenedProfilePrefix .. profileID);
 	end
@@ -1079,7 +1078,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 				end
 			end,
 			alertIcon = "Interface\\GossipFrame\\AvailableQuestIcon",
-			icon = Globals.is_classic and "INV_Misc_Book_09" or "inv_inscription_scroll"
+			icon = TRP3_InterfaceIcons.TargetOpenCharacter,
 		});
 	end
 end);

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -179,11 +179,11 @@ module.TryRegisterField("PS", {
 			elseif trait.LT and trait.RT then
 				-- We'll strip " and ] from the names for simplicity if present.
 				local leftName = trait.LT:gsub("[%]=]", "");
-				local leftIcon = trait.LI or Globals.icons.default;
+				local leftIcon = trait.LI or TRP3_InterfaceIcons.Default;
 				local leftColor = trait.LC or Globals.PSYCHO_DEFAULT_LEFT_COLOR:GetRGBTable();
 
 				local rightName = trait.RT:gsub("[%]=]", "");
-				local rightIcon = trait.RI or Globals.icons.default;
+				local rightIcon = trait.RI or TRP3_InterfaceIcons.Default;
 				local rightColor = trait.RC or Globals.PSYCHO_DEFAULT_RIGHT_COLOR:GetRGBTable();
 
 				table.insert(out, PS_CUSTOM_FORMAT:format(
@@ -261,9 +261,9 @@ module.TryRegisterField("PS", {
 				struct.V2 = v2;
 			elseif struct.LT and struct.RT then
 				-- It's custom, default any missing fields.
-				struct.LI = struct.LI or Globals.icons.default;
+				struct.LI = struct.LI or TRP3_InterfaceIcons.Default;
 				struct.LC = struct.LC or Globals.PSYCHO_DEFAULT_LEFT_COLOR:GetRGBTable();
-				struct.RI = struct.RI or Globals.icons.default;
+				struct.RI = struct.RI or TRP3_InterfaceIcons.Default;
 				struct.RC = struct.RC or Globals.PSYCHO_DEFAULT_RIGHT_COLOR:GetRGBTable();
 			end
 

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -111,7 +111,7 @@ local function onStart()
 		else
 			msp.my['NA'] = getCompleteName(dataTab, Globals.player);
 		end
-		msp.my['IC'] = dataTab.IC or Globals.icons.profile_default;
+		msp.my['IC'] = dataTab.IC or TRP3_InterfaceIcons.ProfileDefault;
 		msp.my['NT'] = dataTab.FT;
 		msp.my['PX'] = dataTab.TI;
 		msp.my['RA'] = dataTab.RA;
@@ -263,7 +263,7 @@ local function onStart()
 	end
 
 	local function parsePeekString(str)
-		local icon = str:match("%f[^\n%z]|TInterface\\Icons\\([^:|]+)[^|]*|t%f[\n%z]") or "INV_Misc_QuestionMark";
+		local icon = str:match("%f[^\n%z]|TInterface\\Icons\\([^:|]+)[^|]*|t%f[\n%z]") or TRP3_InterfaceIcons.Default;
 		local title = str:match("%f[^\n%z]#+% *(.-)% *%f[\n%z]");
 		local text = str:match("%f[^\n%z]% *([^|#].-)%s*$");
 		return {
@@ -278,23 +278,23 @@ local function onStart()
 		MO = {  -- Motto
 			localizedText = loc.REG_PLAYER_MSP_MOTTO,
 			englishText = "Motto",
-			icon = Globals.is_classic and "INV_Scroll_01" or "INV_Inscription_ScrollOfWisdom_01",
+			icon = TRP3_InterfaceIcons.MiscInfoMotto,
 			formatter = function(value) return string.format([["%s"]], value); end,
 		},
 		NH = {  -- House Name
 			localizedText = loc.REG_PLAYER_MSP_HOUSE,
 			englishText = "House name",
-			icon = Globals.is_classic and "INV_Jewelry_Ring_36" or "inv_misc_kingsring1",
+			icon = TRP3_InterfaceIcons.MiscInfoHouse,
 		},
 		NI = {  -- Nickname
 			localizedText = loc.REG_PLAYER_MSP_NICK,
 			englishText = "Nickname",
-			icon = "Ability_Hunter_BeastCall",
+			icon = TRP3_InterfaceIcons.MiscInfoNickname,
 		},
 		PN = {  -- Pronouns
 			localizedText = loc.REG_PLAYER_MISC_PRESET_PRONOUNS,
 			englishText = "Pronouns",
-			icon = Globals.is_classic and "inv_scroll_08" or "vas_namechange",
+			icon = TRP3_InterfaceIcons.MiscInfoPronouns,
 		},
 	};
 
@@ -427,10 +427,10 @@ local function onStart()
 								profile.about.T3 = {};
 							end
 							if not profile.about.T3.HI then
-								profile.about.T3.HI = {BK = 1, IC = "INV_Misc_Book_12"};
+								profile.about.T3.HI = {BK = 1, IC = TRP3_InterfaceIcons.HistorySection };
 							end
 							if not profile.about.T3.PH then
-								profile.about.T3.PH = {BK = 1, IC = Globals.is_classic and "spell_holy_fistofjustice" or "Ability_Warrior_StrengthOfArms"};
+								profile.about.T3.PH = {BK = 1, IC = TRP3_InterfaceIcons.PhysicalSection };
 							end
 							profile.about.T3[ABOUT_FIELDS[field]].TX = value;
 							if profile.about.read ~= false then

--- a/totalRP3/modules/toolbar/toolbar.lua
+++ b/totalRP3/modules/toolbar/toolbar.lua
@@ -102,8 +102,8 @@ local function onStart()
 					uiButton:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 					tinsert(uiButtons, uiButton);
 				end
-				uiButton:SetNormalTexture(Utils.getIconTexture(buttonStructure.icon or Globals.icons.default));
-				uiButton:SetPushedTexture(Utils.getIconTexture(buttonStructure.icon or Globals.icons.default));
+				uiButton:SetNormalTexture(Utils.getIconTexture(buttonStructure.icon or TRP3_InterfaceIcons.Default));
+				uiButton:SetPushedTexture(Utils.getIconTexture(buttonStructure.icon or TRP3_InterfaceIcons.Default));
 				uiButton:GetPushedTexture():SetDesaturated(1);
 				uiButton:SetPoint("TOPLEFT", x, y);
 				uiButton:SetScript("OnClick", function(self, button)

--- a/totalRP3/resources/InterfaceIcons.lua
+++ b/totalRP3/resources/InterfaceIcons.lua
@@ -1,0 +1,249 @@
+--[[
+	Total RP 3
+
+	Copyright 2021 Total RP 3 Development Team
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+--]]
+
+--
+-- Interface Data
+--
+
+local DEFAULT_ICON_NAME = "inv_misc_questionmark";
+
+TRP3_InterfaceIcons = {
+	Default        = { DEFAULT_ICON_NAME },
+	DiceRoll       = { "inv_misc_dice_01", "inv_enchant_shardglowingsmall" },
+	Gears          = { "icon_petfamily_mechanical", "inv_misc_gear_01" },
+	ProfileDefault = { "inv_misc_grouplooking", "achievement_guildperk_everybodysfriend" },
+	ScanCooldown   = { "ability_mage_timewarp", "spell_nature_timestop" },
+	ScanReady      = { "icon_treasuremap", "inv_misc_map_01" },
+	Unknown        = { DEFAULT_ICON_NAME },
+
+	--
+	-- UI Icons
+	--
+
+	DirectorySection  = { "inv_misc_book_09" },
+	HistorySection    = { "inv_misc_book_12" },
+	MiscInfoSection   = { "inv_misc_note_06" },
+	PhysicalSection   = { "ability_warrior_strengthofarms", "spell_holy_fistofjustice" },
+	TraitSection      = { "spell_arcane_mindmastery", "spell_holy_mindsooth" },
+	CharacterMenuItem = { "pet_type_humanoid", "inv_helmet_20" },
+	CompanionMenuItem = { "pet_type_beast", "inv_box_petcarrier_01" },
+	DefaultScanIcon   = { "inv_misc_enggizmos_20" },
+	PlayerScanIcon    = { "achievement_guildperk_everybodysfriend" },
+
+	--
+	-- Target Bar Icons
+	--
+
+	TargetFlagMature       = { "ability_hunter_mastermarksman", "ability_hunter_snipershot" },
+	TargetFlagMatureSafe   = { "inv_valentinescard02" },
+	TargetFlagMatureUnsafe = { "inv_inscription_parchmentvar03", "inv_scroll_07" },
+	TargetIgnoreCharacter  = { "achievement_bg_interruptx_flagcapture_attempts_1game", "spell_holy_silence" },
+	TargetOpenCharacter    = { "inv_inscription_scroll", "inv_misc_book_09" },
+	TargetOpenMount        = { "ability_mount_charger" },
+	TargetPlayMusic        = { "inv_misc_drum_06", "inv_misc_drum_01" },
+	TargetNotes            = { "inv_misc_scrollunrolled03b", "inv_scroll_02" },
+
+	--
+	-- Toolbar Icons
+	--
+
+	ToolbarNPCTalk   = { "ability_warrior_commandingshout", "ability_warrior_battleshout" },
+	ToolbarStatusIC  = { "spell_shadow_charm" },
+	ToolbarStatusOOC = { "inv_misc_grouplooking", "achievement_guildperk_everybodysfriend" },
+	ToolbarCloakOn   = { "inv_misc_cape_18" },
+	ToolbarCloakOff  = { "inv_misc_cape_20" },
+	ToolbarHelmetOn  = { "inv_helmet_13" },
+	ToolbarHelmetOff = { "spell_nature_invisibilty" },
+	ToolbarLanguage  = { "spell_holy_silence" },
+
+	--
+	-- Player Mode Icons
+	--
+
+	ModeNormal = { "ability_rogue_masterofsubtlety", "ability_stealth" },
+	ModeAFK    = { "spell_nature_sleep" },
+	ModeDND    = { "ability_mage_incantersabsorbtion", "ability_warrior_challange" },
+
+	--
+	-- Relation Icons
+	--
+
+	RelationBusiness   = { "achievement_reputation_08", "inv_misc_coin_04" },
+	RelationFamily     = { "achievement_reputation_07", "spell_holy_spellwarding" },
+	RelationFriend     = { "achievement_reputation_06", "spell_holy_prayerofhealing" },
+	RelationLove       = { "inv_valentinescandy" },
+	RelationNeutral    = { "achievement_reputation_05", "ability_hibernation" },
+	RelationNone       = { "ability_rogue_disguise" },
+	RelationUnfriendly = { "ability_dualwield" },
+
+	--
+	-- Race Icons
+	--
+
+	BloodElfFemale           = { "achievement_character_bloodelf_female", DEFAULT_ICON_NAME },
+	BloodElfMale             = { "achievement_character_bloodelf_male", DEFAULT_ICON_NAME },
+	DarkIronDwarfFemale      = { "ability_racial_foregedinflames", DEFAULT_ICON_NAME },
+	DarkIronDwarfMale        = { "ability_racial_fireblood", DEFAULT_ICON_NAME },
+	DraeneiFemale            = { "achievement_character_draenei_female", DEFAULT_ICON_NAME },
+	DraeneiMale              = { "achievement_character_draenei_male", DEFAULT_ICON_NAME },
+	DwarfFemale              = { "achievement_character_dwarf_female", "inv_misc_head_dwarf_02" },
+	DwarfMale                = { "achievement_character_dwarf_male", DEFAULT_ICON_NAME },
+	GnomeFemale              = { "achievement_character_gnome_female", "inv_misc_head_gnome_02" },
+	GnomeMale                = { "achievement_character_gnome_male", "inv_misc_head_gnome_01" },
+	GoblinFemale             = { "ability_racial_rocketjump", DEFAULT_ICON_NAME },
+	GoblinMale               = { "ability_racial_rocketjump", DEFAULT_ICON_NAME },
+	HighmountainTaurenFemale = { "achievement_alliedrace_highmountaintauren", DEFAULT_ICON_NAME },
+	HighmountainTaurenMale   = { "ability_racial_bullrush", DEFAULT_ICON_NAME },
+	HumanFemale              = { "achievement_character_human_female", "inv_misc_head_human_02" },
+	HumanMale                = { "achievement_character_human_male", "ability_warrior_revenge" },
+	KulTiranFemale           = { "ability_racial_childofthesea", DEFAULT_ICON_NAME },
+	KulTiranMale             = { "achievement_boss_zuldazar_manceroy_mestrah", DEFAULT_ICON_NAME },
+	LightforgedDraeneiFemale = { "achievement_alliedrace_lightforgeddraenei", DEFAULT_ICON_NAME },
+	LightforgedDraeneiMale   = { "ability_racial_finalverdict", DEFAULT_ICON_NAME },
+	MagharOrcFemale          = { "achievement_character_orc_female_brn", DEFAULT_ICON_NAME },
+	MagharOrcMale            = { "achievement_character_orc_male_brn", DEFAULT_ICON_NAME },
+	MechagnomeFemale         = { "inv_plate_mechagnome_c_01helm", DEFAULT_ICON_NAME },
+	MechagnomeMale           = { "ability_racial_hyperorganiclightoriginator", DEFAULT_ICON_NAME },
+	NightborneFemale         = { "ability_racial_masquerade", DEFAULT_ICON_NAME },
+	NightborneMale           = { "ability_racial_dispelillusions", DEFAULT_ICON_NAME },
+	NightElfFemale           = { "achievement_character_nightelf_female", DEFAULT_ICON_NAME },
+	NightElfMale             = { "achievement_character_nightelf_male", "ability_ambush" },
+	OrcFemale                = { "achievement_character_orc_female", "inv_misc_head_orc_02" },
+	OrcMale                  = { "achievement_character_orc_male", "ability_warrior_warcry" },
+	PandarenFemale           = { "achievement_character_pandaren_female", DEFAULT_ICON_NAME },
+	PandarenMale             = { "achievement_guild_classypanda", DEFAULT_ICON_NAME },
+	ScourgeFemale            = { "achievement_character_undead_female", "inv_misc_head_undead_02" },
+	ScourgeMale              = { "achievement_character_undead_male", "inv_misc_head_undead_01" },
+	TaurenFemale             = { "achievement_character_tauren_female", "inv_misc_head_tauren_02" },
+	TaurenMale               = { "achievement_character_tauren_male", "spell_holy_blessingofstamina" },
+	TrollFemale              = { "achievement_character_troll_female", "inv_misc_head_troll_02" },
+	TrollMale                = { "achievement_character_troll_male", DEFAULT_ICON_NAME },
+	VoidElfFemale            = { "ability_racial_preturnaturalcalm", DEFAULT_ICON_NAME },
+	VoidElfMale              = { "ability_racial_entropicembrace", DEFAULT_ICON_NAME },
+	VulperaFemale            = { "ability_racial_nosefortrouble", DEFAULT_ICON_NAME },
+	VulperaMale              = { "ability_racial_nosefortrouble", DEFAULT_ICON_NAME },
+	WorgenFemale             = { "ability_racial_viciousness", DEFAULT_ICON_NAME },
+	WorgenMale               = { "achievement_worganhead", DEFAULT_ICON_NAME },
+	ZandalariTrollFemale     = { "inv_zandalarifemalehead", DEFAULT_ICON_NAME },
+	ZandalariTrollMale       = { "inv_zandalarimalehead", DEFAULT_ICON_NAME },
+
+	--
+	-- Miscellaneous Info Field Icons
+	--
+
+	MiscInfoHouse     = { "inv_misc_kingsring1", "inv_jewelry_ring_36" },
+	MiscInfoNickname  = { "ability_hunter_beastcall" },
+	MiscInfoMotto     = { "inv_inscription_scrollofwisdom_01", "inv_scroll_01" },
+	MiscInfoTraits    = { "spell_shadow_mindsteal" },
+	MiscInfoPiercings = { "inv_jewelry_ring_14" },
+	MiscInfoPronouns  = { "vas_namechange", "inv_scroll_08" },
+	MiscInfoTattoos   = { "inv_inscription_inkblack01", "inv_potion_65" },
+
+	--
+	-- Personality Trait Icons
+	--
+
+	TraitAltruistic    = { "inv_misc_gift_02" },
+	TraitAscetic       = { "inv_misc_food_pinenut", "inv_misc_coin_05" },
+	TraitBonViviant    = { "inv_misc_food_99", "inv_misc_coin_02" },
+	TraitBrutal        = { "ability_warrior_trauma", "ability_rogue_eviscerate" },
+	TraitCautious      = { "spell_shadow_brainwash", "inv_misc_pocketwatch_01" },
+	TraitChaotic       = { "ability_rogue_wrongfullyaccused", "spell_shadow_unholyfrenzy" },
+	TraitChaste        = { "inv_belt_27" },
+	TraitDeceitful     = { "ability_rogue_disguise" },
+	TraitForgiving     = { "inv_rosebouquet01" },
+	TraitGentle        = { "inv_valentinescandysack" },
+	TraitImpulsive     = { "achievement_bg_captureflag_eos", "spell_fire_incinerate" },
+	TraitLoyal         = { "ability_paladin_sanctifiedwrath", "spell_holy_righteousfury" },
+	TraitLustful       = { "spell_shadow_summonsuccubus" },
+	TraitParagon       = { "inv_misc_groupneedmore", "achievement_guildperk_havegroup willtravel" },
+	TraitRational      = { "inv_gizmo_02" },
+	TraitRenegade      = { "ability_rogue_honoramongstthieves", "ability_rogue_dualweild" },
+	TraitSelfish       = { "inv_misc_coin_02", "inv_ingot_03" },
+	TraitSpineless     = { "ability_druid_cower" },
+	TraitSuperstitious = { "spell_holy_holyguidance", "spell_holy_powerinfusion" },
+	TraitTruthful      = { "inv_misc_toy_07", "spell_holy_auraoflight" },
+	TraitValorous      = { "ability_paladin_beaconoflight", "ability_warrior_battleshout" },
+	TraitVindictive    = { "ability_hunter_snipershot" },
+
+	--
+	-- Language Icons
+	--
+
+	LanguageCommon        = { "inv_misc_tournaments_banner_human", "spell_arcane_teleportstormwind" },
+	LanguageDarnassian    = { "inv_misc_tournaments_banner_nightelf", "spell_arcane_teleportmoonglade" },
+	LanguageDemonic       = { "artifactability_havocdemonhunter_anguishofthedeceiver", DEFAULT_ICON_NAME },
+	LanguageDraconic      = { "ability_warrior_dragonroar", DEFAULT_ICON_NAME },
+	LanguageDraenei       = { "inv_misc_tournaments_banner_draenei", DEFAULT_ICON_NAME },
+	LanguageDwarvish      = { "inv_misc_tournaments_banner_dwarf", "spell_arcane_teleportironforge" },
+	LanguageForsaken      = { "inv_misc_tournaments_banner_scourge", "spell_arcane_teleportundercity" },
+	LanguageGnomish       = { "inv_misc_tournaments_banner_gnome", "inv_misc_enggizmos_01" },
+	LanguageGnomishBinary = { "inv_misc_punchcards_blue" },
+	LanguageGoblin        = { "achievement_goblinhead", DEFAULT_ICON_NAME },
+	LanguageGoblinBinary  = { "inv_misc_punchcards_blue" },
+	LanguageKalimag       = { "shaman_talent_elementalblast", DEFAULT_ICON_NAME },
+	LanguageMoonkin       = { "ability_druid_improvedmoonkinform", DEFAULT_ICON_NAME },
+	LanguageNerglish      = { "inv_pet_babymurlocs_blue", DEFAULT_ICON_NAME },
+	LanguageOrcish        = { "inv_misc_tournaments_banner_orc", "spell_arcane_teleportorgrimmar" },
+	LanguagePandaren      = { "achievement_guild_classypanda", DEFAULT_ICON_NAME },
+	LanguageShalassian    = { "achievement_alliedrace_nightborne", DEFAULT_ICON_NAME },
+	LanguageShathYar      = { "spell_priest_voidform", DEFAULT_ICON_NAME },
+	LanguageSprite        = { "inv_pet_sprite_darter_hatchling", DEFAULT_ICON_NAME },
+	LanguageTaurahe       = { "inv_misc_tournaments_banner_tauren", "spell_arcane_teleportthunderbluff" },
+	LanguageThalassian    = { "inv_misc_tournaments_banner_bloodelf", DEFAULT_ICON_NAME },
+	LanguageTitan         = { "achievement_dungeon_ulduarraid_titan_01", DEFAULT_ICON_NAME },
+	LanguageZandali       = { "inv_misc_tournaments_banner_troll", "inv_banner_01" },
+	LanguageZombie        = { "icon_petfamily_undead", DEFAULT_ICON_NAME },
+
+};
+
+--
+-- Data Initialization
+--
+
+do
+	local function GetFirstValidTexturePath(candidates, root)
+		root = root or "";
+
+		for _, path in ipairs(candidates) do
+			if GetFileIDFromPath(root .. path) then
+				return path;
+			end
+		end
+	end
+
+	for id, candidates in pairs(TRP3_InterfaceIcons) do
+		local name = GetFirstValidTexturePath(candidates, [[interface\icons\]]);
+
+		if not name and TRP3_API.globals.DEBUG_MODE then
+			CallErrorHandler(string.format("Invalid interface icon %q: No valid texture file found", id));
+		end
+
+		TRP3_InterfaceIcons[id] = name or DEFAULT_ICON_NAME;
+	end
+
+	-- Legacy compatibility: A few icons are copied to the globals table.
+	-- These usages have all been cleaned up internally, but might still be
+	-- used by Extended & co.
+
+	TRP3_API.globals.icons = {
+		default = TRP3_InterfaceIcons.Default,
+		unknown = TRP3_InterfaceIcons.Unknown,
+		profile_default = TRP3_InterfaceIcons.ProfileDefault,
+	};
+end

--- a/totalRP3/resources/InterfaceIcons.lua
+++ b/totalRP3/resources/InterfaceIcons.lua
@@ -160,7 +160,7 @@ TRP3_InterfaceIcons = {
 
 	TraitAltruistic    = { "inv_misc_gift_02" },
 	TraitAscetic       = { "inv_misc_food_pinenut", "inv_misc_coin_05" },
-	TraitBonViviant    = { "inv_misc_food_99", "inv_misc_coin_02" },
+	TraitBonVivant    = { "inv_misc_food_99", "inv_misc_coin_02" },
 	TraitBrutal        = { "ability_warrior_trauma", "ability_rogue_eviscerate" },
 	TraitCautious      = { "spell_shadow_brainwash", "inv_misc_pocketwatch_01" },
 	TraitChaotic       = { "ability_rogue_wrongfullyaccused", "spell_shadow_unholyfrenzy" },

--- a/totalRP3/resources/resources.xml
+++ b/totalRP3/resources/resources.xml
@@ -23,4 +23,5 @@
 	<Script file="musicList.lua"/>
 	<Script file="imageList.lua"/>
 	<Script file="imageList-classic.lua"/>
+	<Script file="InterfaceIcons.lua"/>
 </Ui>


### PR DESCRIPTION
This refactors all our `is_classic` checks when dealing with icon names and file paths to instead use a global table (`TRP3_InterfaceIcons`) which, when queried at runtime, associates an ID with a valid file name for an icon that's supported by the currently loaded client. All usages of icon names/paths in the addon that I've been able to find have been moved to this table.

The icons are defined as a mapping of identifiers to an array of icon file names to be checked on startup. For the first valid icon name that returns a file ID (via `GetFileIDFromPath`), we associate that identifier with the name and use it for all future lookups against the table. This allows us to not hardcode any information whatsoever about which client supports what icons, and solves the longstanding problem of having to duplicate icon file names/paths in various areas of the code.

**Note:** This work is also present in the Classic companions PR (#505) since that changes some areas which conflict; for review purposes I've put the majority of the work in this PR separately however.

Overall this significantly reduces our `is_classic` check count and should make TBC support much easier in the future - we're down to about 19 references now which are all guarding actual blocks of code instead of data.

