### PR TITLE
Refresh directory list only when window is shown

### DIFF
--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -931,7 +931,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 
 	-- To try, but I'm afraid for performances ...
 	Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(unitID, _, dataType)
-		if getCurrentPageID() == REGISTER_LIST_PAGEID and unitID ~= Globals.player_id and (not dataType or dataType == "characteristics") then
+		if TRP3_MainFrame:IsShown() and getCurrentPageID() == REGISTER_LIST_PAGEID and unitID ~= Globals.player_id and (not dataType or dataType == "characteristics") then
 			refreshList();
 		end
 	end);


### PR DESCRIPTION
Not sure on the complete implications of this, all I know is that this solves the stupidly annoying ~0.5s stutter on my client if I've got the window closed on the directory tab when receiving profiles due to my ~18k profile directory.