### PR TITLE
Fix sex-based unit textures

### DIFF
--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -821,7 +821,7 @@ end
 
 TRP3_API.ui.misc.getUnitTexture = function(race, gender)
 	local raceToken = race;
-	local genderToken = (gender == 2) and "Female" or "Male";
+	local genderToken = (gender == 3) and "Female" or "Male";
 
 	return TRP3_InterfaceIcons[raceToken .. genderToken] or TRP3_InterfaceIcons.Default;
 end


### PR DESCRIPTION
UnitSex returns 3 for female, I'd based it as being 2 based off C_PlayerInfo.GetSex.