### PR TITLE
Split profile information responses into queues

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -388,6 +388,7 @@ stds.wow = {
 		"StopSound",
 		"strcmputf8i",
 		"SwapChatChannelByLocalID",
+		"tostringall",
 		"UIDropDownMenu_AddButton",
 		"UIDropDownMenu_AddSeparator",
 		"UIDROPDOWNMENU_INIT_MENU",

--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -121,14 +121,14 @@ local function unregisterMessageTokenProgressHandler(handlerID)
 	subSystemsOnProgressDispatcher:UnregisterCallback(handlerID)
 end
 
-local function sendObject(prefix, object, channel, target, priority, messageToken, useLoggedMessages)
+local function sendObject(prefix, object, channel, target, priority, messageToken, useLoggedMessages, queue)
 	if not tContains(VALID_CHANNELS, channel) then
 		--if channel is ignored, default channel and bump everything along by one
-		channel, target, priority, messageToken, useLoggedMessages = "WHISPER", channel, target, priority, messageToken
+		channel, target, priority, messageToken, useLoggedMessages, queue = "WHISPER", channel, target, priority, messageToken, useLoggedMessages
 	end
 	if tContains(VALID_PRIORITIES, target) then
 		-- if target has values expected for priority, bump everything back by one
-		target, priority, messageToken, useLoggedMessages = nil, target, priority, messageToken
+		target, priority, messageToken, useLoggedMessages, queue = nil, target, priority, messageToken, useLoggedMessages
 	end
 
 	Ellyb.Assertions.isType(prefix, "string", "prefix");
@@ -164,6 +164,7 @@ local function sendObject(prefix, object, channel, target, priority, messageToke
 				priority = priority,
 				binaryBlob = not useLoggedMessages,
 				allowBroadcast = true,
+				queue = queue,
 			}
 		);
 	else

--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -152,10 +152,15 @@ local newVersionAlerts, extendedNewVersionAlerts = {}, {};
 
 local infoTypeTab = {
 	registerInfoTypes.CHARACTERISTICS,
-	registerInfoTypes.ABOUT,
 	registerInfoTypes.MISC,
-	registerInfoTypes.CHARACTER
+	registerInfoTypes.CHARACTER,
+	registerInfoTypes.ABOUT,
 };
+
+local function GenerateQueueName(query, infoType, target)
+	-- Example queue name: "TRP3-SI-ABOUT-Solanya-Moogle"
+	return string.join("-", tostringall("TRP3", query, string.upper(infoType), target));
+end
 
 local COMPANION_PREFIX = "comp_";
 
@@ -358,7 +363,17 @@ local function incomingInformationType(informationType, senderID)
 	end
 	if data then
 		log(("Send %s info to %s"):format(informationType, senderID));
-		AddOn_TotalRP3.Communications.sendObject(INFO_TYPE_SEND_PREFIX, {informationType, data}, senderID, INFO_TYPE_SEND_PRIORITY, nil, true);
+
+		local prefix = INFO_TYPE_SEND_PREFIX;
+		local object = { informationType, data };
+		local channel = "WHISPER";
+		local target = senderID;
+		local priority = INFO_TYPE_SEND_PRIORITY;
+		local messageToken = nil;
+		local useLoggedMessages = true;
+		local queue = GenerateQueueName(prefix, informationType, senderID);
+
+		AddOn_TotalRP3.Communications.sendObject(prefix, object, channel, target, priority, messageToken, useLoggedMessages, queue);
 	end
 end
 


### PR DESCRIPTION
Currently, when responding to a request for profile information we respond without making use of the queue feature of Chomp and place all messages into the default queue ("prefix-channel-target"). As when sending such requests we ask for the About text second, this causes that field to essentially block the sending back of all other data until the About text has been fully  received.

This change makes it so that individual information types are placed into their own queue of the form "prefix-subprefix-type-target"; this means that any information sent back in response to an incoming request no longer blocks other pieces of data being sent to that player.

For normal profiles which are expected to have larger about texts than any other section, the expectation is that this should make those feel a bit snappier as about text would no longer block the misc/character tables. For profiles that are just generally huge all around, the difference shouldn't hopefully be noticeably slower - in those cases we'd expect that the larger profile would cause generally slow comms anyway.