### PR TITLE
Protect "[TRP3:...]" links from chat transforms

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -369,7 +369,7 @@ local function ProtectMessageContents(message)
 
 	message = string.gsub(message, "|H.-%|h.-|h", ProtectString);
 	message = string.gsub(message, "|3%-%d+%b()", ProtectString);
-	message = string.gsub(message, "%[TRP3:[^%]]+%]", ProtectString);
+	message = string.gsub(message, "%b[]", ProtectString);
 
 	return message, replacements;
 end

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -355,21 +355,33 @@ TRP3_API.utils.getCharacterInfoTab = getCharacterInfoTab;
 -- Emote and OOC detection
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
--- For links exception
-local EmoteTempPatternStart = "TRP3BTMPEMOTE"
-local EmoteTempPatternEnd = "TRP3ETEMPEMOTE"
-local OOCTempPatternStart = "TRP3BTEMPOOC"
-local OOCTempPatternEnd = "TRP3ETEMPOOC"
-local SpeechTempPatternStart = "TRP3BTEMPSPEECH"
-local SpeechTempPatternEnd = "TRP3ETEMPSPEECH"
-local RussianDeclensionStart = "TRP3BTEMPRUSSIAN"
-local RussianDeclensionEnd = "TRP3ETEMPRUSSIAN"
+local function ProtectMessageContents(message)
+	local replacements = {};
+	local count = 0;
 
-local LinkDetectionPattern = "(%|H.-%|h.-|h)"
-local EmoteTempDetectionPattern = EmoteTempPatternStart .. ".-" .. EmoteTempPatternEnd
-local OOCTempDetectionPattern = OOCTempPatternStart .. ".-" .. OOCTempPatternEnd
-local SpeechTempDetectionPattern = SpeechTempPatternStart .. ".-" .. SpeechTempPatternEnd
-local RussianDeclensionDetectionPattern = RussianDeclensionStart .. "(.)(.-)" .. RussianDeclensionEnd
+	local function ProtectString(string)
+		local escape = "|Ktrp" .. count .. "|k";
+		replacements[escape] = string;
+		count = count + 1;
+
+		return escape;
+	end
+
+	message = string.gsub(message, "|H.-%|h.-|h", ProtectString);
+	message = string.gsub(message, "|3%-%d+%b()", ProtectString);
+	message = string.gsub(message, "%[TRP3:[^%]]+%]", ProtectString);
+
+	return message, replacements;
+end
+
+local function UnprotectMessageContents(message, replacements)
+	local function UnprotectString(sequence)
+		return replacements[sequence] or "";
+	end
+
+	message = string.gsub(message, "|Ktrp%d+|k", UnprotectString);
+	return message;
+end
 
 ---@param message string
 ---@param NPCEmoteChatColor Color
@@ -384,70 +396,34 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor, isEmote)
 		NPCEmoteChatString = NPCEmoteChatColor:GetColorCodeStartSequence();
 	end
 
-	-- Emote/OOC/Speech replacement
-	if configDoEmoteDetection() and message:find(configEmoteDetectionPattern()) then
-		-- Wrapping patterns in a temporary pattern
-		local chatColor = TRP3_API.chat.getEmoteDetectionColor();
-		message = message:gsub(configEmoteDetectionPattern(), function(content)
-			return EmoteTempPatternStart .. content .. EmoteTempPatternEnd;
-		end);
+	local protections;
+	message, protections = ProtectMessageContents(message);
 
-		-- Removing temporary patterns from links
-		message = message:gsub(LinkDetectionPattern, function(content)
-			return content:gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "");
-		end);
+	do -- Emote/OOC/Speech replacement
+		if configDoEmoteDetection() then
+			local color = TRP3_API.chat.getEmoteDetectionColor();
+			message = message:gsub(configEmoteDetectionPattern(), function(content)
+				return color:WrapTextInColorCode(content) .. NPCEmoteChatString;
+			end);
+		end
 
-		-- Replacing temporary patterns by color wrap
-		message = message:gsub(EmoteTempDetectionPattern, function(content)
-			return chatColor:WrapTextInColorCode(content):gsub(EmoteTempPatternStart, ""):gsub(EmoteTempPatternEnd, "") .. NPCEmoteChatString;
-		end);
+		if configDoOOCDetection() then
+			local color = TRP3_API.chat.getOOCDetectionColor();
+			message = message:gsub(configOOCDetectionPattern(), function(content)
+				return color:WrapTextInColorCode(content) .. NPCEmoteChatString;
+			end);
+		end
+
+		-- Only apply speech detections on emotes (excluding NPC non-emote speech)
+		if isEmote and configDoSpeechDetection() then
+			local color = TRP3_API.chat.getSpeechDetectionColor();
+			message = message:gsub('%b""', function(content)
+				return color:WrapTextInColorCode(content) .. NPCEmoteChatString;
+			end);
+		end
 	end
 
-	if configDoOOCDetection() and message:find(configOOCDetectionPattern()) then
-
-		-- Wrapping Russian declension in a temporary pattern
-		message = message:gsub("|3%-(.)%((.-)%)", function(declension, content)
-			return RussianDeclensionStart .. declension .. content .. RussianDeclensionEnd;
-		end);
-
-		-- Wrapping patterns in a temporary pattern
-		local OOCColor = TRP3_API.chat.getOOCDetectionColor();
-		message = message:gsub(configOOCDetectionPattern(), function(content)
-			return OOCTempPatternStart .. content .. OOCTempPatternEnd;
-		end);
-
-		-- Removing temporary patterns from links
-		message = message:gsub(LinkDetectionPattern, function(content)
-			return content:gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "");
-		end);
-
-		-- Replacing temporary patterns by color wrap
-		message = message:gsub(OOCTempDetectionPattern, function(content)
-			return OOCColor:WrapTextInColorCode(content):gsub(OOCTempPatternStart, ""):gsub(OOCTempPatternEnd, "") .. NPCEmoteChatString;
-		end);
-
-		message = message:gsub(RussianDeclensionDetectionPattern, "|3-%1(%2)");
-	end
-
-	-- Only apply speech detections on emotes (excluding NPC non-emote speech)
-	if isEmote and configDoSpeechDetection() and message:find('%b""') then
-		-- Wrapping patterns in a temporary pattern
-		local chatColor = TRP3_API.chat.getSpeechDetectionColor();
-		message = message:gsub('%b""', function(content)
-			return SpeechTempPatternStart .. content .. SpeechTempPatternEnd;
-		end);
-
-		-- Removing temporary patterns from links
-		message = message:gsub(LinkDetectionPattern, function(content)
-			return content:gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "");
-		end);
-
-		-- Replacing temporary patterns by color wrap
-		message = message:gsub(SpeechTempDetectionPattern, function(content)
-			return chatColor:WrapTextInColorCode(content):gsub(SpeechTempPatternStart, ""):gsub(SpeechTempPatternEnd, "") .. NPCEmoteChatString;
-		end);
-	end
-
+	message = UnprotectMessageContents(message, protections);
 	return message;
 end
 TRP3_API.chat.detectEmoteAndOOC = detectEmoteAndOOC;


### PR DESCRIPTION
Fixes #540. Previously a chat link that contained any OOC, speech or emote pattern matches would have their inner text mangled and replaced with the appropriate color sequences, as it was possible for the message handler that processes these to be installed after the one used for text color processing.

This rewrites the message protection code; the old approach would first find the patterns it was interested in and replace them with a temporary pre/postfix marker, it'd then check the things it didn't want to mess up and remove those markers, and then replace the remaining markers with the intended color sequence.

Instead, this new approach changes the order of operations - we find things that should be protected (hyperlinks, declensions, and our own textual link format) and replace those with a uniquely generated escape sequences, borrowing from Blizzards' "|K" protected strings, and store the replacements in a table. Message processing then occurs as normal after that with the protected strings stashed away, and then they're restored as the last step of the chat handler. This approach ends up being safer and more maintainable, as well as more efficient as we need less closures and string replacements.

Proof that it all still works - I also manually verified that we don't screw up `|H` or declensions separately.

![image](https://user-images.githubusercontent.com/287102/113688531-4b3bd900-96c1-11eb-9962-c33930f0140b.png)
