### PR TITLE
Test for pets via UnitCreatureFamily

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -395,6 +395,7 @@ stds.wow = {
 		"UnitBattlePetType",
 		"UnitClass",
 		"UnitClassBase",
+		"UnitCreatureFamily",
 		"UnitCreatureType",
 		"UnitExists",
 		"UnitFactionGroup",

--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -518,11 +518,6 @@ function TRP3_API.ui.misc.isTargetTypeACompanion(unitType)
 	return unitType == TRP3_Enums.UNIT_TYPE.BATTLE_PET or unitType == TRP3_Enums.UNIT_TYPE.PET;
 end
 
-local function IsPetUnit(unitToken)
-	local unitGUID = UnitGUID(unitToken);
-	return unitGUID and strsplit("-", unitGUID) == "Pet";
-end
-
 local function IsBattlePetUnit(unitToken)
 	if UnitIsBattlePetCompanion then
 		return UnitIsBattlePetCompanion(unitToken);
@@ -548,7 +543,7 @@ function TRP3_API.ui.misc.getTargetType(unitType)
 		return TRP3_Enums.UNIT_TYPE.CHARACTER, getUnitID(unitType) == globals.player_id;
 	elseif IsBattlePetUnit(unitType) then
 		return TRP3_Enums.UNIT_TYPE.BATTLE_PET, UnitIsOwnerOrControllerOfUnit("player", unitType);
-	elseif UnitPlayerControlled(unitType) and IsPetUnit(unitType) then
+	elseif UnitPlayerControlled(unitType) and UnitCreatureFamily(unitType) ~= nil then
 		return TRP3_Enums.UNIT_TYPE.PET, UnitIsOwnerOrControllerOfUnit("player", unitType);
 	end
 	if TRP3_API.utils.str.getUnitNPCID(unitType) then


### PR DESCRIPTION
This function should reliably return non-nil for units that can be classified as pets, and resolves an issue where the initial summon of
a warlock pet (or probably _any_ pet) would render it unable to be assigned a profile as it'd be given a Creature GUID instead of a Pet one.