### PR TITLE
Fix mature tooltips overlapping GameTooltip

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1100,8 +1100,9 @@ local function show(targetType, targetID, targetMode)
 
 				-- Stock all the current text from the GameTooltip
 				local originalTexts = getGameTooltipTexts(GameTooltip);
+				local isIgnoredOrMatureFlagged = ownerIsIgnored(targetID) or unitIDIsFilteredForMatureContent(targetID);
 
-				if (targetMode == TRP3_Enums.UNIT_TYPE.CHARACTER and isIDIgnored(targetID)) or ((targetMode == TRP3_Enums.UNIT_TYPE.BATTLE_PET or targetMode == TRP3_Enums.UNIT_TYPE.PET) and ownerIsIgnored(targetID)) then
+				if (targetMode == TRP3_Enums.UNIT_TYPE.CHARACTER and isIgnoredOrMatureFlagged) or ((targetMode == TRP3_Enums.UNIT_TYPE.BATTLE_PET or targetMode == TRP3_Enums.UNIT_TYPE.PET) and isIgnoredOrMatureFlagged) then
 					ui_CharacterTT:SetOwner(GameTooltip, "ANCHOR_TOPRIGHT");
 				elseif not getAnchoredFrame() then
 					GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1100,9 +1100,9 @@ local function show(targetType, targetID, targetMode)
 
 				-- Stock all the current text from the GameTooltip
 				local originalTexts = getGameTooltipTexts(GameTooltip);
-				local isIgnoredOrMatureFlagged = ownerIsIgnored(targetID) or unitIDIsFilteredForMatureContent(targetID);
+				local isMatureFlagged = unitIDIsFilteredForMatureContent(targetID);
 
-				if (targetMode == TRP3_Enums.UNIT_TYPE.CHARACTER and isIgnoredOrMatureFlagged) or ((targetMode == TRP3_Enums.UNIT_TYPE.BATTLE_PET or targetMode == TRP3_Enums.UNIT_TYPE.PET) and isIgnoredOrMatureFlagged) then
+				if (targetMode == TRP3_Enums.UNIT_TYPE.CHARACTER and (isIDIgnored(targetID) or isMatureFlagged)) or ((targetMode == TRP3_Enums.UNIT_TYPE.BATTLE_PET or targetMode == TRP3_Enums.UNIT_TYPE.PET) and (ownerIsIgnored(targetID) or isMatureFlagged)) then
 					ui_CharacterTT:SetOwner(GameTooltip, "ANCHOR_TOPRIGHT");
 				elseif not getAnchoredFrame() then
 					GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);


### PR DESCRIPTION
Fixes #541. When a profile with mature content is assigned to the mouseover unit, with the "Hide original tooltip" setting checked
we'd both fail to hide said tooltip and would overlap our mature content warning right over it.

This changes the logic to treat the mature content warning in the same way as the ignored profile one, and should anchor it such that it sits atop GameTooltip.

![image](https://user-images.githubusercontent.com/287102/113695899-4c710400-96c9-11eb-8181-eb0325ed9a78.png)
