### PR TITLE
Don't answer scans while PvP flagged in Classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Fixed an issue with chat customization not properly registering on login while using Prat.
 - Fixed missing sound cue when opening/closing the main window.
-
+- Fixed an issue that could cause PvP flagged players to show their location on map scans in Classic.
 
 # Changelog version 2.2
 

--- a/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/modules/register/characters/PlayerMapScan/PlayerMapScanner.lua
@@ -50,7 +50,7 @@ local function shouldAnswerToLocationRequest()
 	end
 	if getConfigValue(CONFIG_DISABLE_MAP_LOCATION_ON_WAR_MODE) then
 		if TRP3_API.globals.is_classic then
-			return UnitIsPVP("player");
+			return not UnitIsPVP("player");
 		elseif C_PvP.IsWarModeActive() then
 			return GetZonePVPInfo() == "sanctuary"
 		end


### PR DESCRIPTION
The "Disable location when flagged for PvP" option has been lying on Classic this whole time and was more a giant "PLEASE SHOW ME ON THE MAP PRETTY PLEASE I BEG OF YOU" setting the whole time.
