### PR TITLE
Default localizations based on client locale

### DIFF
--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1775,3 +1775,12 @@ Please use TRP3_API.loc:GetLocale(localeID) and locale:AddText(key, value) to in
 		})
 	}
 end
+
+-- The default locale for any lookups in script bodies is based on the client
+-- locale; this may change later based on the "addon locale" setting and cause
+-- differences, but for the majority of users it should go unnoticed.
+--
+-- Long term we should look at fixing those things; primary area being module
+-- names and descriptions which are looked up in script bodies.
+
+TRP3_API.loc:SetCurrentLocale(GetLocale(), true);


### PR DESCRIPTION
This fixes an issue where localization keys looked up in script bodies would always default to English as the addon locale setting isn't loaded until much later.

This primarily affects module names and descriptions, but also did (until fixes were implemented) affect the nameplate and unitpopup module settings too.

For most people the addon locale won't differ from the client locale, however in this case the new behavior is no worse than the old since they'll both be wrong. For the common case where the locales match, we fix a bug.