### PR TITLE
Implement smart nameplate queue strategy

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -178,10 +178,22 @@ stds.wow = {
 			},
 		},
 
+		C_BattleNet = {
+			fields = {
+				"GetAccountInfoByGUID",
+			},
+		},
+
 		C_ChatInfo = {
 			fields = {
 				"RegisterAddonMessagePrefix",
 				"SwapChatChannelsByChannelIndex",
+			},
+		},
+
+		C_FriendList = {
+			fields = {
+				"IsFriend",
 			},
 		},
 
@@ -281,6 +293,7 @@ stds.wow = {
 
 		"AbbreviateLargeNumbers",
 		"Ambiguate",
+		"BNGetGameAccountInfoByGUID",
 		"BNGetInfo",
 		"CallErrorHandler",
 		"ChatEdit_FocusActiveWindow",
@@ -346,6 +359,7 @@ stds.wow = {
 		"IsAddOnLoaded",
 		"IsAltKeyDown",
 		"IsControlKeyDown",
+		"IsGuildMember",
 		"IsInGroup",
 		"IsInInstance",
 		"IsInRaid",
@@ -409,6 +423,7 @@ stds.wow = {
 		"UnitGUID",
 		"UnitHealth",
 		"UnitHealthMax",
+		"UnitInAnyGroup",
 		"UnitInParty",
 		"UnitInRaid",
 		"UnitIsAFK",
@@ -440,6 +455,7 @@ stds.wow = {
 		"BaseMapPoiPinMixin",
 		"ChatFrame1EditBox",
 		"ChatTypeInfo",
+		"DoublyLinkedListMixin",
 		"DropDownList1",
 		"FontableFrameMixin",
 		"GameFontNormal",

--- a/totalRP3/modules/NamePlates/NamePlates.xml
+++ b/totalRP3/modules/NamePlates/NamePlates.xml
@@ -13,8 +13,10 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 -->
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI-Classic.xsd">
 	<Include file="NamePlates_Shared.lua"/>
+	<Include file="NamePlates_RequestQueue.lua"/>
 	<Include file="NamePlates_Core.lua"/>
 	<Include file="NamePlates_Blizzard.lua"/>
 	<Include file="NamePlates_Kui.lua"/>

--- a/totalRP3/modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Core.lua
@@ -118,24 +118,6 @@ local function ShouldUseClassColorFallback()
 	return TRP3_API.configuration.getValue("NamePlates_EnableClassColorFallback");
 end
 
-local function GetUnitRegisterID(unitToken)
-	local unitType = TRP3_API.ui.misc.getTargetType(unitToken);
-	local registerID;
-
-	if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.CHARACTER then
-		registerID = TRP3_API.utils.str.getUnitID(unitToken);
-	elseif unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then
-		registerID = TRP3_API.ui.misc.getCompanionFullID(unitToken, unitType);
-	end
-
-	if registerID and string.find(registerID, UNKNOWNOBJECT, 1, true) == 1 then
-		-- The player that owns this profile isn't yet known to the client.
-		registerID = nil;
-	end
-
-	return registerID;
-end
-
 local function GetUnitRoleplayStatus(unitToken)
 	local player;
 
@@ -343,7 +325,6 @@ local TRP3_NamePlates = {};
 
 function TRP3_NamePlates:OnModuleInitialize()
 	self.callbacks = LibStub:GetLibrary("CallbackHandler-1.0"):New(self);
-	self.characterRequestTimes = {};
 	self.unitRegisterIDs = {};
 
 	self.callbacks.OnUsed = function() self:OnModuleUsed(); end;
@@ -382,6 +363,8 @@ function TRP3_NamePlates:ActivateModule()
 
 	self.moduleActivated = true;
 
+	TRP3_NamePlatesRequestQueue:Init();
+
 	TRP3_API.Ellyb.GameEvents.registerCallback("NAME_PLATE_UNIT_ADDED", function(...) return self:OnNamePlateUnitAdded(...); end);
 	TRP3_API.Ellyb.GameEvents.registerCallback("NAME_PLATE_UNIT_REMOVED", function(...) return self:OnNamePlateUnitRemoved(...); end);
 	TRP3_API.Ellyb.GameEvents.registerCallback("UNIT_NAME_UPDATE", function(...) return self:OnUnitNameUpdate(...); end);
@@ -400,6 +383,7 @@ function TRP3_NamePlates:OnNamePlateUnitAdded(unitToken)
 end
 
 function TRP3_NamePlates:OnNamePlateUnitRemoved(unitToken)
+	TRP3_NamePlatesRequestQueue:DequeueUnitQuery(unitToken);
 	self:ClearRegisterIDForUnit(unitToken);
 	self:UpdateNamePlateForUnit(unitToken);
 end
@@ -437,7 +421,7 @@ end
 
 function TRP3_NamePlates:GetUnitDisplayInfo(unitToken)
 	local unitType = TRP3_API.ui.misc.getTargetType(unitToken);
-	local registerID = GetUnitRegisterID(unitToken);
+	local registerID = TRP3_NamePlatesUtil.GetUnitRegisterID(unitToken);
 
 	if not ShouldCustomizeUnitNamePlate(unitToken) then
 		return nil;  -- Customizations disabled for this unit.
@@ -475,35 +459,11 @@ function TRP3_NamePlates:UpdateNamePlateForRegisterID(registerID)
 	end
 end
 
-function TRP3_NamePlates:ShouldRequestProfileFromCharacter(characterID)
-	local REQUEST_WAIT_SEC = 90;
-
-	local lastRequestTime = self.characterRequestTimes[characterID] or -math.huge;
-
-	if not ShouldRequestProfiles() then
-		return false;  -- Requests are disabled.
-	elseif GetTime() < (lastRequestTime + REQUEST_WAIT_SEC) then
-		return false;  -- Profile information was recently requested.
-	else
-		return true;
-	end
-end
-
 function TRP3_NamePlates:RequestUnitProfile(unitToken)
-	local unitType = TRP3_API.ui.misc.getTargetType(unitToken);
-	local characterID;
-
-	if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.CHARACTER then
-		characterID = TRP3_API.utils.str.getUnitID(unitToken);
-	elseif unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then
-		characterID = select(2, TRP3_API.ui.misc.getCompanionFullID(unitToken, unitType));
-	end
-
-	if self:ShouldRequestProfileFromCharacter(characterID) then
-		TRP3_API.r.sendQuery(characterID);
-		TRP3_API.r.sendMSPQuery(characterID);
-
-		self.characterRequestTimes[characterID] = GetTime();
+	if ShouldRequestProfiles() then
+		TRP3_NamePlatesRequestQueue:EnqueueUnitQuery(unitToken);
+	else
+		TRP3_NamePlatesRequestQueue:DequeueUnitQuery(unitToken);
 	end
 end
 
@@ -514,7 +474,7 @@ function TRP3_NamePlates:ClearRegisterIDForUnit(unitToken)
 end
 
 function TRP3_NamePlates:UpdateRegisterIDForUnit(unitToken)
-	local registerID = GetUnitRegisterID(unitToken);
+	local registerID = TRP3_NamePlatesUtil.GetUnitRegisterID(unitToken);
 
 	if registerID and self.unitRegisterIDs[unitToken] ~= registerID then
 		self:RequestUnitProfile(unitToken);

--- a/totalRP3/modules/NamePlates/NamePlates_RequestQueue.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_RequestQueue.lua
@@ -1,0 +1,362 @@
+--[[
+	Copyright 2021 Total RP 3 Development Team
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+]]--
+
+-- Enumeration of priorities attributable to any single request. Anything
+-- aside from the "Normal" priority is considered a "priority request" and
+-- will gain queue perks.
+--
+-- Note that the values assigned to the keys in this enumeration are used
+-- for sorting; lower values have a higher priority.
+local RequestPriority =
+{
+	Friend = 1,  -- Priority used for friended units.
+	Group = 2,   -- Priority used for grouped units.
+	Guild = 3,   -- Priority used for guild members.
+	Normal = 4,  -- Default priority for other units.
+};
+
+local function GetOrCreateTable(t, key)
+	if t[key] ~= nil then
+		return t[key];
+	end
+
+	t[key] = {};
+	return t[key];
+end
+
+local function GetRequestPriority(requestInfo)
+	if requestInfo.isFriend then
+		return RequestPriority.Friend;
+	elseif UnitInParty(requestInfo.unit) or UnitInRaid(requestInfo.unit) then
+		return RequestPriority.Group;
+	elseif requestInfo.isGuildMember then
+		return RequestPriority.Guild;
+	else
+		return RequestPriority.Normal;
+	end
+end
+
+local function IsRequestEligibleToSend(requestInfo)
+	return GetTime() >= requestInfo.eligibleAt;
+end
+
+local function RequestSortPredicate(requestInfoA, requestInfoB)
+	do  -- Priority check
+		local requestPriorityA = requestInfoA.priority;
+		local requestPriorityB = requestInfoB.priority;
+
+		if requestPriorityA < requestPriorityB then
+			return true;
+		elseif requestPriorityB < requestPriorityA then
+			return false;
+		end
+	end
+
+	do  -- Eligibility check
+		local requestEligibilityA = requestInfoA.eligibleAt;
+		local requestEligibilityB = requestInfoB.eligibleAt;
+
+		if requestEligibilityA < requestEligibilityB then
+			return true;
+		elseif requestEligibilityB < requestEligibilityA then
+			return false;
+		end
+	end
+
+	-- Everything is identical so go on insertion order.
+	return requestInfoA.order < requestInfoB.order;
+end
+
+TRP3_NamePlatesRequestQueue = {};
+
+-- Period in fractional seconds at which the request queue and slot cooldowns
+-- are processed.
+--
+-- Lower values will be more responsive but may slightly increase CPU usage.
+TRP3_NamePlatesRequestQueue.ProcessRate = 0.5;
+
+-- Time in fractional seconds that a unit must be enqueued for before the
+-- request for its nameplate will be dispatched.
+--
+-- Lower values will cause more requests to be sent on average; higher values
+-- reduce "one hit wonders" for people you might quickly see on-screen for
+-- a moment and then never again.
+TRP3_NamePlatesRequestQueue.EligibilityDelay = 2.5;
+
+-- Number of request "slots" that the system has. Each request in the queue
+-- consumes a slot when sent, and slots are regained based on a recharge
+-- period that must elapse.
+--
+-- A higher slot count means that we can burst-request more nameplates in a
+-- single go, and a lower slot count will reduce the number of requests that
+-- can be issued within a close time period.
+TRP3_NamePlatesRequestQueue.SlotLimit = 5;
+
+-- Period in fractional sections that request slots will be regained at.
+--
+-- Lower values will allow requests to be sent quicker if the slot limit is
+-- reached, and higher values will potentially reduce the number of requests
+-- that may be outstanding.
+TRP3_NamePlatesRequestQueue.SlotRechargePeriod = 1.25;
+
+-- Time in fractional seconds that must pass before a request for a character
+-- that was already previously requested can be re-issued.
+--
+-- Higher values mean that if we see the nameplate for the same character
+-- repeatedly within a session, we won't re-download any associated data
+-- for a while. Lower values will cause such cases to be more responsive
+-- but could significantly increase bandwidth consumption.
+TRP3_NamePlatesRequestQueue.CharacterCooldown = 300;
+
+function TRP3_NamePlatesRequestQueue:Init()
+	self.requestsInfo = {};
+	self.requestsQueue = CreateFromMixins(DoublyLinkedListMixin);
+	self.requestsOrdered = {};
+	self.requestsCount = 0;
+
+	self.slotsAvailable = TRP3_NamePlatesRequestQueue.SlotLimit;
+	self.slotsCooldown = math.huge;
+
+	self.characterCooldowns = {};
+
+	do
+		local function TickerCallback()
+			return self:OnQueueProcessTimerTicked();
+		end;
+
+		self.processTicker = C_Timer.NewTicker(TRP3_NamePlatesRequestQueue.ProcessRate, TickerCallback);
+	end
+end
+
+function TRP3_NamePlatesRequestQueue:GetQueueSize()
+	return self.requestsQueue.nodeCount;
+end
+
+function TRP3_NamePlatesRequestQueue:EnqueueUnitQuery(unitToken)
+	local requestInfo = self:GetUnitRequestInfo(unitToken);
+
+	-- If a node already exists for this unit then we'll dequeue it
+	-- implicitly, since there isn't much else we can do that's sane.
+
+	if requestInfo then
+		self:DequeueUnitQuery(unitToken);
+	end
+
+	-- For sanity, don't permit non-existent or unknown units to be queued.
+
+	local registerID = TRP3_NamePlatesUtil.GetUnitRegisterID(unitToken);
+
+	if not registerID then
+		return;
+	end
+
+	if not requestInfo then
+		requestInfo = {};
+	end
+
+	local guid = UnitGUID(unitToken);
+	local currentTime = GetTime();
+
+	requestInfo.unit = unitToken;
+	requestInfo.guid = guid;
+	requestInfo.registerID = registerID;
+	requestInfo.enqueuedAt = currentTime;
+	requestInfo.order = self.requestsCount;
+
+	-- Eligibility of a request will typically incur a small delay unless
+	-- the character associated with this nameplate has previously been
+	-- requested; if so then the delay is much larger.
+
+	if self.characterCooldowns[registerID] and self.characterCooldowns[registerID] > GetTime() then
+		local remainingCooldown = self.characterCooldowns[registerID] - currentTime;
+		requestInfo.eligibleAt = currentTime + remainingCooldown;
+	else
+		requestInfo.eligibleAt = currentTime + TRP3_NamePlatesRequestQueue.EligibilityDelay;
+	end
+
+	-- Some attributes about the unit we're requesting from are cached ahead
+	-- of time; these are things that are unlikely to change while this
+	-- request is queued or are otherwise possibly expensive to query
+	-- periodically.
+
+	if C_FriendList.IsFriend(guid) then
+		requestInfo.isFriend = true;
+	elseif C_BattleNet then
+		requestInfo.isFriend = (C_BattleNet.GetAccountInfoByGUID(guid) ~= nil);
+	else
+		requestInfo.isFriend = (BNGetGameAccountInfoByGUID(guid) ~= nil);
+	end
+
+	requestInfo.isGuildMember = IsGuildMember(guid);
+
+	-- The fields below are considered dynamic and may be modified while the
+	-- request is enqueued; see UpdateDynamicRequestData for details.
+
+	requestInfo.priority = RequestPriority.Normal;
+
+	self.requestsInfo[unitToken] = requestInfo;
+	self.requestsCount = self.requestsCount + 1;
+	self.requestsQueue:PushBack(requestInfo);
+end
+
+function TRP3_NamePlatesRequestQueue:DequeueUnitQuery(unitToken)
+	local requestInfo = self:GetUnitRequestInfo(unitToken);
+
+	if requestInfo then
+		self.requestsQueue:Remove(requestInfo);
+		self.requestsInfo[unitToken] = nil;
+	end
+end
+
+function TRP3_NamePlatesRequestQueue:DequeueAllQueries()
+	table.wipe(self.requestsOrdered);
+	table.wipe(self.requestsQueue);
+	table.wipe(self.requestsInfo);
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:GetUnitRequestInfo(unitToken)
+	return self.requestsInfo[unitToken];
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:GetOrCreateUnitRequestInfo(unitToken)
+	return GetOrCreateTable(self.requestsInfo, unitToken);
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:UpdateDynamicRequestData(requestInfo)
+	-- Priority is dynamic due to grouping information.
+	requestInfo.priority = GetRequestPriority(requestInfo);
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:SubmitRequest(requestInfo)
+	local registerID = requestInfo.registerID;
+	local unitToken = requestInfo.unit;
+
+	self:DequeueUnitQuery(unitToken);
+
+	TRP3_API.r.sendQuery(registerID);
+	TRP3_API.r.sendMSPQuery(registerID);
+
+	self.characterCooldowns[registerID] = GetTime() + TRP3_NamePlatesRequestQueue.CharacterCooldown;
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:AcquireRequestSlot()
+	if self.slotsAvailable == 0 then
+		return false;  -- No request slots available.
+	end
+
+	-- On acquisition of the first request slot we need to start the cooldown
+	-- recharge it.
+
+	if self.slotsAvailable == TRP3_NamePlatesRequestQueue.SlotLimit then
+		self.slotsCooldown = TRP3_NamePlatesRequestQueue.SlotRechargePeriod;
+	end
+
+	self.slotsAvailable = self.slotsAvailable - 1;
+	return true;
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:ReleaseRequestSlot()
+	if self.slotsAvailable >= TRP3_NamePlatesRequestQueue.SlotLimit then
+		-- Already at the request slot limit. Setting the cooldown to infinity
+		-- here is just for safety; we _shouldn't_ need it but let's be safe.
+
+		self.slotsCooldown = math.huge;
+
+		return false;
+	end
+
+	self.slotsAvailable = self.slotsAvailable + 1;
+
+	-- If we've regained all our request slots we'll disable the cooldown
+	-- by setting it to infinity; otherwise it needs to be reset to that
+	-- of the recharge rate.
+
+	if self.slotsAvailable == TRP3_NamePlatesRequestQueue.SlotLimit then
+		self.slotsCooldown = math.huge;
+	else
+		self.slotsCooldown = self.slotsCooldown + TRP3_NamePlatesRequestQueue.SlotRechargePeriod;
+	end
+
+	return true;
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:ProcessRequestSlotCooldown(dt)
+	self.slotsCooldown = self.slotsCooldown - dt;
+
+	while self.slotsCooldown <= 0 do
+		self:ReleaseRequestSlot();
+	end
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:ProcessRequestQueue()
+	-- The ordered request table is reused on each process operation;
+	-- we copy the nodes present in the queue to the table to the first
+	-- n indices (where n is the queue length) and nil out anything left
+	-- over in the ordered queue.
+	--
+	-- The resulting list is then sorted via our predicate.
+
+	for index, requestInfo in self.requestsQueue:EnumerateNodes() do
+		self:UpdateDynamicRequestData(requestInfo);
+		self.requestsOrdered[index] = requestInfo;
+	end
+
+	for index = #self.requestsOrdered, self:GetQueueSize() + 1, -1 do
+		self.requestsOrdered[index] = nil;
+	end
+
+	table.sort(self.requestsOrdered, RequestSortPredicate);
+
+	-- With everything ordered we can now actually process the queue. Note
+	-- that entries aren't removed from this table during iteration; if
+	-- something is dequeued it will remain and instead be cleared when
+	-- next processed.
+	--
+	-- The ordering should be such that eligible requests are always at
+	-- the front of the queue - so if we find something that's not eligible
+	-- we use that as a signal to stop processing early.
+
+	for _, requestInfo in ipairs(self.requestsOrdered) do
+		if not IsRequestEligibleToSend(requestInfo) then
+			break;  -- Request isn't eligible.
+		elseif not self:AcquireRequestSlot() then
+			break;  -- No request slots available yet.
+		end
+
+		self:SubmitRequest(requestInfo);
+	end
+end
+
+-- private
+function TRP3_NamePlatesRequestQueue:OnQueueProcessTimerTicked()
+	-- Don't allow errors in processing to kill the ticker; if an error occurs
+	-- we'll just flush the whole queue and hope the user doesn't re-encounter
+	-- the problem.
+
+	xpcall(self.ProcessRequestSlotCooldown, CallErrorHandler, self, TRP3_NamePlatesRequestQueue.ProcessRate);
+
+	if not xpcall(self.ProcessRequestQueue, CallErrorHandler, self) then
+		self:DequeueAllQueries();
+	end
+end

--- a/totalRP3/modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/modules/NamePlates/NamePlates_Shared.lua
@@ -60,6 +60,24 @@ function TRP3_NamePlatesUtil.PrependRoleplayStatusToFontString(fontstring, rolep
 	end
 end
 
+function TRP3_NamePlatesUtil.GetUnitRegisterID(unitToken)
+	local unitType = TRP3_API.ui.misc.getTargetType(unitToken);
+	local registerID;
+
+	if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.CHARACTER then
+		registerID = TRP3_API.utils.str.getUnitID(unitToken);
+	elseif unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then
+		registerID = TRP3_API.ui.misc.getCompanionFullID(unitToken, unitType);
+	end
+
+	if registerID and string.find(registerID, UNKNOWNOBJECT, 1, true) == 1 then
+		-- The player that owns this profile isn't yet known to the client.
+		registerID = nil;
+	end
+
+	return registerID;
+end
+
 --
 -- Configuration Data
 --


### PR DESCRIPTION
This reworks the nameplate request system to use a much smarter queue mechanism than we currently have.

Our existing approach only applies a cooldown on a per-character level, such that we only throttle requests sent to nameplates of units we've already seen at most once per 90 seconds. Unfortunately it doesn't account for a few real-world issues.

Firstly, nameplates often quickly appear on-screen and then go off. These can be thought of as one-hit wonders for people you're probably not going to interact with and whose data isn't quite so important.

Secondly, you can walk into a field of a hundred players and turn your nameplates on and suddenly request every visible nameplates' profile immediately all at the same time. This completely throttles comms on both sender and receiver ends.

To resolve this a smarter queue system is implemented for nameplate requests with the following characteristics.

To solve the first issue, an enqueued request for a nameplate must first exceed a minimum eligibility time before the request is sent. This is kept small - at around 2.5 seconds - and should solve the issue of nameplates briefly popping onto the screen an disappearing issuing a full request for their data.

For the second issue, the queue system has an internal semaphore representing request "slots". Each attempt to send a request will first attempt to obtain a slot and decrement an internal counter; if no slots are available the request won't be dispatched immediately and must wait until a "recharge period" has elapsed. Each tick of the period regains a single request slot.

The idea behind this is to significantly hamstring the ability to burst request nameplate information; if you walk into a field of a hundred players who all stay on screen to exceed their eligibility period, you will only send at-most five requests to people on-screen immediately and then one additional request each time a slot is regained every ~1.25s thereafter.

Finally, the existing system of applying a per-character cooldown is kept around - so if you repeatedly see a nameplate for someone you've already requested then they will gain a significantly increased eligibility time. The timer for this has been increased from 90 seconds to 5 minutes; the idea is if you're interacting with someone for that long you'll probably have seen their tooltip accidentally and requested updated data anyway, or that they won't have made any change to their
profile worth querying.


The changes described significantly reduce the amount of requests that can be sent in any short period of time, however for the user experience this will come at a significantly increased latency as far as seeing an undecorated nameplate and actually receiving their profile data.

To minimize this, there also exists a basic system of prioritized requests. Prioritized requests will always be placed at the front of the queue and apply to the nameplates of units that are either in your friends list - both character and Battle.net, units that you are presently grouped with, and members of your own guild.