### PR TITLE
Implement pooled queue strategy for profile comms

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -129,6 +129,7 @@ stds.wow = {
 			fields = {
 				"band",
 				"bor",
+				"bxor",
 			},
 		},
 
@@ -426,6 +427,7 @@ stds.wow = {
 		"UnitPVPName",
 		"UnitRace",
 		"UnitSex",
+		"Wrap",
 
 		-- Global Mixins and UI Objects
 

--- a/totalRP3/core/impl/AdvancedSettings.lua
+++ b/totalRP3/core/impl/AdvancedSettings.lua
@@ -148,6 +148,37 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		listCancel = true,
 	});
 
+	-- Comms settings
+
+	tAppendAll(TRP3_API.ADVANCED_SETTINGS_STRUCTURE.elements,
+		{
+			{
+				inherit = "TRP3_ConfigH1",
+				title = loc.CONFIG_COMMS_SETTINGS_HEADER,
+			},
+			{
+				inherit = "TRP3_ConfigSlider",
+				title = loc.CONFIG_COMMS_QUEUE_POOL_COUNT,
+				help = loc.CONFIG_COMMS_QUEUE_POOL_COUNT_DESCRIPTION,
+				configKey = "Exchange_QueuePoolCount",
+				min = TRP3_API.r.MINIMUM_QUEUE_POOL_COUNT,
+				max = TRP3_API.r.MAXIMUM_QUEUE_POOL_COUNT,
+				step = 1,
+				integer = true,
+			},
+			{
+				inherit = "TRP3_ConfigSlider",
+				title = loc.CONFIG_COMMS_QUEUE_POOL_WEIGHT_THRESHOLD,
+				help = loc.CONFIG_COMMS_QUEUE_POOL_WEIGHT_THRESHOLD_DESCRIPTION,
+				configKey = "Exchange_QueuePoolWeightThreshold",
+				min = TRP3_API.r.MINIMUM_QUEUE_POOL_MINIMUM_WEIGHT,
+				max = TRP3_API.r.MAXIMUM_QUEUE_POOL_MINIMUM_WEIGHT,
+				step = 1,
+				integer = true,
+			},
+		}
+	);
+
 	-- Reset button
 	tinsert(TRP3_API.ADVANCED_SETTINGS_STRUCTURE.elements, 1, {
 		inherit = "TRP3_ConfigH1",

--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -218,7 +218,7 @@ end
 
 -- Estimate the number of packet needed to send a object.
 local function estimateStructureLoad(object, shouldBeCompressed)
-	return estimateStructureSize(object, shouldBeCompressed) / Chomp.GetBPS();
+	return math.ceil(estimateStructureSize(object, shouldBeCompressed) / Chomp.GetBPS());
 end
 
 AddOn_TotalRP3.Communications = {

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1674,6 +1674,13 @@ We are aware of a current issue on Retail causing **quest item usage from the ob
 	CREDITS_WEBSITE_LINK_TEXT = "Website",
 	CREDITS_NAME_WITH_ROLE = "%1$s (%2$s)",
 	CREDITS_GUILD_NAME = "<%1$s>",
+
+	CONFIG_COMMS_SETTINGS_HEADER = "Communications settings",
+	CONFIG_COMMS_QUEUE_POOL_COUNT = "Queue pool size",
+	CONFIG_COMMS_QUEUE_POOL_COUNT_DESCRIPTION = "Controls the size of the queue pool used for profile communications.|n|nLower values will reduce latency of addon communications for non-RP profile data, but may increase the amount of time before other players begin to receive any profile data at all in high load scenarios.",
+	CONFIG_COMMS_QUEUE_POOL_WEIGHT_THRESHOLD = "Queue pool data weight threshold",
+	CONFIG_COMMS_QUEUE_POOL_WEIGHT_THRESHOLD_DESCRIPTION = "Controls the minimum weight your RP profile data must be before queue pools will be used.|n|nFor larger profiles, increasing this value may |cffff0000severely deteriorate|r the performance of all addon communications.",
+
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
This reverts the previous change to comms in 2.3.3 which has, from user feedback on Moon Guard, made things worse instead of better.

The new change implements a pair of queue strategies - independent and pooled - which are selected based on the data being sent and the approximate size of the data.

For all comms except sending profile data the independent strategy is used, which leaves queuing down to the underlying transport library.

When sending profile data, if the size of the players' profile is above a certain threshold of messages the pooled strategy will be enabled. This uses a fixed number of queues for sending data, which should reduce cross-addon contention (as well as for metadata comms) and not allow individual profile transfers to choke one another out, but for larger profiles this comes at the expense of increased latency data is sent to any single player should the queues become large.