### PR TITLE
Don't create MSP profiles if VA field is empty

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -333,7 +333,7 @@ local function onStart()
 			TRP3_API.r.sendMSPQuery(senderID);
 		end
 
-		if not isIgnored(senderID) and not string.find(data.VA, "TotalRP3") then
+		if not isIgnored(senderID) and data.VA ~= "" and not string.find(data.VA, "TotalRP3") then
 			local profile, character = getProfileForSender(senderID);
 			if not profile.characteristics then
 				profile.characteristics = {};
@@ -570,7 +570,7 @@ function TRP3_API.r.sendMSPQuery(name, targetMode)
 		outstandingHelloRequests[name] = true;
 		msp:Request(name, { "VA" });
 	else
-		outstandingHelloRequests[name] = false;
+		outstandingHelloRequests[name] = nil;
 		msp:Request(name, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
 	end
 end


### PR DESCRIPTION
LibMSP currently has a bug (of sorts) where the "received" callback is executed irrespective of whether or not the message it has received is either a profile request or a response to a request we've made.

This causes a rare condition exacerbated by our nameplate module where if a player sees us for the first time in a session they'll send an MSP request for our VA field; this request would then trigger our received callback and as we'd likely not have VA data for the requester yet, we'd replace their active profile ID with a new MSP-based one because their VA field is empty and can't possibly contain the "TotalRP3" string.

To mitigate this, if the VA field is empty we won't process the received callback. This field should never be empty for valid MSP users, and this is a cheaper fix for now than trying to solve the issue in LibMSP directly at this point or swapping to the "updated" callback.