### PR TITLE
Fix incorrect vernum checks with profile exchange

### DIFF
--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -427,8 +427,8 @@ local function incomingVernumQuery(structure, senderID, sendBack)
 
 	-- Query specific data, depending on version number.
 	TryQueryInformation(senderID, registerInfoTypes.CHARACTERISTICS, structure[VERNUM_QUERY_INDEX_CHARACTER_CHARACTERISTICS_V]);
-	TryQueryInformation(senderID, registerInfoTypes.MISC, structure[VERNUM_QUERY_INDEX_CHARACTER_MISC_V]);
 	TryQueryInformation(senderID, registerInfoTypes.CHARACTER, structure[VERNUM_QUERY_INDEX_CHARACTER_CHARACTER_V]);
+	TryQueryInformation(senderID, registerInfoTypes.MISC, structure[VERNUM_QUERY_INDEX_CHARACTER_MISC_V]);
 	TryQueryInformation(senderID, registerInfoTypes.ABOUT, structure[VERNUM_QUERY_INDEX_CHARACTER_ABOUT_V]);
 
 	-- Battle pet


### PR DESCRIPTION
So it turns out that the order of things in the infoTypeTab table, which was changed in 2.3.3 to deprioritize About texts has a rather insidious and hidden link to the query index constants about thirty lines higher in the script that is entirely undocumented and completely unobvious.

In effect since 2.3.3 each time we've been checking if we should request information from someone we've been comparing the wrong version numbers, so every request has been a full profile transfer. This changeset removes that table and makes the whole thing painfully explicit so that no one ever trips up over this again.

There's also a change to clean up some upvalues which, in typical TRP3 codebase fashion, included renaming functions to things that are completely different. "time" is not "GetTime" - if anyone reads code and sees a call to the time function they're going to assume it's an integral timestamp representing seconds since the epoch _because that is what the time function does_. This is basically like redefining true to false, it goes completely against expectations and is like setting up landmines for people to walk on.