### PR TITLE
Route logging to _DebugLog if installed

### DIFF
--- a/totalRP3/libs/Ellyb/Logs/Logger.lua
+++ b/totalRP3/libs/Ellyb/Logs/Logger.lua
@@ -15,7 +15,7 @@ local print = print;
 local Log = Ellyb.Log;
 
 ---@class Logger : Object
-local Logger, _private = Ellyb.Class("Logger");
+local Logger = Ellyb.Class("Logger");
 Ellyb.Logger = Logger;
 
 Logger.LEVELS = {
@@ -26,7 +26,7 @@ Logger.LEVELS = {
 }
 
 ---@return Ellyb_Color
-local function getColorForLevel(level)
+local function GetColorForLevel(level)
 	if level == Logger.LEVELS.SEVERE then
 		return Ellyb.ColorManager.RED;
 	elseif level == Logger.LEVELS.WARNING then
@@ -38,32 +38,7 @@ local function getColorForLevel(level)
 	end
 end
 
---- Constructor
----@param moduleName string @ The name of the module initializing the Logger
-function Logger:initialize(moduleName)
-	_private[self] = {};
-	_private[self].moduleName = moduleName;
-
-	Ellyb.LogsManager:RegisterLogger(self);
-	self:Info("Logger " .. moduleName .. " initialized.");
-end
-
----@return string moduleName @ Returns the name of the Logger's module
-function Logger:GetModuleName()
-	return _private[self].moduleName;
-end
-
-local LOG_HEADER_FORMAT = "[%s - %s]: ";
-function Logger:GetLogHeader(logLevel)
-	local color = getColorForLevel(logLevel);
-	return format(LOG_HEADER_FORMAT, Ellyb.ColorManager.ORANGE(self:GetModuleName()), color(logLevel));
-end
-
-function Logger:Log(level, ...)
-	if not Ellyb:IsDebugModeEnabled() then
-		return;
-	end
-
+local function WriteToChatFrame(logger, level, message, ...)
 	local ChatFrame;
 	for i = 0, NUM_CHAT_WINDOWS do
 		if GetChatWindowInfo(i) == "Logs" then
@@ -71,15 +46,60 @@ function Logger:Log(level, ...)
 		end
 	end
 
-	local log = Log(level, ...);
+	local log = Log(level, message, ...);
 	local logText = log:GetText();
-	local logHeader = self:GetLogHeader(log:GetLevel());
+	local logHeader = logger:GetLogHeader(log:GetLevel());
 	local timestamp = format("[%s]", date("%X", log:GetTimestamp()));
 	local message = Ellyb.ColorManager.GREY(timestamp) .. logHeader .. logText;
-	if ChatFrame and log:GetLevel() ~= self.LEVELS.WARNING and log:GetLevel() ~= self.LEVELS.SEVERE then
+	if ChatFrame and log:GetLevel() ~= Logger.LEVELS.WARNING and log:GetLevel() ~= Logger.LEVELS.SEVERE then
 		ChatFrame:AddMessage(message)
 	else
 		print(message)
+	end
+end
+
+local function WriteToDebugLogAddOn(logger, level, message, ...)
+	local prefix = logger:GetModuleName() .. "~";
+
+	if level == Logger.LEVELS.WARNING then
+		prefix = "WARN~" .. prefix;
+	elseif level == Logger.LEVELS.SEVERE then
+		prefix = "ERR~" .. prefix;
+	end
+
+    message = string.join(" ", tostringall(prefix, message, ...));
+    message = string.gsub(message, "%%", "%%%%");
+
+    DLAPI.DebugLog(addOnName, message);
+end
+
+--- Constructor
+---@param moduleName string @ The name of the module initializing the Logger
+function Logger:initialize(moduleName)
+	self.moduleName = moduleName;
+
+	Ellyb.LogsManager:RegisterLogger(self);
+	self:Info("Logger " .. moduleName .. " initialized.");
+end
+
+---@return string moduleName @ Returns the name of the Logger's module
+function Logger:GetModuleName()
+	return self.moduleName;
+end
+
+local LOG_HEADER_FORMAT = "[%s - %s]: ";
+function Logger:GetLogHeader(logLevel)
+	local color = GetColorForLevel(logLevel);
+	return format(LOG_HEADER_FORMAT, Ellyb.ColorManager.ORANGE(self:GetModuleName()), color(logLevel));
+end
+
+function Logger:Log(level, message, ...)
+	if not Ellyb:IsDebugModeEnabled() then
+		return;
+	elseif DLAPI then
+		WriteToDebugLogAddOn(self, level, message, ...);
+	else
+		WriteToChatFrame(self, level, message, ...);
 	end
 end
 

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -14,3 +14,7 @@
 ## X-URL: http://totalrp3.info
 
 totalRP3.xml
+
+#@do-not-package@
+## OptionalDeps: _DebugLog
+#@end-do-not-package@


### PR DESCRIPTION
This removes all the log spam going to the chat frame on initial login with a dev build, as well as the need to set up a "Logs" window, by routing all log messages to the [_DebugLog](https://www.curseforge.com/wow/addons/debuglog) addon if it's loaded on the client. If not installed, logs continue going to the chat frame as they initially did.

Logs can be accessed via `/dl` and are categorised by the name of the logger that sent them. The tool provides filtering, search, and export capabilities which I think was the initial aim for the logging system anyway.