### PR TITLE
Focus editor text box after formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - The URL copy window now closes after pressing the copy shortcut.
 - The default profile no longer shows the amount of characters bound to it.
 - Cropped characteristic fields will now show a tooltip on hover with the full content of the field.
+- The description editor will now receive input focus after clicking any formatting tool button.
 
 ## Fixed
 

--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -860,6 +860,7 @@ end
 local function postInsertHighlight(index, tagSize, textSize, frame)
 	frame:SetCursorPosition(index + tagSize + textSize);
 	frame:HighlightText(index + tagSize, index + tagSize + textSize);
+	frame:SetFocus();
 end
 
 local function insertContainerTag(alignIndex, button, frame)
@@ -875,6 +876,7 @@ local function onColorTagSelected(red, green, blue, frame)
 	local tag = ("{col:%s}"):format(strconcat(numberToHexa(red), numberToHexa(green), numberToHexa(blue)));
 	insertTag(tag .. "{/col}", cursorIndex, frame);
 	frame:SetCursorPosition(cursorIndex + tag:len());
+	frame:SetFocus();
 end
 
 local function onIconTagSelected(icon, frame)
@@ -882,6 +884,7 @@ local function onIconTagSelected(icon, frame)
 	local tag = ("{icon:%s:25}"):format(icon);
 	insertTag(tag, cursorIndex, frame);
 	frame:SetCursorPosition(cursorIndex + tag:len());
+	frame:SetFocus();
 end
 
 local function onImageTagSelected(image, frame)
@@ -889,6 +892,7 @@ local function onImageTagSelected(image, frame)
 	local tag = ("{img:%s:%s:%s}"):format(image.url, math.min(image.width, 512), math.min(image.height, 512));
 	insertTag(tag, cursorIndex, frame);
 	frame:SetCursorPosition(cursorIndex + tag:len());
+	frame:SetFocus();
 end
 
 local function onLinkTagClicked(frame)
@@ -897,6 +901,7 @@ local function onLinkTagClicked(frame)
 	insertTag(tag, cursorIndex, frame);
 	frame:SetCursorPosition(cursorIndex + 6);
 	frame:HighlightText(cursorIndex + 6, cursorIndex + 6 + loc.UI_LINK_URL:len());
+	frame:SetFocus();
 end
 
 -- Drop down


### PR DESCRIPTION
When clicking a format toolbar button to insert a color or icon we'd put the cursor at the correct position for editing, but wouldn't give focus to the frame - so users still had to click back into it manually.