### PR TITLE
Fix Kui names when level text/health is disabled

### DIFF
--- a/totalRP3/modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Kui.lua
@@ -179,18 +179,21 @@ function TRP3_KuiNamePlates:OnNameplateNameTextUpdated(nameplate)
 	end
 
 	if displayText then
+		nameplate.NameText:SetText(displayText);
+
 		if nameplate.IN_NAMEONLY then
 			-- In name-only mode we need to account for health coloring, which
 			-- reads from the current state. We replace it long enough to
 			-- update the underlying font string before restoring it.
+			--
+			-- Note this needs to occur after a SetText call to replace the
+			-- name, as health coloring and level information is only placed
+			-- onto the name if either are enabled.
 
 			local originalText = nameplate.state.name;
 			nameplate.state.name = displayText;
 			KuiNameplatesCore:NameOnlyUpdateNameText(nameplate);
 			nameplate.state.name = originalText;
-		else
-			-- Not in name-only mode so the logic is straightforward.
-			nameplate.NameText:SetText(displayText);
 		end
 	end
 

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -8,7 +8,7 @@
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@
 ## Notes: The best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
-## OptionalDeps: Prat-3.0, WoWUnit
+## OptionalDeps: Kui_Nameplates, Kui_Nameplates_Core, Prat-3.0, WoWUnit
 ## RequiredDeps: totalRP3_Data
 ## SavedVariables: TRP3_Profiles, TRP3_Characters, TRP3_Configuration, TRP3_Flyway, TRP3_Presets, TRP3_Companions, TRP3_MatureFilter, TRP3_Colors, TRP3_Notes
 ## X-URL: http://totalrp3.info


### PR DESCRIPTION
In Kui name-only mode, the NameOnlyUpdateNameText function only changes the name text on the fontstring if the user has either the level text or coloring of health on the name enabled. If neither are enabled, the text isn't updated.

Moving the SetText call out of the else block and unconditionally replacing the contents prior to the NameOnlyUpdateNameText call should resolve this.