### PR TITLE
Nameplate Tweaks 2: Electric Boogaloo

### DIFF
--- a/totalRP3/modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Core.lua
@@ -424,7 +424,7 @@ function TRP3_NamePlates:UpdateNamePlateForRegisterID(registerID)
 end
 
 function TRP3_NamePlates:ShouldRequestProfileFromCharacter(characterID)
-	local REQUEST_WAIT_SEC = 60;
+	local REQUEST_WAIT_SEC = 90;
 
 	local lastRequestTime = self.characterRequestTimes[characterID] or -math.huge;
 


### PR DESCRIPTION
Not planning any more feature changes so these will just be bugfixes and performance tweaks that should be safe without another beta.

- [x] Reduced memory usage under certain nameplate visibility configurations.
- [x] Increased throttling of requests generated by nameplates.