### PR TITLE
TBC Packager Support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
           git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
           bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
         env:
-          JOB_STATUS:    ${{ job.status }}
-          HOOK_OS_NAME:  ${{ runner.os }}
-          WEBHOOK_URL:   ${{ secrets.WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Create Retail Package
         uses: BigWigsMods/packager@master
-        with:
-          args: -p 75973 -w 24113 -a q96dnGOm
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +26,7 @@ jobs:
       - name: Create BC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 75973 -w 24113 -a q96dnGOm -g bc
+          args: -g bc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +36,7 @@ jobs:
       - name: Create Classic Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 335857 -w 25153 -a q96dnGOm -g classic
+          args: -g classic
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ jobs:
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
+      - name: Create BC Package
+        uses: BigWigsMods/packager@master
+        with:
+          args: -p 335857 -w 25153 -a q96dnGOm -g bc
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+
       - name: Create Classic Package
         uses: BigWigsMods/packager@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create BC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 335857 -w 25153 -a q96dnGOm -g bc
+          args: -p 75973 -w 24113 -a q96dnGOm -g bc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -27,6 +27,15 @@ jobs:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
+      - name: Create BC Package
+        uses: BigWigsMods/packager@master
+        with:
+          args: -p 335857 -a q96dnGOm -g bc
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+
       - name: Create Classic Package
         uses: BigWigsMods/packager@master
         with:

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create BC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 335857 -a q96dnGOm -g bc
+          args: -p 75973 -a q96dnGOm -g bc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create Retail Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 75973 -a q96dnGOm
+          args: -w 0
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
       - name: Create BC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 75973 -a q96dnGOm -g bc
+          args: -w 0 -g bc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
       - name: Create Classic Package
         uses: BigWigsMods/packager@master
         with:
-          args: -p 335857 -a q96dnGOm -g classic
+          args: -w 0 -g classic
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -8,6 +8,12 @@
 ## OptionalDeps: Prat-3.0, WoWUnit
 ## RequiredDeps: totalRP3_Data
 ## SavedVariables: TRP3_Profiles, TRP3_Characters, TRP3_Configuration, TRP3_Flyway, TRP3_Presets, TRP3_Companions, TRP3_MatureFilter, TRP3_Colors, TRP3_Notes
-## X-URL: http://totalrp3.info
+
+## X-Category: Roleplay
+## X-License: Apache-2.0
+## X-Website: http://totalrp3.info
+## X-Curse-Project-ID: 75973
+## X-Wago-ID: q96dnGOm
+## X-WoWI-ID: 24113
 
 totalRP3.xml

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,9 +1,6 @@
-#@retail@
 ## Interface: 90005
-#@end-retail@
-#@non-retail@
-# ## Interface: 11307
-#@end-non-retail@
+## Interface-BC: 20501
+## Interface-Classic: 11307
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,9 +1,6 @@
-﻿#@retail@
-## Interface: 90005
-#@end-retail@
-#@non-retail@
-# ## Interface: 11307
-#@end-non-retail@
+﻿## Interface: 90005
+## Interface-BC: 20501
+## Interface-Classic: 11307
 ## Title: Total RP 3: Data
 ## Author: Telkostrasz & Ellypse
 ## Notes: The best data storage for the best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 90005
+## Interface: 90005
 ## Interface-BC: 20501
 ## Interface-Classic: 11307
 ## Title: Total RP 3: Data


### PR DESCRIPTION
The upstream packager has (ahead-of-time) adopted the proposal for multiple interface version support, such that it now supports distinct TOC tags for each target client which will replace the existing "Interface" TOC tag automatically when packaged.

In addition the "bc" game version has been added, so new workflow steps for packaging have been added there.

See: Stanzilla/WoWUIBugs#68 and BigWigsMods/packager@2963e10c110324e3dad8357f7c7e4a23caacec24.

Note that the project IDs for this are temporary at the moment and default to the retail project; as we're likely heading for the three-client scenario we might need to reconsider the Classic project being separate on CF/WoWI anyway and merge that back in, and handle the localization differences ourselves (perhaps by just appending `_CLASSIC` to some of the keys).

No work has also been done on changing or removing the existing `@retail@` or `@non-retail@` substitutions as upstream work there is pending; we'll possibly be getting a set of `@version-{retail,classic,bc}@` substitutions for each client.