### PR TITLE
Recursively unprotect string content

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -379,7 +379,11 @@ local function UnprotectMessageContents(message, replacements)
 		return replacements[sequence] or "";
 	end
 
-	message = string.gsub(message, "|Ktrp%d+|k", UnprotectString);
+	repeat
+		local replaced;
+		message, replaced = string.gsub(message, "|Ktrp%d+|k", UnprotectString);
+	until replaced == 0;
+
 	return message;
 end
 


### PR DESCRIPTION
The hypothetical case is that a string like `[|Hlinkdata:1:2:3|hLink|h]` would be protected twice as the patterns applied to protect contents would first match the inner "|H" string and then the outer brackets.

On restoring strings we'd only do one loop and restore a string like `[|Ktrp1|k]`, so we need to continually unprotect strings until we stop making replacements.