### PR TITLE
Fix lack of sound cue when opening main window

### DIFF
--- a/totalRP3/core/impl/main_structure.lua
+++ b/totalRP3/core/impl/main_structure.lua
@@ -292,13 +292,13 @@ TRP3_API.navigation.page.getCurrentPageID = getCurrentPageID;
 TRP3_API.navigation.openMainFrame = function()
 	TRP3_MainFrame:Show();
 	TRP3_MainFrame:Raise();
-	TRP3_API.ui.misc.playUISound(SOUNDKIT.ACHIEVEMENT_MENU_OPEN);
+	TRP3_API.ui.misc.playUISound(TRP3_API.globals.is_classic and SOUNDKIT.IG_CHARACTER_INFO_TAB or SOUNDKIT.ACHIEVEMENT_MENU_OPEN);
 end
 
 local function switchMainFrame()
 	if TRP3_MainFrame:IsVisible() then
 		TRP3_MainFrame:Hide();
-		TRP3_API.ui.misc.playUISound(SOUNDKIT.ACHIEVEMENT_MENU_CLOSE);
+		TRP3_API.ui.misc.playUISound(TRP3_API.globals.is_classic and SOUNDKIT.IG_MAINMENU_CLOSE or SOUNDKIT.ACHIEVEMENT_MENU_CLOSE);
 	else
 		TRP3_API.navigation.openMainFrame();
 	end


### PR DESCRIPTION
Blizzard actually has a bunch of non-existent file IDs in the SOUNDKIT table, so nothing was explicitly broken but the sounds that play when opening the main window didn't work in Classic.

This is a quick fix; we'll do something similar to the interface icon work to fix these throughout the addon some other time.