### PR TITLE
Added unit popup module settings

### DIFF
--- a/totalRP3/modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/modules/UnitPopups/UnitPopups.lua
@@ -17,6 +17,8 @@
 local TRP3_API = select(2, ...);
 local L = TRP3_API.loc;
 
+local GenerateConfigurationPage;
+
 local function ShouldDisableOutOfCharacter()
 	return TRP3_API.configuration.getValue("UnitPopups_DisableOutOfCharacter");
 end
@@ -63,7 +65,7 @@ function UnitPopupsModule:OnModuleInitialize()
 		TRP3_API.configuration.registerConfigKey(setting.key, setting.default);
 	end
 
-	TRP3_API.configuration.registerConfigurationPage(UnitPopupsModule.ConfigurationPage);
+	TRP3_API.configuration.registerConfigurationPage(GenerateConfigurationPage());
 end
 
 function UnitPopupsModule:OnModuleEnable()
@@ -274,82 +276,84 @@ UnitPopupsModule.Configuration = {
 	},
 };
 
-UnitPopupsModule.ConfigurationPage = {
-	id = "main_config_unitpopups",
-	menuText = L.UNIT_POPUPS_CONFIG_MENU_TITLE,
-	pageText = L.UNIT_POPUPS_CONFIG_PAGE_TEXT,
-	elements = {
-		{
-			inherit = "TRP3_ConfigParagraph",
-			title = L.UNIT_POPUPS_CONFIG_PAGE_HELP,
+function GenerateConfigurationPage()
+	return {
+		id = "main_config_unitpopups",
+		menuText = L.UNIT_POPUPS_CONFIG_MENU_TITLE,
+		pageText = L.UNIT_POPUPS_CONFIG_PAGE_TEXT,
+		elements = {
+			{
+				inherit = "TRP3_ConfigParagraph",
+				title = L.UNIT_POPUPS_CONFIG_PAGE_HELP,
+			},
+			{
+				inherit = "TRP3_ConfigButton",
+				title = L.UNIT_POPUPS_CONFIG_ENABLE_MODULE,
+				text = DISABLE,
+				OnClick = function()
+					TRP3_API.popup.showConfirmPopup(L.UNIT_POPUPS_MODULE_DISABLE_WARNING, function()
+						local current = TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"];
+						TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"] = not current;
+						ReloadUI();
+					end);
+				end,
+			},
+			{
+				inherit = "TRP3_ConfigH1",
+				title = L.UNIT_POPUPS_CONFIG_VISIBILITY_HEADER,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER,
+				help = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP,
+				configKey = "UnitPopups_DisableOutOfCharacter",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT,
+				help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP,
+				configKey = "UnitPopups_DisableInCombat",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES,
+				help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP,
+				configKey = "UnitPopups_DisableInInstances",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES,
+				help = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP,
+				configKey = "UnitPopups_DisableOnUnitFrames",
+			},
+			{
+				inherit = "TRP3_ConfigH1",
+				title = L.UNIT_POPUPS_CONFIG_ENTRIES_HEADER,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT,
+				help = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP,
+				configKey = "UnitPopups_ShowHeaderText",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR,
+				help = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP,
+				configKey = "UnitPopups_ShowSeparator",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE,
+				help = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP,
+				configKey = "UnitPopups_ShowOpenProfile",
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS,
+				help = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP,
+				configKey = "UnitPopups_ShowCharacterStatus",
+			},
 		},
-		{
-			inherit = "TRP3_ConfigButton",
-			title = L.UNIT_POPUPS_CONFIG_ENABLE_MODULE,
-			text = DISABLE,
-			OnClick = function()
-				TRP3_API.popup.showConfirmPopup(L.UNIT_POPUPS_MODULE_DISABLE_WARNING, function()
-					local current = TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"];
-					TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"] = not current;
-					ReloadUI();
-				end);
-			end,
-		},
-		{
-			inherit = "TRP3_ConfigH1",
-			title = L.UNIT_POPUPS_CONFIG_VISIBILITY_HEADER,
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER,
-			help = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP,
-			configKey = "UnitPopups_DisableOutOfCharacter",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT,
-			help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP,
-			configKey = "UnitPopups_DisableInCombat",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES,
-			help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP,
-			configKey = "UnitPopups_DisableInInstances",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES,
-			help = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP,
-			configKey = "UnitPopups_DisableOnUnitFrames",
-		},
-		{
-			inherit = "TRP3_ConfigH1",
-			title = L.UNIT_POPUPS_CONFIG_ENTRIES_HEADER,
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT,
-			help = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP,
-			configKey = "UnitPopups_ShowHeaderText",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR,
-			help = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP,
-			configKey = "UnitPopups_ShowSeparator",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE,
-			help = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP,
-			configKey = "UnitPopups_ShowOpenProfile",
-		},
-		{
-			inherit = "TRP3_ConfigCheck",
-			title = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS,
-			help = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP,
-			configKey = "UnitPopups_ShowCharacterStatus",
-		},
-	},
-};
+	};
+end

--- a/totalRP3/modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/modules/UnitPopups/UnitPopups.lua
@@ -149,7 +149,7 @@ local function OpenProfile(button)  -- luacheck: ignore 212 (unused button)
 	local server = dropdownFrame.server;
 	local fullName = string.join("-", name or UNKNOWNOBJECT, server or GetNormalizedRealmName());
 
-	if UnitExists(unit) and false then
+	if UnitExists(unit) then
 		TRP3_API.slash.openProfile(unit);
 	elseif not string.find(fullName, UNKNOWNOBJECT, 1, true) then
 		TRP3_API.slash.openProfile(fullName);

--- a/totalRP3/modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/modules/UnitPopups/UnitPopups.lua
@@ -17,6 +17,18 @@
 local TRP3_API = select(2, ...);
 local L = TRP3_API.loc;
 
+local function ShouldDisableOutOfCharacter()
+	return TRP3_API.configuration.getValue("UnitPopups_DisableOutOfCharacter");
+end
+
+local function ShouldDisableInCombat()
+	return TRP3_API.configuration.getValue("UnitPopups_DisableInCombat");
+end
+
+local function ShouldDisableInInstances()
+	return TRP3_API.configuration.getValue("UnitPopups_DisableInInstances");
+end
+
 local function ShouldShowHeaderText()
 	return TRP3_API.configuration.getValue("UnitPopups_ShowHeaderText");
 end
@@ -55,7 +67,7 @@ function UnitPopupsModule:OnModuleEnable()
 end
 
 function UnitPopupsModule:OnUnitPopupShown(dropdownMenu, menuType)
-	if not dropdownMenu or not self.MenuEntries[menuType] then
+	if not dropdownMenu or not self.MenuEntries[menuType] or not self:ShouldCustomizeMenus() then
 		return;
 	end
 
@@ -94,6 +106,20 @@ function UnitPopupsModule:OnUnitPopupShown(dropdownMenu, menuType)
 
 	for _, button in ipairs(buttons) do
 		UIDropDownMenu_AddButton(button, UIDROPDOWNMENU_MENU_LEVEL);
+	end
+end
+
+function UnitPopupsModule:ShouldCustomizeMenus()
+	local player = AddOn_TotalRP3.Player.GetCurrentUser();
+
+	if ShouldDisableOutOfCharacter() and not player:IsInCharacter() then
+		return false;
+	elseif ShouldDisableInCombat() and InCombatLockdown() then
+		return false;
+	elseif ShouldDisableInInstances() and IsInInstance() then
+		return false;
+	else
+		return true;
 	end
 end
 
@@ -208,6 +234,21 @@ TRP3_API.module.registerModule({
 --
 
 UnitPopupsModule.Configuration = {
+	DisableOutOfCharacter = {
+		key = "UnitPopups_DisableOutOfCharacter",
+		default = false,
+	},
+
+	DisableInCombat = {
+		key = "UnitPopups_DisableInCombat",
+		default = false,
+	},
+
+	DisableInInstances = {
+		key = "UnitPopups_DisableInInstances",
+		default = false,
+	},
+
 	ShowHeaderText = {
 		key = "UnitPopups_ShowHeaderText",
 		default = true,
@@ -249,6 +290,28 @@ UnitPopupsModule.ConfigurationPage = {
 					ReloadUI();
 				end);
 			end,
+		},
+		{
+			inherit = "TRP3_ConfigH1",
+			title = L.UNIT_POPUPS_CONFIG_VISIBILITY_HEADER,
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER,
+			help = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP,
+			configKey = "UnitPopups_DisableOutOfCharacter",
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT,
+			help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP,
+			configKey = "UnitPopups_DisableInCombat",
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES,
+			help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP,
+			configKey = "UnitPopups_DisableInInstances",
 		},
 		{
 			inherit = "TRP3_ConfigH1",

--- a/totalRP3/modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/modules/UnitPopups/UnitPopups.lua
@@ -17,6 +17,22 @@
 local TRP3_API = select(2, ...);
 local L = TRP3_API.loc;
 
+local function ShouldShowHeaderText()
+	return TRP3_API.configuration.getValue("UnitPopups_ShowHeaderText");
+end
+
+local function ShouldShowSeparator()
+	return TRP3_API.configuration.getValue("UnitPopups_ShowSeparator");
+end
+
+local function ShouldShowOpenProfile()
+	return TRP3_API.configuration.getValue("UnitPopups_ShowOpenProfile");
+end
+
+local function ShouldShowCharacterStatus()
+	return TRP3_API.configuration.getValue("UnitPopups_ShowCharacterStatus");
+end
+
 --
 -- Unit Popups Module
 --
@@ -26,7 +42,15 @@ local UnitPopupsModule = {};
 UnitPopupsModule.MenuButtons = {};
 UnitPopupsModule.MenuEntries = {};
 
-function UnitPopupsModule:Init()
+function UnitPopupsModule:OnModuleInitialize()
+	for _, setting in pairs(UnitPopupsModule.Configuration) do
+		TRP3_API.configuration.registerConfigKey(setting.key, setting.default);
+	end
+
+	TRP3_API.configuration.registerConfigurationPage(UnitPopupsModule.ConfigurationPage);
+end
+
+function UnitPopupsModule:OnModuleEnable()
 	hooksecurefunc("UnitPopup_ShowMenu", function(...) return self:OnUnitPopupShown(...); end);
 end
 
@@ -52,13 +76,73 @@ function UnitPopupsModule:OnUnitPopupShown(dropdownMenu, menuType)
 	-- as the Raider.IO addon which itself also adds unit menu options with
 	-- its own separator.
 
-	if UIDROPDOWNMENU_MENU_LEVEL == 1 then
-		UIDropDownMenu_AddSeparator();
-		UIDropDownMenu_AddButton(self.MenuButtons.RoleplayOptions);
+	local buttons = self:GetButtonsForMenu(menuType);
+
+	if #buttons == 0 then
+		return;
 	end
 
+	if UIDROPDOWNMENU_MENU_LEVEL == 1 then
+		if ShouldShowSeparator() then
+			UIDropDownMenu_AddSeparator();
+		end
+
+		if ShouldShowHeaderText() then
+			UIDropDownMenu_AddButton(self.MenuButtons.RoleplayOptions);
+		end
+	end
+
+	for _, button in ipairs(buttons) do
+		UIDropDownMenu_AddButton(button, UIDROPDOWNMENU_MENU_LEVEL);
+	end
+end
+
+function UnitPopupsModule:GetButtonsForMenu(menuType)
+	local buttons = {};
+
 	for _, buttonId in ipairs(self.MenuEntries[menuType]) do
-		UIDropDownMenu_AddButton(self.MenuButtons[buttonId], UIDROPDOWNMENU_MENU_LEVEL);
+		local button = self.MenuButtons[buttonId];
+
+		if button:ShouldShow() then
+			table.insert(buttons, button);
+		end
+	end
+
+	return buttons;
+end
+
+--
+-- Menu Commands
+--
+
+local function OpenProfile(button)  -- luacheck: ignore 212 (unused button)
+	local dropdownFrame = UIDROPDOWNMENU_INIT_MENU;
+	local unit = dropdownFrame.unit;
+	local name = dropdownFrame.name;
+	local server = dropdownFrame.server;
+	local fullName = string.join("-", name or UNKNOWNOBJECT, server or GetNormalizedRealmName());
+
+	if UnitExists(unit) and false then
+		TRP3_API.slash.openProfile(unit);
+	elseif not string.find(fullName, UNKNOWNOBJECT, 1, true) then
+		TRP3_API.slash.openProfile(fullName);
+	end
+end
+
+local function IsOutOfCharacter(button)  -- luacheck: ignore 212 (unused button)
+	local player = AddOn_TotalRP3.Player.GetCurrentUser();
+	local roleplayStatus = player:GetRoleplayStatus();
+
+	return roleplayStatus == AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER;
+end
+
+local function ToggleCharacterStatus(button)
+	local player = AddOn_TotalRP3.Player.GetCurrentUser();
+
+	if button.checked() then
+		player:SetRoleplayStatus(AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.IN_CHARACTER);
+	else
+		player:SetRoleplayStatus(AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER);
 	end
 end
 
@@ -77,19 +161,8 @@ Mixin(UnitPopupsModule.MenuButtons, {
 	OpenProfile = {
 		text = L.UNIT_POPUPS_OPEN_PROFILE,
 		notCheckable = true,
-		func = function()
-			local dropdownFrame = UIDROPDOWNMENU_INIT_MENU;
-			local unit = dropdownFrame.unit;
-			local name = dropdownFrame.name;
-			local server = dropdownFrame.server;
-			local fullName = string.join("-", name or UNKNOWNOBJECT, server or GetNormalizedRealmName());
-
-			if UnitExists(unit) and false then
-				TRP3_API.slash.openProfile(unit);
-			elseif not string.find(fullName, UNKNOWNOBJECT, 1, true) then
-				TRP3_API.slash.openProfile(fullName);
-			end
-		end,
+		func = OpenProfile,
+		ShouldShow = ShouldShowOpenProfile,
 	},
 
 	CharacterStatus = {
@@ -97,21 +170,9 @@ Mixin(UnitPopupsModule.MenuButtons, {
 		notCheckable = false,
 		isNotRadio = true,
 		keepShownOnClick = true,
-		checked = function()
-			local player = AddOn_TotalRP3.Player.GetCurrentUser();
-			local roleplayStatus = player:GetRoleplayStatus();
-
-			return roleplayStatus == AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER;
-		end,
-		func = function(button)
-			local player = AddOn_TotalRP3.Player.GetCurrentUser();
-
-			if button.checked() then
-				player:SetRoleplayStatus(AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.IN_CHARACTER);
-			else
-				player:SetRoleplayStatus(AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER);
-			end
-		end,
+		checked = IsOutOfCharacter,
+		func = ToggleCharacterStatus,
+		ShouldShow = ShouldShowCharacterStatus,
 	},
 });
 
@@ -138,5 +199,84 @@ TRP3_API.module.registerModule({
 	description = L.UNIT_POPUPS_MODULE_DESCRIPTION,
 	version = 1,
 	minVersion = 92,
-	onStart = function() UnitPopupsModule:Init(); end,
+	onInit = function() UnitPopupsModule:OnModuleInitialize(); end,
+	onStart = function() UnitPopupsModule:OnModuleEnable(); end,
 });
+
+--
+-- Configuration Data
+--
+
+UnitPopupsModule.Configuration = {
+	ShowHeaderText = {
+		key = "UnitPopups_ShowHeaderText",
+		default = true,
+	},
+
+	ShowSeparator = {
+		key = "UnitPopups_ShowSeparator",
+		default = true,
+	},
+
+	ShowOpenProfile = {
+		key = "UnitPopups_ShowOpenProfile",
+		default = true,
+	},
+
+	ShowCharacterStatus = {
+		key = "UnitPopups_ShowCharacterStatus",
+		default = true,
+	},
+};
+
+UnitPopupsModule.ConfigurationPage = {
+	id = "main_config_unitpopups",
+	menuText = L.UNIT_POPUPS_CONFIG_MENU_TITLE,
+	pageText = L.UNIT_POPUPS_CONFIG_PAGE_TEXT,
+	elements = {
+		{
+			inherit = "TRP3_ConfigParagraph",
+			title = L.UNIT_POPUPS_CONFIG_PAGE_HELP,
+		},
+		{
+			inherit = "TRP3_ConfigButton",
+			title = L.UNIT_POPUPS_CONFIG_ENABLE_MODULE,
+			text = DISABLE,
+			OnClick = function()
+				TRP3_API.popup.showConfirmPopup(L.UNIT_POPUPS_MODULE_DISABLE_WARNING, function()
+					local current = TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"];
+					TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"] = not current;
+					ReloadUI();
+				end);
+			end,
+		},
+		{
+			inherit = "TRP3_ConfigH1",
+			title = L.UNIT_POPUPS_CONFIG_ENTRIES_HEADER,
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT,
+			help = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP,
+			configKey = "UnitPopups_ShowHeaderText",
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR,
+			help = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP,
+			configKey = "UnitPopups_ShowSeparator",
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE,
+			help = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP,
+			configKey = "UnitPopups_ShowOpenProfile",
+		},
+		{
+			inherit = "TRP3_ConfigCheck",
+			title = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS,
+			help = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP,
+			configKey = "UnitPopups_ShowCharacterStatus",
+		},
+	},
+};

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1562,6 +1562,13 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP = "If checked, adds a checkbox to your own unit frame menu that allows you to toggle your in-character/out-of-character status.",
 	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE = "Show open profile button",
 	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP = "If checked, adds a button that opens the selected units' RP profile when clicked.|n|nThis option will be visible on all unit frame and chat menus.",
+	UNIT_POPUPS_CONFIG_VISIBILITY_HEADER = "Visibility options",
+	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER = "Hide menu entries while out of character",
+	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP = "If checked, additional menu entries will not be shown while out-of-character.",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT = "Hide menu entries while in combat",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP = "If checked, additional menu entries will not be shown while in combat.",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES = "Hide menu entries while in instances",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP = "If checked, additional menu entries will not be shown while in instanced content.",
 
 };
 

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1476,11 +1476,6 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 
 ]],
 
-	------------------------------------------------------------------------------------------------
-	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
-	--- THEN MOVE IT UP ONCE IMPORTED
-	------------------------------------------------------------------------------------------------
-
 	COPY_DROPDOWN_POPUP_TEXT = "Copy with %1$s. Paste with %2$s.\nThis frame will close upon copy.",
 	REG_LIST_CHAR_NAME_COPY = "Copy character name",
 	COPY_SYSTEM_MESSAGE = "Copied to clipboard.",
@@ -1547,6 +1542,27 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	KUI_NAMEPLATES_WARN_OUTDATED_MODULE = "The Kui |cff9966ffNameplates|r plugin for Total RP 3 has been integrated directly into the main addon.|n|nThe old plugin has been disabled automatically, and |cffffcc00we recommend that you uninstall it|r as it is no longer needed.",
 
 	CO_TOOLTIP_HIDE_IN_INSTANCE = "Hide while in instance",
+
+	------------------------------------------------------------------------------------------------
+	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
+	--- THEN MOVE IT UP ONCE IMPORTED
+	------------------------------------------------------------------------------------------------
+
+	UNIT_POPUPS_CONFIG_MENU_TITLE = "Menu settings",
+	UNIT_POPUPS_CONFIG_PAGE_TEXT = "Menu settings",
+	UNIT_POPUPS_CONFIG_PAGE_HELP = "The unit popups module adds additional entries to the right-click menus found on unit frames and names in the chat frame.",
+	UNIT_POPUPS_CONFIG_ENABLE_MODULE = "Module |cff00ff00enabled|r",
+	UNIT_POPUPS_MODULE_DISABLE_WARNING = "A user interface reload is required to disable the unit popups module.|n|n|cffff0000Warning: |rOnce disabled, this module can only be re-enabled from the |cffffcc00Modules status|r page.|n|nAre you sure you want to disable this module?",
+	UNIT_POPUPS_CONFIG_ENTRIES_HEADER = "Menu entries",
+	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT = "Show header text",
+	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP = "If checked, shows a \"Roleplay Options\" header above any added menu entries.",
+	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR = "Show separator",
+	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP = "If checked, shows a separator bar above any added menu entries.",
+	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS = "Show character status toggle",
+	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP = "If checked, adds a checkbox to your own unit frame menu that allows you to toggle your in-character/out-of-character status.",
+	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE = "Show open profile button",
+	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP = "If checked, adds a button that opens the selected units' RP profile when clicked.|n|nThis option will be visible on all unit frame and chat menus.",
+
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1569,6 +1569,8 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP = "If checked, additional menu entries will not be shown while in combat.",
 	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES = "Hide menu entries while in instances",
 	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP = "If checked, additional menu entries will not be shown while in instanced content.",
+	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES = "Hide menu entries on unit frames",
+	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP = "If checked, additional menu entries will not be shown in menus activated by right-clicking unit frames.",
 
 };
 


### PR DESCRIPTION
These were initially planned but I'd scrapped them to keep the module smaller, but based on feedback about the visibility of any way to configure or disable the module we might as well add some stuff here in-line with the nameplates work.