### PR TITLE
Search VA field for "TotalRP3" in any position

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -333,7 +333,7 @@ local function onStart()
 			TRP3_API.r.sendMSPQuery(senderID);
 		end
 
-		if not isIgnored(senderID) and data.VA:sub(1, 8) ~= "TotalRP3" then
+		if not isIgnored(senderID) and not string.find(data.VA, "TotalRP3") then
 			local profile, character = getProfileForSender(senderID);
 			if not profile.characteristics then
 				profile.characteristics = {};


### PR DESCRIPTION
This fixes a hypothetical issue whereby if the VA field didn't begin with our addon ID, we could treat an incoming profile as not actually being sources from TRP3 and thus replace the profile ID among other things.