### PR TITLE
CI Updates for Wago addons support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 ---
 name: Pull Request
-on:   pull_request
+on: pull_request
 
 jobs:
   build:
@@ -8,9 +8,9 @@ jobs:
     steps:
       - name: Check Destination Branch
         uses: marocchino/sticky-pull-request-comment@v1.4.0
-        if:   github.base_ref == 'master'
+        if: github.base_ref == 'master'
         with:
-          message:      Warning - This pull request is targeting master.
+          message: Warning - This pull request is targeting master.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
@@ -23,17 +23,17 @@ jobs:
       - name: Run Luacheck
         uses: nebularg/actions-luacheck@v1
         with:
-          args:     --no-color -q
+          args: --no-color -q
           annotate: warning
 
       - name: Run editorconfig-checker
         uses: wow-rp-addons/actions-editorconfig-check@v1.0.1
         with:
-          args:  -no-color
+          args: -no-color
           files: $(git ls-files '*.lua' '*.sh' '*.xml' ':!:totalRP3/libs/**/*' ':!:totalRP3/tools/Locale.lua')
 
       - name: Create Retail Package
-        uses: Total-RP/packager@master
+        uses: BigWigsMods/packager@master
         with:
           args: -d -z
 
@@ -43,7 +43,7 @@ jobs:
           path: .release/
 
       - name: Create Classic Package
-        uses: Total-RP/packager@master
+        uses: BigWigsMods/packager@master
         with:
           args: -d -z -g classic
 
@@ -52,8 +52,8 @@ jobs:
           name: totalRP3-PR-${{ github.event.number }}-classic
           path: .release/
 
-      - name:  Send Webhook Notification
-        if:    failure()
+      - name: Send Webhook Notification
+        if: failure()
         run: |
           git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Create Retail Package
-        uses: janpantel/packager@add_wago_addons_target
+        uses: BigWigsMods/packager@master
         with:
           args: -p 75973 -w 24113 -a q96dnGOm
         env:
@@ -26,7 +26,7 @@ jobs:
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
       - name: Create Classic Package
-        uses: janpantel/packager@add_wago_addons_target
+        uses: BigWigsMods/packager@master
         with:
           args: -p 335857 -w 25153 -a q96dnGOm -g classic
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,23 +25,15 @@ jobs:
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
-      - name: Create Classic Package (CF/WoWI)
-        uses: nebularg/packager@custom-filename
-        with:
-          args: -p 335857 -w 25153 -g classic -n '{package-name}-{project-version}'
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
-
-      - name: Create Classic Package (GitHub/Wago)
+      - name: Create Classic Package
         uses: janpantel/packager@add_wago_addons_target
         with:
-          # -L skips upload to CF, as we need to provide the project ID/API key for fetching localizations.
-          args: -p 335857 -a q96dnGOm -g classic -L
+          args: -p 335857 -w 25153 -a q96dnGOm -g classic
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
       - name: Send Webhook Notification
         if: failure()

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -1,11 +1,14 @@
 ---
-name: Package (Release)
+# The differences between this workflow and the standard release are that no
+# upload to wowinterface occurs, since it lacks support for processing any
+#
+
+name: Package (Prerelease)
 on:
   push:
     tags:
-      - '*'
-      - '!**-alpha**'
-      - '!**-beta**'
+      - '**-alpha**'
+      - '**-beta**'
 
 jobs:
   build:
@@ -18,20 +21,18 @@ jobs:
       - name: Create Retail Package
         uses: janpantel/packager@add_wago_addons_target
         with:
-          args: -p 75973 -w 24113 -a q96dnGOm
+          args: -p 75973 -a q96dnGOm
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
       - name: Create Classic Package (CF/WoWI)
         uses: nebularg/packager@custom-filename
         with:
-          args: -p 335857 -w 25153 -g classic -n '{package-name}-{project-version}'
+          args: -p 335857 -g classic -n '{package-name}-{project-version}'
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
       - name: Create Classic Package (GitHub/Wago)
         uses: janpantel/packager@add_wago_addons_target

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -27,18 +27,10 @@ jobs:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
-      - name: Create Classic Package (CF/WoWI)
-        uses: nebularg/packager@custom-filename
-        with:
-          args: -p 335857 -g classic -n '{package-name}-{project-version}'
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-
-      - name: Create Classic Package (GitHub/Wago)
+      - name: Create Classic Package
         uses: janpantel/packager@add_wago_addons_target
         with:
-          # -L skips upload to CF, as we need to provide the project ID/API key for fetching localizations.
-          args: -p 335857 -a q96dnGOm -g classic -L
+          args: -p 335857 -a q96dnGOm -g classic
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -1,7 +1,7 @@
 ---
 # The differences between this workflow and the standard release are that no
 # upload to wowinterface occurs, since it lacks support for processing any
-#
+# alpha/beta releases separately.
 
 name: Package (Prerelease)
 on:

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
 
       - name: Create Retail Package
-        uses: janpantel/packager@add_wago_addons_target
+        uses: BigWigsMods/packager@master
         with:
           args: -p 75973 -a q96dnGOm
         env:
@@ -28,7 +28,7 @@ jobs:
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
       - name: Create Classic Package
-        uses: janpantel/packager@add_wago_addons_target
+        uses: BigWigsMods/packager@master
         with:
           args: -p 335857 -a q96dnGOm -g classic
         env:


### PR DESCRIPTION
This changeset does the following:

  - Adds the Wago project ID to our packager runs.
  - Separates the workflow for a release into two, where one handles prerelease versions. This solves us having to modify the packager to not have it upload tagged alphas/betas to WoWI.
  - Removes the renaming of the Classic .zip as this was only really relevant for one site, and causes pain if we have to go and package the addon three times.

With these changes and the necessary PRs merged into the packager, we're able to remove the need for our packager fork entirely and can use the upstream one unaltered.