### PR TITLE
Add soundFile flag in sound handler

### DIFF
--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -1115,7 +1115,7 @@ function Utils.music.playSoundFileID(soundFileID, channel, source)
 	assert(soundFileID, "soundFileID can't be nil.")
 	local willPlay, handlerID = PlaySoundFile(soundFileID, channel);
 	if willPlay then
-		tinsert(soundHandlers, {channel = channel, id = soundFileID, handlerID = handlerID, source = source, date = date("%H:%M:%S"), stopped = false});
+		tinsert(soundHandlers, {channel = channel, id = soundFileID, handlerID = handlerID, source = source, date = date("%H:%M:%S"), stopped = false, soundFile = true});
 		if TRP3_SoundsHistoryFrame then
 			TRP3_SoundsHistoryFrame.onSoundPlayed();
 		end


### PR DESCRIPTION
Very boring change, as I'm adding the ability to play a sound file in Extended, I need a way to tell whether a handler is using a sound ID or a soundfile ID so that the sounds history can replay the appropriate type.