### PR TITLE
Added tooltip fields

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -201,6 +201,7 @@ stds.wow = {
 		C_Map = {
 			fields = {
 				"GetBestMapForUnit",
+				"GetMapInfo",
 				"GetPlayerMapPosition",
 			},
 		},
@@ -299,6 +300,7 @@ stds.wow = {
 		"FCF_GetCurrentChatFrame",
 		"FindInTableIf",
 		"FormatLargeNumber",
+		"FormatPercentage",
 		"GameTooltip_AddBlankLineToTooltip",
 		"GameTooltip_AddColoredLine",
 		"GameTooltip_AddNormalLine",
@@ -401,6 +403,8 @@ stds.wow = {
 		"UnitFactionGroup",
 		"UnitFullName",
 		"UnitGUID",
+		"UnitHealth",
+		"UnitHealthMax",
 		"UnitInParty",
 		"UnitInRaid",
 		"UnitIsAFK",
@@ -468,6 +472,7 @@ stds.wow = {
 		"FOCUS",
 		"FUEL",
 		"FURY",
+		"HEALTH",
 		"HOLY_POWER",
 		"INSANITY",
 		"ITEM_QUALITY0_DESC",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -276,7 +276,7 @@ stds.wow = {
 			},
 		},
 
-        "AbbreviateLargeNumbers",
+		"AbbreviateLargeNumbers",
 		"Ambiguate",
 		"BNGetInfo",
 		"CallErrorHandler",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -276,6 +276,7 @@ stds.wow = {
 			},
 		},
 
+        "AbbreviateLargeNumbers",
 		"Ambiguate",
 		"BNGetInfo",
 		"CallErrorHandler",

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -784,19 +784,6 @@ function Utils.math.round(value, decimals)
 	return math.floor(value * mult) / mult;
 end
 
-Utils.math.formatHealth = function(health)
-	local formattedHealth;
-	if health >= 1000000 then
-		formattedHealth = string.format("%.1fM", health / 1000000);
-	elseif health >= 1000 then
-		formattedHealth = string.format("%.1fk", health / 1000);
-	else
-		formattedHealth = tostring(health);
-	end
-
-	return formattedHealth;
-end
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Text tags utils
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -784,6 +784,19 @@ function Utils.math.round(value, decimals)
 	return math.floor(value * mult) / mult;
 end
 
+Utils.math.formatHealth = function(health)
+	local formattedHealth;
+	if health >= 1000000 then
+		formattedHealth = string.format("%.1fM", health / 1000000);
+	elseif health >= 1000 then
+		formattedHealth = string.format("%.1fk", health / 1000);
+	else
+		formattedHealth = tostring(health);
+	end
+
+	return formattedHealth;
+end
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Text tags utils
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -89,6 +89,7 @@ local CONFIG_CHARACT_NOTIF = "tooltip_char_notif";
 local CONFIG_CHARACT_CURRENT = "tooltip_char_current";
 local CONFIG_CHARACT_OOC = "tooltip_char_ooc";
 local CONFIG_CHARACT_PRONOUNS = "tooltip_char_pronouns";
+local CONFIG_CHARACT_ZONE = "tooltip_char_zone";
 local CONFIG_CHARACT_CURRENT_SIZE = "tooltip_char_current_size";
 local CONFIG_CHARACT_RELATION = "tooltip_char_relation";
 local CONFIG_CHARACT_SPACING = "tooltip_char_spacing";
@@ -188,6 +189,10 @@ end
 
 local function showPronouns()
 	return getConfigValue(CONFIG_CHARACT_PRONOUNS);
+end
+
+local function showZone()
+	return getConfigValue(CONFIG_CHARACT_ZONE);
 end
 
 local function getCurrentMaxSize()
@@ -660,6 +665,20 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			end
 		end
 		tooltipBuilder:AddLine(loc.REG_TT_TARGET:format(name), 1, 1, 1, getSubLineFontSize());
+	end
+
+	--
+	-- Zone
+	--
+
+	if showZone() and targetType ~= "player" then
+		local mapID = C_Map.GetBestMapForUnit(targetType);
+		local playerMapID = C_Map.GetBestMapForUnit("player");
+		if mapID and mapID ~= playerMapID then
+			local mapInfo = C_Map.GetMapInfo(mapID);
+			local lineText = string.format("%1$s: |cffff9900%2$s|r", TRP3_API.loc.REG_TT_ZONE, mapInfo.name);
+			tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
+		end
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -1277,6 +1296,7 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_CHARACT_CURRENT, true);
 	registerConfigKey(CONFIG_CHARACT_OOC, true);
 	registerConfigKey(CONFIG_CHARACT_PRONOUNS, true);
+	registerConfigKey(CONFIG_CHARACT_ZONE, true);
 	registerConfigKey(CONFIG_CHARACT_CURRENT_SIZE, 140);
 	registerConfigKey(CONFIG_CHARACT_RELATION, true);
 	registerConfigKey(CONFIG_CHARACT_SPACING, true);
@@ -1466,6 +1486,11 @@ local function onModuleInit()
 				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_TOOLTIP_PRONOUNS,
 				configKey = CONFIG_CHARACT_PRONOUNS,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_TOOLTIP_ZONE,
+				configKey = CONFIG_CHARACT_ZONE,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -690,19 +690,22 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	if healthFormat ~= 0 then
 		local targetHP = UnitHealth(targetType);
 		local targetHPMax = UnitHealthMax(targetType);
-		local percentHP = targetHP / targetHPMax;
-		local lineText;
-		-- Number
-		if healthFormat == 1 then
-			lineText = string.format("%1$s: |cffff9900%2$s/%3$s|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax));
-		-- Percentage
-		elseif healthFormat == 2 then
-			lineText = string.format("%1$s: |cffff9900%2$s|r", HEALTH, FormatPercentage(percentHP, true));
-		-- Both
-		else
-			lineText = string.format("%1$s: |cffff9900%2$s/%3$s (%4$s)|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax), FormatPercentage(percentHP, true));
+		-- Don't show health if full
+		if targetHP ~= targetHPMax then
+			local percentHP = targetHP / targetHPMax;
+			local lineText;
+			-- Number
+			if healthFormat == 1 then
+				lineText = string.format("%1$s: |cffff9900%2$s/%3$s|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax));
+				-- Percentage
+			elseif healthFormat == 2 then
+				lineText = string.format("%1$s: |cffff9900%2$s|r", HEALTH, FormatPercentage(percentHP, true));
+				-- Both
+			else
+				lineText = string.format("%1$s: |cffff9900%2$s/%3$s (%4$s)|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax), FormatPercentage(percentHP, true));
+			end
+			tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
 		end
-		tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -1530,6 +1533,7 @@ local function onModuleInit()
 				title = loc.CO_TOOLTIP_HEALTH,
 				listContent = HEALTH_FORMAT_TAB,
 				configKey = CONFIG_CHARACT_HEALTH,
+				help = loc.CO_TOOLTIP_HEALTH_TT,
 				listWidth = nil,
 				listCancel = false,
 			},

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -90,6 +90,7 @@ local CONFIG_CHARACT_CURRENT = "tooltip_char_current";
 local CONFIG_CHARACT_OOC = "tooltip_char_ooc";
 local CONFIG_CHARACT_PRONOUNS = "tooltip_char_pronouns";
 local CONFIG_CHARACT_ZONE = "tooltip_char_zone";
+local CONFIG_CHARACT_HEALTH = "tooltip_char_health";
 local CONFIG_CHARACT_CURRENT_SIZE = "tooltip_char_current_size";
 local CONFIG_CHARACT_RELATION = "tooltip_char_relation";
 local CONFIG_CHARACT_SPACING = "tooltip_char_spacing";
@@ -679,6 +680,29 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			local lineText = string.format("%1$s: |cffff9900%2$s|r", TRP3_API.loc.REG_TT_ZONE, mapInfo.name);
 			tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
 		end
+	end
+
+	--
+	-- Health
+	--
+
+	local healthFormat = getConfigValue(CONFIG_CHARACT_HEALTH);
+	if healthFormat ~= 0 then
+		local targetHP = UnitHealth(targetType);
+		local targetHPMax = UnitHealthMax(targetType);
+		local percentHP = targetHP / targetHPMax;
+		local lineText;
+		-- Number
+		if healthFormat == 1 then
+			lineText = string.format("%1$s: |cffff9900%2$s/%3$s|r", HEALTH, Utils.math.formatHealth(targetHP), Utils.math.formatHealth(targetHPMax));
+		-- Percentage
+		elseif healthFormat == 2 then
+			lineText = string.format("%1$s: |cffff9900%2$s|r", HEALTH, FormatPercentage(percentHP, true));
+		-- Both
+		else
+			lineText = string.format("%1$s: |cffff9900%2$s/%3$s (%4$s)|r", HEALTH, Utils.math.formatHealth(targetHP), Utils.math.formatHealth(targetHPMax), FormatPercentage(percentHP, true));
+		end
+		tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -1297,6 +1321,7 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_CHARACT_OOC, true);
 	registerConfigKey(CONFIG_CHARACT_PRONOUNS, true);
 	registerConfigKey(CONFIG_CHARACT_ZONE, true);
+	registerConfigKey(CONFIG_CHARACT_HEALTH, 0);
 	registerConfigKey(CONFIG_CHARACT_CURRENT_SIZE, 140);
 	registerConfigKey(CONFIG_CHARACT_RELATION, true);
 	registerConfigKey(CONFIG_CHARACT_SPACING, true);
@@ -1324,7 +1349,14 @@ local function onModuleInit()
 	local OOC_INDICATOR_TYPES = {
 		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_TEXT .. ColorManager.RED("[" .. loc.CM_OOC .. "] "), "TEXT"},
 		{loc.CO_TOOLTIP_PREFERRED_OOC_INDICATOR_ICON .. OOC_ICON, "ICON"}
-	}
+	};
+
+	local HEALTH_FORMAT_TAB = {
+		{loc.CO_TOOLTIP_HEALTH_DISABLED, 0},
+		{loc.CO_TOOLTIP_HEALTH_NUMBER, 1},
+		{loc.CO_TOOLTIP_HEALTH_PERCENT, 2},
+		{loc.CO_TOOLTIP_HEALTH_BOTH, 3},
+	};
 
 	-- Build configuration page
 	local CONFIG_STRUCTURE = {
@@ -1491,6 +1523,15 @@ local function onModuleInit()
 				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_TOOLTIP_ZONE,
 				configKey = CONFIG_CHARACT_ZONE,
+			},
+			{
+				inherit = "TRP3_ConfigDropDown",
+				widgetName = "TRP3_ConfigurationTooltip_Charact_Health",
+				title = loc.CO_TOOLTIP_HEALTH,
+				listContent = HEALTH_FORMAT_TAB,
+				configKey = CONFIG_CHARACT_HEALTH,
+				listWidth = nil,
+				listCancel = false,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -1525,6 +1525,7 @@ local function onModuleInit()
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = loc.CO_TOOLTIP_ZONE,
+				help = loc.CO_TOOLTIP_ZONE_TT,
 				configKey = CONFIG_CHARACT_ZONE,
 			},
 			{

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -694,13 +694,13 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		local lineText;
 		-- Number
 		if healthFormat == 1 then
-			lineText = string.format("%1$s: |cffff9900%2$s/%3$s|r", HEALTH, Utils.math.formatHealth(targetHP), Utils.math.formatHealth(targetHPMax));
+			lineText = string.format("%1$s: |cffff9900%2$s/%3$s|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax));
 		-- Percentage
 		elseif healthFormat == 2 then
 			lineText = string.format("%1$s: |cffff9900%2$s|r", HEALTH, FormatPercentage(percentHP, true));
 		-- Both
 		else
-			lineText = string.format("%1$s: |cffff9900%2$s/%3$s (%4$s)|r", HEALTH, Utils.math.formatHealth(targetHP), Utils.math.formatHealth(targetHPMax), FormatPercentage(percentHP, true));
+			lineText = string.format("%1$s: |cffff9900%2$s/%3$s (%4$s)|r", HEALTH, AbbreviateLargeNumbers(targetHP), AbbreviateLargeNumbers(targetHPMax), FormatPercentage(percentHP, true));
 		end
 		tooltipBuilder:AddLine(lineText, 1, 1, 1, getSubLineFontSize());
 	end

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1616,6 +1616,7 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	REG_TT_ZONE = "Zone",
 	CO_TOOLTIP_ZONE = "Show zone",
 	CO_TOOLTIP_HEALTH = "Show health",
+	CO_TOOLTIP_HEALTH_TT = "Note: Health will only show if the target is not at full health",
 	CO_TOOLTIP_HEALTH_DISABLED = "Disabled",
 	CO_TOOLTIP_HEALTH_NUMBER = "Number",
 	CO_TOOLTIP_HEALTH_PERCENT = "Percentage",

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -311,6 +311,7 @@ It also works on the |cffffff00"At first glance" bar|r!]],
 	REG_LIST_CHAR_EMPTY = "No character",
 	REG_LIST_CHAR_EMPTY2 = "No character matches your selection",
 	REG_LIST_CHAR_IGNORED = "Ignored",
+	REG_LIST_CHAR_NAME_COPY = "Copy character name",
 	REG_LIST_IGNORE_TITLE = "Ignored list",
 	REG_LIST_IGNORE_EMPTY = "No ignored character",
 	REG_LIST_IGNORE_TT = "Reason:\n|cff00ff00%s\n\n|cffffff00Click to remove from ignore list",
@@ -466,6 +467,7 @@ Class: 50 characters|r]],
 	CO_TOOLTIP_RACE = "Show race, class and level",
 	CO_TOOLTIP_REALM = "Show realm",
 	CO_TOOLTIP_GUILD = "Show guild info",
+	CO_TOOLTIP_PRONOUNS = "Show pronouns",
 	CO_TOOLTIP_TARGET = "Show target",
 	CO_TOOLTIP_TITLE = "Show title",
 	CO_TOOLTIP_CLIENT = "Show client",
@@ -477,6 +479,7 @@ Class: 50 characters|r]],
 	CO_TOOLTIP_CURRENT_SIZE = "Max \"current\" information length",
 	CO_TOOLTIP_PROFILE_ONLY = "Use only if target has a profile",
 	CO_TOOLTIP_IN_CHARACTER_ONLY = "Hide when out of character",
+	CO_TOOLTIP_HIDE_IN_INSTANCE = "Hide while in instance",
 	CO_REGISTER = "Register settings",
 	CO_REGISTER_ABOUT_SETTINGS = "\"About\" settings",
 	CO_REGISTER_ABOUT_H1_SIZE = "Header 1 text size",
@@ -1455,7 +1458,6 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	UI_PET_BROWSER_INTRO_TEXT = "Select a pet with the buttons below and click |cffffff00Assign|r to bind it to the profile.",
 	UI_PET_BROWSER_BOUND_WARNING = "|cffff0000Warning: |rThis pet is currently assigned to the profile |cff00ff00%1$s|r. Assigning a profile to this pet will replace the current profile.",
 	UI_PET_BROWSER_NAME_WARNING = "|cffff0000Warning: |rThis pet has not been renamed. We recommend renaming the pet to prevent showing this profile on other pets you own with the same name.",
-	CO_TOOLTIP_PRONOUNS = "Show pronouns",
 	REG_PLAYER_MISC_PRESET_PRONOUNS = "Pronouns",
 	WHATS_NEW_24_3 =  [[# Changelog version 2.2
 
@@ -1505,8 +1507,21 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 - Fixed missing vulpera language icon.
 
 ]],
+	WHATS_NEW_24_5 = [[# Changelog version 2.3.2
+
+## Added
+
+- Added settings for right-click options on unit frames and chat names.
+
+## Fixed
+
+- Fixed incorrect names showing up on Blizzard NPC nameplates.
+- Fixed display issue with KuiNameplates tank mode.
+- Fixed a dependency issue preventing chat customization from working when using Prat and Listener.
+- Fixed localization not being properly applied to various settings.
+
+]],
 	COPY_DROPDOWN_POPUP_TEXT = "Copy with %1$s. Paste with %2$s.\nThis frame will close upon copy.",
-	REG_LIST_CHAR_NAME_COPY = "Copy character name",
 	COPY_SYSTEM_MESSAGE = "Copied to clipboard.",
 	UNIT_POPUPS_MODULE_NAME = "Unit Popups",
 	UNIT_POPUPS_MODULE_DESCRIPTION = "Adds integration with right-click menus on unit frames and player names in chat frames.",
@@ -1515,6 +1530,29 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	UNIT_POPUPS_CURRENT_PROFILE = "Current Profile",
 	UNIT_POPUPS_CURRENT_PROFILE_NAME = "Current Profile: %1$s",
 	UNIT_POPUPS_CHARACTER_STATUS = "Character Status",
+	UNIT_POPUPS_CONFIG_MENU_TITLE = "Menu settings",
+	UNIT_POPUPS_CONFIG_PAGE_TEXT = "Menu settings",
+	UNIT_POPUPS_CONFIG_PAGE_HELP = "The unit popups module adds additional entries to the right-click menus found on unit frames and names in the chat frame.",
+	UNIT_POPUPS_CONFIG_ENABLE_MODULE = "Module |cff00ff00enabled|r",
+	UNIT_POPUPS_MODULE_DISABLE_WARNING = "A user interface reload is required to disable the unit popups module.|n|n|cffff0000Warning: |rOnce disabled, this module can only be re-enabled from the |cffffcc00Modules status|r page.|n|nAre you sure you want to disable this module?",
+	UNIT_POPUPS_CONFIG_ENTRIES_HEADER = "Menu entries",
+	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT = "Show header text",
+	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP = "If checked, shows a \"Roleplay Options\" header above any added menu entries.",
+	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR = "Show separator",
+	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP = "If checked, shows a separator bar above any added menu entries.",
+	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS = "Show character status toggle",
+	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP = "If checked, adds a checkbox to your own unit frame menu that allows you to toggle your in-character/out-of-character status.",
+	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE = "Show open profile button",
+	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP = "If checked, adds a button that opens the selected units' RP profile when clicked.|n|nThis option will be visible on all unit frame and chat menus.",
+	UNIT_POPUPS_CONFIG_VISIBILITY_HEADER = "Visibility options",
+	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER = "Hide menu entries while out of character",
+	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP = "If checked, additional menu entries will not be shown while out-of-character.",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT = "Hide menu entries while in combat",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP = "If checked, additional menu entries will not be shown while in combat.",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES = "Hide menu entries while in instances",
+	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP = "If checked, additional menu entries will not be shown while in instanced content.",
+	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES = "Hide menu entries on unit frames",
+	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP = "If checked, additional menu entries will not be shown in menus activated by right-clicking unit frames.",
 
 	NAMEPLATES_MODULE_NAME = "Nameplates",
 	NAMEPLATES_MODULE_DESCRIPTION = "Enables the customization of nameplates with information obtained from roleplay profiles.",
@@ -1570,51 +1608,13 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	KUI_NAMEPLATES_MODULE_DESCRIPTION = "Enables the customization of Kui nameplates.",
 	KUI_NAMEPLATES_WARN_OUTDATED_MODULE = "The Kui |cff9966ffNameplates|r plugin for Total RP 3 has been integrated directly into the main addon.|n|nThe old plugin has been disabled automatically, and |cffffcc00we recommend that you uninstall it|r as it is no longer needed.",
 
-	CO_TOOLTIP_HIDE_IN_INSTANCE = "Hide while in instance",
-
 	------------------------------------------------------------------------------------------------
 	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
-	UNIT_POPUPS_CONFIG_MENU_TITLE = "Menu settings",
-	UNIT_POPUPS_CONFIG_PAGE_TEXT = "Menu settings",
-	UNIT_POPUPS_CONFIG_PAGE_HELP = "The unit popups module adds additional entries to the right-click menus found on unit frames and names in the chat frame.",
-	UNIT_POPUPS_CONFIG_ENABLE_MODULE = "Module |cff00ff00enabled|r",
-	UNIT_POPUPS_MODULE_DISABLE_WARNING = "A user interface reload is required to disable the unit popups module.|n|n|cffff0000Warning: |rOnce disabled, this module can only be re-enabled from the |cffffcc00Modules status|r page.|n|nAre you sure you want to disable this module?",
-	UNIT_POPUPS_CONFIG_ENTRIES_HEADER = "Menu entries",
-	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT = "Show header text",
-	UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP = "If checked, shows a \"Roleplay Options\" header above any added menu entries.",
-	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR = "Show separator",
-	UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP = "If checked, shows a separator bar above any added menu entries.",
-	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS = "Show character status toggle",
-	UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP = "If checked, adds a checkbox to your own unit frame menu that allows you to toggle your in-character/out-of-character status.",
-	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE = "Show open profile button",
-	UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP = "If checked, adds a button that opens the selected units' RP profile when clicked.|n|nThis option will be visible on all unit frame and chat menus.",
-	UNIT_POPUPS_CONFIG_VISIBILITY_HEADER = "Visibility options",
-	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER = "Hide menu entries while out of character",
-	UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP = "If checked, additional menu entries will not be shown while out-of-character.",
-	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT = "Hide menu entries while in combat",
-	UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP = "If checked, additional menu entries will not be shown while in combat.",
-	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES = "Hide menu entries while in instances",
-	UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP = "If checked, additional menu entries will not be shown while in instanced content.",
-	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES = "Hide menu entries on unit frames",
-	UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP = "If checked, additional menu entries will not be shown in menus activated by right-clicking unit frames.",
-	WHATS_NEW_24_5 = [[# Changelog version 2.3.2
-
-## Added
-
-- Added settings for right-click options on unit frames and chat names.
-
-## Fixed
-
-- Fixed incorrect names showing up on Blizzard NPC nameplates.
-- Fixed display issue with KuiNameplates tank mode.
-- Fixed a dependency issue preventing chat customization from working when using Prat and Listener.
-- Fixed localization not being properly applied to various settings.
-
-]],
-
+	REG_TT_ZONE = "Zone",
+	CO_TOOLTIP_ZONE = "Show zone",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1615,8 +1615,9 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 
 	REG_TT_ZONE = "Zone",
 	CO_TOOLTIP_ZONE = "Show zone",
+	CO_TOOLTIP_ZONE_TT = "This will only show if the target is not in the same zone as you.",
 	CO_TOOLTIP_HEALTH = "Show health",
-	CO_TOOLTIP_HEALTH_TT = "Note: Health will only show if the target is not at full health",
+	CO_TOOLTIP_HEALTH_TT = "This will only show if the target is not at full health.",
 	CO_TOOLTIP_HEALTH_DISABLED = "Disabled",
 	CO_TOOLTIP_HEALTH_NUMBER = "Number",
 	CO_TOOLTIP_HEALTH_PERCENT = "Percentage",

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1615,6 +1615,11 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 
 	REG_TT_ZONE = "Zone",
 	CO_TOOLTIP_ZONE = "Show zone",
+	CO_TOOLTIP_HEALTH = "Show health",
+	CO_TOOLTIP_HEALTH_DISABLED = "Disabled",
+	CO_TOOLTIP_HEALTH_NUMBER = "Number",
+	CO_TOOLTIP_HEALTH_PERCENT = "Percentage",
+	CO_TOOLTIP_HEALTH_BOTH = "Number + Percentage",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
Adds character tooltip fields for zone and health ( #218 ).
Zone field is only shown when the character is not in your zone (usually if they're in your group somewhere else).
Health field is only shown when the character is not full health, and is disabled by default.