### PR TITLE
Apply custom bar color to personality trait names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The default profile no longer shows the amount of characters bound to it.
 - Cropped characteristic fields will now show a tooltip on hover with the full content of the field.
 - The description editor will now receive input focus after clicking any formatting tool button.
+- Custom colors for personality traits now apply to attribute names.
 
 ## Fixed
 

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -448,8 +448,23 @@ local function setConsultDisplay(context)
 			frame:ClearAllPoints();
 			frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 0);
 			frame:SetPoint("RIGHT", 0, 0);
-			frame.LeftText:SetText(psychoStructure.LT or "");
-			frame.RightText:SetText(psychoStructure.RT or "");
+
+			-- Applying custom colors to attribute names (with contrast adjustment for readability)
+			local leftText = psychoStructure.LT or "";
+			if psychoStructure.LC then
+				local leftTextColor = Ellyb.Color(psychoStructure.LC);
+				leftTextColor:LightenColorUntilItIsReadableOnDarkBackgrounds();
+				leftText = leftTextColor:WrapTextInColorCode(leftText);
+			end
+			local rightText = psychoStructure.RT or "";
+			if psychoStructure.RC then
+				local rightTextColor = Ellyb.Color(psychoStructure.RC);
+				rightTextColor:LightenColorUntilItIsReadableOnDarkBackgrounds();
+				rightText = rightTextColor:WrapTextInColorCode(rightText);
+			end
+
+			frame.LeftText:SetText(leftText);
+			frame.RightText:SetText(rightText);
 
 			frame.LeftIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.LI or TRP3_InterfaceIcons.Default));
 			frame.RightIcon:SetTexture("Interface\\ICONS\\" .. (psychoStructure.RI or TRP3_InterfaceIcons.Default));


### PR DESCRIPTION
When an attribute has a custom color selected, the color will now be applied to the attribute name as well. Contrast is improved by default to make the trait names more readable on the characteristics page dark background.