### PR TITLE
Improve TextArea scroll behavior when editing

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -386,6 +386,9 @@ stds.wow = {
 		"RemoveChatWindowChannel",
 		"ResetCursor",
 		"Saturate",
+		"ScrollingEdit_OnCursorChanged",
+		"ScrollingEdit_OnLoad",
+		"ScrollingEdit_OnTextChanged",
 		"SecondsToClock",
 		"SendChatMessage",
 		"SetCursor",
@@ -455,6 +458,7 @@ stds.wow = {
 		},
 
 		"BaseMapPoiPinMixin",
+		"CallbackRegistryMixin",
 		"ChatFrame1EditBox",
 		"ChatTypeInfo",
 		"DoublyLinkedListMixin",

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -316,3 +316,71 @@ function TRP3_TooltipMixin:SetBorderColor(r, g, b, a)
 		self:SetBackdropBorderColor(r, g, b, a or 1);
 	end
 end
+
+TRP3_TextAreaBaseMixin = {};
+
+function TRP3_TextAreaBaseMixin:OnLoad()
+	local editbox = self:GetEditBox();
+	editbox:RegisterCallback("OnEditFocusGained", self.OnEditFocusGained, self);
+	editbox:RegisterCallback("OnEditFocusGained", self.OnEditFocusLost, self);
+end
+
+function TRP3_TextAreaBaseMixin:OnSizeChanged(w)
+	local editbox = self:GetEditBox();
+	editbox:SetWidth(w - 40);
+end
+
+function TRP3_TextAreaBaseMixin:OnEditFocusGained()
+	local focus = self:GetFocusFrame();
+	focus:Hide();
+end
+
+function TRP3_TextAreaBaseMixin:OnEditFocusLost()
+	local focus = self:GetFocusFrame();
+	focus:Show();
+end
+
+
+function TRP3_TextAreaBaseMixin:GetEditBox()
+	return self.scroll.text;
+end
+
+function TRP3_TextAreaBaseMixin:GetFocusFrame()
+	return self.dummy;
+end
+
+TRP3_TextAreaBaseEditBoxMixin = CreateFromMixins(CallbackRegistryMixin);
+TRP3_TextAreaBaseEditBoxMixin:GenerateCallbackEvents({
+	"OnEditFocusGained",
+	"OnEditFocusLost",
+});
+
+function TRP3_TextAreaBaseEditBoxMixin:OnLoad()
+	CallbackRegistryMixin.OnLoad(self);
+	ScrollingEdit_OnLoad(self);
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:OnCursorChanged(x, y, w, h)
+	ScrollingEdit_OnCursorChanged(self, x, y, w, h);
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:OnTextChanged()
+	ScrollingEdit_OnTextChanged(self, self:GetScrollFrame());
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:OnEscapePressed()
+	self:ClearFocus();
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:OnEditFocusGained()
+	self:TriggerEvent("OnEditFocusGained", self);
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:OnEditFocusLost()
+	self:HighlightText(0, 0);
+	self:TriggerEvent("OnEditFocusLost", self);
+end
+
+function TRP3_TextAreaBaseEditBoxMixin:GetScrollFrame()
+	return self:GetParent();
+end

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -590,7 +590,7 @@
 		</Scripts>
 	</Button>
 
-	<Frame name="TRP3_TextAreaBase" virtual="true" enableMouse="true">
+	<Frame name="TRP3_TextAreaBase" mixin="TRP3_TextAreaBaseMixin" virtual="true" enableMouse="true">
 		<Frames>
 			<ScrollFrame parentKey="scroll" name="$parentScroll" inherits="UIPanelScrollFrameTemplate">
 				<Anchors>
@@ -600,26 +600,14 @@
 					<Anchor point="RIGHT" x="-18" y="0"/>
 				</Anchors>
 				<ScrollChild>
-					<EditBox name="$parentText" parentKey="text" multiLine="true" enableMouse="false" autoFocus="false">
+					<EditBox name="$parentText" mixin="TRP3_TextAreaBaseEditBoxMixin" parentKey="text" multiLine="true" enableMouse="false" autoFocus="false">
 						<Scripts>
-							<OnShow>
-								self:SetWidth(self:GetParent():GetParent():GetWidth() - 40);
-							</OnShow>
-							<OnTextChanged>
-								if self:IsVisible() and self:GetCursorPosition() == string.len(self:GetText()) then
-								self:GetParent():SetVerticalScroll(self:GetParent():GetVerticalScrollRange());
-								end
-							</OnTextChanged>
-							<OnEscapePressed>
-								self:ClearFocus();
-							</OnEscapePressed>
-							<OnEditFocusGained>
-								self:GetParent():GetParent().dummy:Hide();
-							</OnEditFocusGained>
-							<OnEditFocusLost>
-								self:HighlightText(0,0);
-								self:GetParent():GetParent().dummy:Show();
-							</OnEditFocusLost>
+							<OnLoad method="OnLoad"/>
+							<OnCursorChanged method="OnCursorChanged"/>
+							<OnTextChanged method="OnTextChanged"/>
+							<OnEscapePressed method="OnEscapePressed"/>
+							<OnEditFocusGained method="OnEditFocusGained"/>
+							<OnEditFocusLost method="OnEditFocusLost"/>
 						</Scripts>
 						<FontString inherits="ChatFontNormal"/>
 					</EditBox>
@@ -639,6 +627,9 @@
 				</Scripts>
 			</Button>
 		</Frames>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
 	</Frame>
 
 	<!-- Text area -->


### PR DESCRIPTION
This modifies the TextAreaBase template to use Blizzards' ScrollingEdit APIs which behave slightly better than our existing code with respect to scrolling-down a scrollframe when the user is editing text toward the lower end of the view.

The main changes this results in is that:

- Scrolling is no longer dependant upon the caret being at the end of the input field, and will occur if - for example - you're inserting text before it that would cause the new caret position to be outside the viewable field.
- Scrolling will leave a buffer region below the caret, so you've got  a few visible lines for the mid-field edit case.

Any usages of the TRP3_TextAreaBase or TRP3_TextArea templates in extended will need to be checked to see if they're providing an OnLoad script handler, as one has been added to the template to handle resizing of the child editbox component.