### PR TITLE
Show truncated characteristic fontstrings in tooltips

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -374,6 +374,7 @@ stds.wow = {
 		"BaseMapPoiPinMixin",
 		"ChatFrame1EditBox",
 		"ChatTypeInfo",
+		"FontableFrameMixin",
 		"GameFontNormal",
 		"GameFontNormalHuge",
 		"GameFontNormalHuge3",

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -357,3 +357,46 @@ end
 --]]
 
 TRP3_BackdropTemplateMixin = CreateFromMixins(BackdropTemplateMixin or BackdropTemplatePolyfillMixin);
+
+--[[
+	TRP3_TruncatedTextMixin
+--]]
+
+TRP3_TruncatedTextMixin = CreateFromMixins(FontableFrameMixin);
+
+function TRP3_TruncatedTextMixin:OnLoad()
+	self.Text = self:CreateFontString(nil, self.fontStringLayer, self.fontStringTemplate, self.fontStringSubLayer);
+	self.Text:SetAllPoints(self);
+
+	if self.fontStringColor then
+		self.Text:SetTextColor(self.fontStringColor);
+	end
+
+	if self.fontStringJustifyH then
+		self.Text:SetJustifyH(self.fontStringJustifyH);
+	end
+
+	if self.fontStringJustifyV then
+		self.Text:SetJustifyV(self.fontStringJustifyV);
+	end
+end
+
+function TRP3_TruncatedTextMixin:GetText()
+	return self.Text:GetText();
+end
+
+function TRP3_TruncatedTextMixin:IsTruncated()
+	return self.Text:IsTruncated();
+end
+
+function TRP3_TruncatedTextMixin:SetFormattedText(format, ...)
+	return self.Text:SetFormattedText(format, ...)
+end
+
+function TRP3_TruncatedTextMixin:SetText(text)
+	return self.Text:SetText(text);
+end
+
+--[[override]] function TRP3_TruncatedTextMixin:OnFontObjectUpdated()
+	self.Text:SetFontObject(self:GetFontObject());
+end

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -19,7 +19,7 @@
 		limitations under the License.
 	-->
 
-	<Script file="widgets.lua"/>
+	<Include file="widgets.lua"/>
 
 	<!--
 		BackdropFrameTemplate
@@ -179,6 +179,27 @@
 			<OnHide>
 				MSA_CloseDropDownMenus();
 			</OnHide>
+		</Scripts>
+	</Frame>
+
+	<!--
+		TRP3_TruncatedTextTemplate
+
+		Fontable frame template that displays a tooltip for its contents if
+		they would be truncated.
+	-->
+
+	<Frame name="TRP3_TruncatedTextTemplate" virtual="true" inherits="TruncatedTooltipScriptTemplate" mixin="TRP3_TruncatedTextMixin" motionScriptsWhileDisabled="true">
+		<KeyValues>
+			<KeyValue key="fontStringLayer" value="OVERLAY"/>
+			<KeyValue key="fontStringTemplate" value="GameFontNormal"/>
+			<KeyValue key="fontStringSublayer" value="0" type="number"/>
+			<!-- <KeyValue key="fontStringColor" value="NORMAL_FONT_COLOR" type="global"/> -->
+			<!-- <KeyValue key="fontStringJustifyH" value="CENTER"/> -->
+			<!-- <KeyValue key="fontStringJustifyV" value="MIDDLE"/> -->
+		</KeyValues>
+		<Scripts>
+			<OnLoad method="OnLoad" inherit="prepend"/>
 		</Scripts>
 	</Frame>
 

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -250,7 +250,15 @@ local CHAR_KEYS = { "RA", "CL", "AG", "EC", "HE", "WE", "BP", "RE", "RS" };
 local FIELD_TITLE_SCALE = 0.3;
 
 local function scaleField(field, containerSize, fieldName)
-	_G[field:GetName() .. (fieldName or "FieldName")]:SetSize(containerSize * FIELD_TITLE_SCALE, 18);
+	local widget;
+
+	if fieldName then
+		widget = _G[field:GetName() .. fieldName];
+	else
+		widget = field.Name;
+	end
+
+	widget:SetSize(containerSize * FIELD_TITLE_SCALE, 18);
 end
 
 -- Create the pin template, above group members
@@ -349,20 +357,21 @@ local function setConsultDisplay(context)
 		frame:ClearAllPoints();
 		frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 10);
 		frame:SetPoint("RIGHT", 0, 0);
-		_G[frame:GetName() .. "FieldName"]:SetText(loc:GetText(registerCharLocals[charName]));
+		frame.Icon:Hide();
+		frame.Name:SetText(loc:GetText(registerCharLocals[charName]));
 		if charName == "EC" then
 			local hexa = dataTab.EH or "ffffff"
-			_G[frame:GetName() .. "FieldValue"]:SetText("|cff" .. hexa .. shownValues[charName] .. "|r");
+			frame.Value:SetText("|cff" .. hexa .. shownValues[charName] .. "|r");
 		elseif charName == "CL" then
 			local hexa = dataTab.CH or "ffffff";
-			_G[frame:GetName() .. "FieldValue"]:SetText("|cff" .. hexa .. shownValues[charName] .. "|r");
+			frame.Value:SetText("|cff" .. hexa .. shownValues[charName] .. "|r");
 		else
-			_G[frame:GetName() .. "FieldValue"]:SetText(shownValues[charName]);
+			frame.Value:SetText(shownValues[charName]);
 		end
 		if charName == "RE" and dataTab.RC and # dataTab.RC >= 4 then
 			TRP3_RegisterCharact_CharactPanel_ResidenceButton:Show();
 			TRP3_RegisterCharact_CharactPanel_ResidenceButton:ClearAllPoints();
-			TRP3_RegisterCharact_CharactPanel_ResidenceButton:SetPoint("RIGHT", frame:GetName() .. "FieldValue", "LEFT", -5, 0);
+			TRP3_RegisterCharact_CharactPanel_ResidenceButton:SetPoint("RIGHT", frame.Value, "LEFT", -5, 0);
 			setTooltipForSameFrame(TRP3_RegisterCharact_CharactPanel_ResidenceButton, "RIGHT", 0, 5, loc.REG_PLAYER_RESIDENCE_SHOW, loc.REG_PLAYER_RESIDENCE_SHOW_TT:format(dataTab.RC[4]));
 			TRP3_RegisterCharact_CharactPanel_ResidenceButton:SetScript("OnClick", function()
 				if TRP3_API.globals.is_classic then
@@ -411,8 +420,9 @@ local function setConsultDisplay(context)
 			frame:ClearAllPoints();
 			frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 7);
 			frame:SetPoint("RIGHT", 0, 0);
-			_G[frame:GetName() .. "FieldName"]:SetText(strconcat(Utils.str.icon(miscStructure.IC, 18), " ", miscStructure.NA or ""));
-			_G[frame:GetName() .. "FieldValue"]:SetText(miscStructure.VA or "");
+			frame.Icon:SetTexture([[interface\icons\]] .. miscStructure.IC);
+			frame.Name:SetText(miscStructure.NA or "");
+			frame.Value:SetText(miscStructure.VA or "");
 			frame:Show();
 			previous = frame;
 		end

--- a/totalRP3/modules/register/characters/register_ui_characteristics.xml
+++ b/totalRP3/modules/register/characters/register_ui_characteristics.xml
@@ -362,24 +362,38 @@
 	<Frame name="TRP3_RegisterCharact_RegisterInfoLine" virtual="true">
 		<Size x="0" y="30"/>
 		<Layers>
-			<Layer level="OVERLAY">
-				<FontString name="$parentFieldName" inherits="GameFontNormal" justifyH="LEFT" text="[Field]">
-					<Size x="135" y="10"/>
+			<Layer level="ARTWORK">
+				<Texture parentKey="Icon" file="Interface\ICONS\INV_Misc_QuestionMark">
+					<Size x="16" y="16"/>
 					<Anchors>
-						<Anchor point="LEFT" x="25" y="0"/>
+						<Anchor point="LEFT" x="15" y="0"/>
 					</Anchors>
-					<Color r="0.95" g="0.75" b="0.10"/>
-				</FontString>
-				<FontString name="$parentFieldValue" inherits="GameFontNormal" justifyH="LEFT" text="[Value]">
-					<Size x="0" y="10"/>
-					<Anchors>
-						<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="$parentFieldName"/>
-						<Anchor point="RIGHT" x="0" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
+				</Texture>
 			</Layer>
 		</Layers>
+		<Frames>
+			<Frame parentKey="Name" inherits="TRP3_TruncatedTextTemplate">
+				<KeyValues>
+					<KeyValue key="fontStringTemplate" value="GameFontNormal"/>
+					<KeyValue key="fontStringJustifyH" value="LEFT"/>
+				</KeyValues>
+				<Size x="135" y="10"/>
+				<Anchors>
+					<Anchor point="LEFT" x="35" y="0"/>
+				</Anchors>
+			</Frame>
+			<Frame parentKey="Value" inherits="TRP3_TruncatedTextTemplate">
+				<KeyValues>
+					<KeyValue key="fontStringTemplate" value="GameFontHighlight"/>
+					<KeyValue key="fontStringJustifyH" value="LEFT"/>
+				</KeyValues>
+				<Size x="0" y="10"/>
+				<Anchors>
+					<Anchor point="LEFT" relativeKey="$parent.Name" relativePoint="RIGHT" x="15" y="0"/>
+					<Anchor point="RIGHT" x="0" y="0"/>
+				</Anchors>
+			</Frame>
+		</Frames>
 	</Frame>
 
 	<!-- Register characteristics panel -->


### PR DESCRIPTION
Fixes #379, somewhat.

This modifies the fontstrings displayed in the characteristics tab under both the "directory information" and "additional information" sections to, if their contents are truncated, display them in a tooltip on hover.

![image](https://user-images.githubusercontent.com/287102/111093506-09d86380-8531-11eb-86d7-1571cca062e5.png)
![image](https://user-images.githubusercontent.com/287102/111093510-0d6bea80-8531-11eb-95b3-bf21d3d785b6.png)


This largely just reuses the existing stuff in the Blizzard UI to do so, but I've added a new TRP3_TruncatedTextTemplate which is a generic frame that can be used in place of a fontstring to enable this behaviour elsewhere if needed in the future.