### PR TITLE
Hide trimmed Currently/OOC tooltip texts if empty

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -584,11 +584,13 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	if showCurrently() and info.character and info.character.CU and info.character.CU ~= "" then
-		tooltipBuilder:AddLine(loc.REG_PLAYER_CURRENT, 1, 1, 1, getSubLineFontSize());
-
 		local text = strtrim(info.character.CU);
-		text = limitText(text, getCurrentMaxSize(), getCurrentMaxLines());
-		tooltipBuilder:AddLine(text, 1, 0.75, 0, getSmallLineFontSize(), true);
+
+		if text ~= "" then
+			text = limitText(text, getCurrentMaxSize(), getCurrentMaxLines());
+			tooltipBuilder:AddLine(loc.REG_PLAYER_CURRENT, 1, 1, 1, getSubLineFontSize());
+			tooltipBuilder:AddLine(text, 1, 0.75, 0, getSmallLineFontSize(), true);
+		end
 	end
 
 	tooltipBuilder:AddSpace();
@@ -598,11 +600,13 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	if showMoreInformation() and info.character and info.character.CO and info.character.CO ~= "" then
-		tooltipBuilder:AddLine(loc.DB_STATUS_CURRENTLY_OOC, 1, 1, 1, getSubLineFontSize());
-
 		local text = strtrim(info.character.CO);
-		text = limitText(text, getCurrentMaxSize(), getCurrentMaxLines());
-		tooltipBuilder:AddLine(text, 1, 0.75, 0, getSmallLineFontSize(), true);
+
+		if text ~= "" then
+			text = limitText(text, getCurrentMaxSize(), getCurrentMaxLines());
+			tooltipBuilder:AddLine(loc.DB_STATUS_CURRENTLY_OOC, 1, 1, 1, getSubLineFontSize());
+			tooltipBuilder:AddLine(text, 1, 0.75, 0, getSmallLineFontSize(), true);
+		end
 	end
 
 	tooltipBuilder:AddSpace();


### PR DESCRIPTION
If a profile is displayed in the tooltip contains a CU/CO field with whitespace then the resulting tooltip would show the respective header but have no content beneath it, as trimming of the field occurs after the empty check.

![image](https://user-images.githubusercontent.com/287102/113749438-94138200-9701-11eb-8d6d-3bc6ee1372c5.png)

This changeset makes us additionally check if the trimmed text for these fields is empty and, if so, prevents us from doing the above which will instead now only show the OOC section (which actually had text).