### PR TITLE
Use "bcc" game type for packager

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,16 +34,6 @@ jobs:
           name: totalRP3-PR-${{ github.event.number }}
           path: .release/
 
-      - name: Create Classic Package
-        uses: BigWigsMods/packager@master
-        with:
-          args: -d -z -g classic
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: totalRP3-PR-${{ github.event.number }}-classic
-          path: .release/
-
       - name: Send Webhook Notification
         if: failure()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
-      - name: Create BC Package
+      - name: Create BCC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -g bc
+          args: -g bcc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -27,10 +27,10 @@ jobs:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
-      - name: Create BC Package
+      - name: Create BCC Package
         uses: BigWigsMods/packager@master
         with:
-          args: -w 0 -g bc
+          args: -w 0 -g bcc
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,5 +1,5 @@
 ## Interface: 90005
-## Interface-BC: 20501
+## Interface-BCC: 20501
 ## Interface-Classic: 11307
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,11 +1,18 @@
 ## Interface: 90005
-## Interface-BC: 20501
+## Interface-BCC: 20501
 ## Interface-Classic: 11307
 ## Title: Total RP 3: Data
 ## Author: Telkostrasz & Ellypse
+## Version: @project-version@
 ## Notes: The best data storage for the best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
-## URL: http://totalrp3.info
-## DefaultState: Enabled
-## LoadOnDemand: 1
 ## SavedVariables: TRP3_Register
+## LoadOnDemand: 1
+
+## X-Category: Roleplay
+## X-License: Apache-2.0
+## X-Website: http://totalrp3.info
+## X-Curse-Project-ID: 75973
+## X-Wago-ID: q96dnGOm
+## X-WoWI-ID: 24113
+
 totalRP3_Data.lua


### PR DESCRIPTION
The packager changed this from "bc" to "bcc" in an incompatible manner last night for consistency with the multiple interface version stuff we _actually_ got from Blizzard. I also did a quick pass over the Data addons' TOC to make it more consistent with the main one.