### PR TITLE
9.1.5 player scan fix

### DIFF
--- a/totalRP3/modules/map/MapPoiMixins.lua
+++ b/totalRP3/modules/map/MapPoiMixins.lua
@@ -36,11 +36,13 @@ local CoalescedMapPinMixin = {};
 
 function CoalescedMapPinMixin:OnMouseEnter()
 	local tooltip = Tooltips.getTooltip(self);
-	for marker in self:GetMap():EnumerateAllPins() do
-		if marker:IsVisible() and marker:IsMouseOver() then
-			tooltip:AddTempLine(marker.tooltipLine)
+	self:GetMap():ExecuteOnAllPins(
+		function(marker)
+			if marker:IsVisible() and marker:IsMouseOver() then
+				tooltip:AddTempLine(marker.tooltipLine)
+			end
 		end
-	end
+	);
 	tooltip:Show();
 end
 MapPoiMixins.CoalescedMapPinMixin = CoalescedMapPinMixin;
@@ -80,11 +82,13 @@ function GroupedCoalescedMapPinMixin:OnMouseEnter()
 	local markerTooltipEntries = Tables.getTempTable();
 	-- Iterate over the blips in a first pass to build a list of all the
 	-- ones we're mousing over.
-	for marker in self:GetMap():EnumerateAllPins() do
-		if marker:IsVisible() and marker:IsMouseOver() then
-			table.insert(markerTooltipEntries, marker);
+	self:GetMap():ExecuteOnAllPins(
+		function(marker)
+			if marker:IsVisible() and marker:IsMouseOver() then
+				table.insert(markerTooltipEntries, marker);
+			end
 		end
-	end
+	);
 
 	-- Sort the entries prior to display.
 	sort(markerTooltipEntries, sortMarkerEntries);

--- a/totalRP3/modules/map/MapPoiMixins.lua
+++ b/totalRP3/modules/map/MapPoiMixins.lua
@@ -115,8 +115,8 @@ function GroupedCoalescedMapPinMixin:OnMouseEnter()
 	-- when the type changes. Requires the entries be sorted by category.
 	for _, marker in pairs(markerTooltipEntries) do
 		if marker.categoryName ~= lastCategory and marker.tooltipLine then
-		-- If the previous category was nil we assume this is
-		-- the first, so we'll not put a separating border in.
+			-- If the previous category was nil we assume this is
+			-- the first, so we'll not put a separating border in.
 			if lastCategory ~= nil then
 				tooltip:AddTempLine(TOOLTIP_CATEGORY_SEPARATOR, WHITE);
 			end

--- a/totalRP3/modules/map/MapPoiMixins.lua
+++ b/totalRP3/modules/map/MapPoiMixins.lua
@@ -114,24 +114,24 @@ function GroupedCoalescedMapPinMixin:OnMouseEnter()
 	-- This layout will put the category status text above entries
 	-- when the type changes. Requires the entries be sorted by category.
 	for _, marker in pairs(markerTooltipEntries) do
-	if marker.categoryName ~= lastCategory and marker.tooltipLine then
-	-- If the previous category was nil we assume this is
-	-- the first, so we'll not put a separating border in.
-	if lastCategory ~= nil then
-	tooltip:AddTempLine(TOOLTIP_CATEGORY_SEPARATOR, WHITE);
-	end
+		if marker.categoryName ~= lastCategory and marker.tooltipLine then
+		-- If the previous category was nil we assume this is
+		-- the first, so we'll not put a separating border in.
+			if lastCategory ~= nil then
+				tooltip:AddTempLine(TOOLTIP_CATEGORY_SEPARATOR, WHITE);
+			end
 
-	tooltip:AddTempLine(marker.categoryName or "");
-	lastCategory = marker.categoryName;
-	end
+			tooltip:AddTempLine(marker.categoryName or "");
+			lastCategory = marker.categoryName;
+		end
 
-	tooltip:AddTempLine(marker.tooltipLine or "", WHITE);
+		tooltip:AddTempLine(marker.tooltipLine or "", WHITE);
 	end
 
 	Tables.releaseTempTable(markerTooltipEntries)
 
 	tooltip:Show();
-	end
+end
 MapPoiMixins.GroupedCoalescedMapPinMixin = GroupedCoalescedMapPinMixin;
 --endregion
 


### PR DESCRIPTION
9.1.5 removed EnumerateAllPins which caused the player scan pins to error out when hovering them. I'm now making use of the convenient ExecuteOnAllPins to achieve the exact same result and confirmed after test that it works as previously.