### PR TITLE
Hide default profile character count

### DIFF
--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -219,22 +219,27 @@ local function decorateProfileList(widget, index)
 			i = i + 1;
 		end
 	end
-	_G[widget:GetName().."Count"]:SetText(loc.PR_PROFILEMANAGER_COUNT:format(i));
-
-	local text = "";
-	if i > 0 then
-		text = text..loc.PR_PROFILE_DETAIL..":\n"..listText;
-	else
-		text = text..loc.PR_UNUSED_PROFILE;
-	end
 
 	if id == getConfigValue("default_profile_id") then
+		_G[widget:GetName().."Info"]:Hide();
+		_G[widget:GetName().."Count"]:Hide();
 		_G[widget:GetName().."Action"]:Hide();
 	else
+		_G[widget:GetName().."Info"]:Show();
+		_G[widget:GetName().."Count"]:Show();
 		_G[widget:GetName().."Action"]:Show();
-	end
 
-	setTooltipForSameFrame(_G[widget:GetName().."Info"], "RIGHT", 0, 0, loc.PR_PROFILE, text);
+		_G[widget:GetName().."Count"]:SetText(loc.PR_PROFILEMANAGER_COUNT:format(i));
+
+		local text = "";
+		if i > 0 then
+			text = text..loc.PR_PROFILE_DETAIL..":\n"..listText;
+		else
+			text = text..loc.PR_UNUSED_PROFILE;
+		end
+
+		setTooltipForSameFrame(_G[widget:GetName().."Info"], "RIGHT", 0, 0, loc.PR_PROFILE, text);
+	end
 end
 
 local function profileSortingByProfileName(profileID1, profileID2)


### PR DESCRIPTION
I considered removing the default profile count while making the feature but kept it in thinking it wouldn't really matter. Turns out some people are complaining about the count being incorrect when characters are deleted, so we'll hide it.