### PR TITLE
Profile sanitization improvements

### DIFF
--- a/totalRP3/core/impl/AdvancedSettings.lua
+++ b/totalRP3/core/impl/AdvancedSettings.lua
@@ -31,7 +31,6 @@ TRP3_API.ADVANCED_SETTINGS_STRUCTURE = {
 }
 
 TRP3_API.ADVANCED_SETTINGS_KEYS = {
-	PROFILE_SANITIZATION = "register_sanitization",
 }
 
 -- Broadcast keys should only be registered in Retail
@@ -88,21 +87,6 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			help = loc.CO_ADVANCED_BROADCAST_CHANNEL_ALWAYS_LAST_TT
 		});
 	end
-
-	-- Sanitization
-	tinsert(TRP3_API.ADVANCED_SETTINGS_STRUCTURE.elements, {
-		inherit = "TRP3_ConfigH1",
-		title = loc.REG_REGISTER,
-	});
-
-	-- Profile sanitization
-	TRP3_API.ADVANCED_SETTINGS_DEFAULT_VALUES[TRP3_API.ADVANCED_SETTINGS_KEYS.PROFILE_SANITIZATION] = true;
-	tinsert(TRP3_API.ADVANCED_SETTINGS_STRUCTURE.elements, {
-		inherit = "TRP3_ConfigCheck",
-		title = loc.CO_SANITIZER,
-		configKey = TRP3_API.ADVANCED_SETTINGS_KEYS.PROFILE_SANITIZATION,
-		help = loc.CO_SANITIZER_TT
-	});
 
 	for configurationKey, defaultValue in pairs(TRP3_API.ADVANCED_SETTINGS_DEFAULT_VALUES) do
 		Configuration.registerConfigKey(configurationKey, defaultValue)

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -437,6 +437,7 @@ local escapes = {
 	["|H.-|h(.-)|h"] = "%1", -- links
 	["|T.-|t"] = "", -- textures
 	["|A.-|a"] = "", -- atlas textures
+	["|K.-|k"] = "", -- protected strings
 }
 function Utils.str.sanitize(text)
 	if not text then return end

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -332,9 +332,7 @@ function TRP3_API.register.saveInformation(unitID, informationType, data)
 		wipe(profile[informationType]);
 	end
 
-	if getConfigValue(TRP3_API.ADVANCED_SETTINGS_KEYS.PROFILE_SANITIZATION) == true then
-		TRP3_API.register.sanitizeProfile(informationType, data);
-	end
+	TRP3_API.register.sanitizeProfile(informationType, data);
 	profile[informationType] = data;
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), informationType);
 end


### PR DESCRIPTION
This removes the option to disable sanitization of profiles and adds a small tweak to also strip protected string sequences (|K). Some more work will be done here to improve sanitization of existing fields as well, but that's pending for now.