### PR TITLE
Remove heavy profile alert option

### DIFF
--- a/totalRP3/core/impl/configuration.lua
+++ b/totalRP3/core/impl/configuration.lua
@@ -423,12 +423,6 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
-				title = loc.CO_GENERAL_HEAVY,
-				configKey = "heavy_profile_alert",
-				help = loc.CO_GENERAL_HEAVY_TT,
-			},
-			{
-				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_GENERAL_UI_SOUNDS,
 				configKey = "ui_sounds",
 				help = loc.CO_GENERAL_UI_SOUNDS_TT,

--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -41,7 +41,6 @@ local getMiscExchangeData = playerAPI.getMiscExchangeData;
 local boundAndCheckCompanion = TRP3_API.companions.register.boundAndCheckCompanion;
 local getCompanionData = TRP3_API.companions.player.getCompanionData;
 local saveCompanionInformation = TRP3_API.companions.register.saveInformation;
-local getConfigValue = TRP3_API.configuration.getValue;
 local displayMessage = TRP3_API.utils.message.displayMessage;
 local TRP3_Enums = AddOn_TotalRP3.Enums;
 

--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -430,10 +430,8 @@ local function checkPlayerDataWeight()
 	local totalData = {getCharExchangeData(), getAboutExchangeData(), getMiscExchangeData(), getCharacterExchangeData()};
 	local computedSize = Comm.estimateStructureLoad(totalData);
 	if computedSize > ALERT_FOR_SIZE then
-		log(("Profile too heavy ! It would take %s messages to send."):format(computedSize));
-		if getConfigValue("heavy_profile_alert") then
-			TRP3_API.ui.tooltip.toast(loc.REG_PLAYER_ALERT_HEAVY_SMALL, 5);
-		end
+		log(("Profile too heavy! It would take %s messages to send."):format(computedSize));
+		TRP3_API.ui.tooltip.toast(loc.REG_PLAYER_ALERT_HEAVY_SMALL, 5);
 	end
 end
 


### PR DESCRIPTION
Having this actually be something a user can ignore only really leads to issues, so we're removing it.