### PR TITLE
Bump TOCs and perform single package release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,10 +24,10 @@ jobs:
           args: -no-color
           files: $(git ls-files '*.lua' '*.sh' '*.xml' ':!:totalRP3/libs/**/*' ':!:totalRP3/tools/Locale.lua')
 
-      - name: Create Retail Package
-        uses: BigWigsMods/packager@master
+      - name: Create Package
+        uses: BigWigsMods/packager@v2
         with:
-          args: -d -z
+          args: -d -S -z
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,28 +15,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Create Retail Package
-        uses: BigWigsMods/packager@master
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
-
-      - name: Create BCC Package
-        uses: BigWigsMods/packager@master
+      - name: Create Package
+        uses: BigWigsMods/packager@v2
         with:
-          args: -g bcc
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
-
-      - name: Create Classic Package
-        uses: BigWigsMods/packager@master
-        with:
-          args: -g classic
+          args: -S
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -18,28 +18,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Create Retail Package
-        uses: BigWigsMods/packager@master
+      - name: Create Package
+        uses: BigWigsMods/packager@v2
         with:
-          args: -w 0
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-
-      - name: Create BCC Package
-        uses: BigWigsMods/packager@master
-        with:
-          args: -w 0 -g bcc
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-
-      - name: Create Classic Package
-        uses: BigWigsMods/packager@master
-        with:
-          args: -w 0 -g classic
+          args: -S -w 0
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,6 +1,6 @@
 ## Interface: 90200
-## Interface_TBC: 20503
-## Interface_Vanilla: 11402
+## Interface-TBC: 20503
+## Interface-Vanilla: 11402
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,6 +1,6 @@
-## Interface: 90105
-## Interface-BCC: 20502
-## Interface-Classic: 11400
+## Interface: 90200
+## Interface_TBC: 20503
+## Interface_Vanilla: 11402
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,6 +1,6 @@
 ## Interface: 90200
-## Interface_TBC: 20503
-## Interface_Vanilla: 11402
+## Interface-TBC: 20503
+## Interface-Vanilla: 11402
 ## Title: Total RP 3: Data
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,6 +1,6 @@
-## Interface: 90105
-## Interface-BCC: 20502
-## Interface-Classic: 11400
+## Interface: 90200
+## Interface_TBC: 20503
+## Interface_Vanilla: 11402
 ## Title: Total RP 3: Data
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@


### PR DESCRIPTION
Updated the TOCs for 9.2.0/2.5.3/1.14.2 and pulled in a newer LibRPMedia as needed. The workflows have also been updated to take advantage of the "multitoc" support whereby one archive can be generated and uploaded to all hosts, with per-client TOCs automatically generated via the "-S" flag.