### PR TITLE
Fix wrong names showing on Blizzard NPC nameplates

### DIFF
--- a/totalRP3/modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Blizzard.lua
@@ -278,7 +278,13 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateName(nameplate)
 
 		-- No cropping occurs after this point.
 
-		overrideText = TRP3_NamePlatesUtil.PrependRoleplayStatusToText(overrideText, displayInfo.roleplayStatus);
+		if displayInfo.roleplayStatus then
+			overrideText = overrideText or unitframe.name.TRP3_originalText;
+
+			if overrideText then
+				overrideText = TRP3_NamePlatesUtil.PrependRoleplayStatusToText(overrideText, displayInfo.roleplayStatus);
+			end
+		end
 
 		-- Process color overrides.
 

--- a/totalRP3/modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Blizzard.lua
@@ -268,7 +268,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateName(nameplate)
 	local unitToken = nameplate.namePlateUnitToken;
 	local displayInfo = self:GetUnitDisplayInfo(unitToken);
 
-	local overrideText = unitframe.name.TRP3_originalText;
+	local overrideText;
 	local overrideColor;
 
 	if displayInfo then


### PR DESCRIPTION
The override text was being initialized to the original text of the nameplate widget, which led to a case where if a nameplate unitframe were recycled for a unit that shouldn't have customizations applied we'd promote that "original" name to an override, and thus Deer could become Sheep.