### PR TITLE
Correctly update text area layout on size changes

### DIFF
--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -325,9 +325,12 @@ function TRP3_TextAreaBaseMixin:OnLoad()
 	editbox:RegisterCallback("OnEditFocusGained", self.OnEditFocusLost, self);
 end
 
-function TRP3_TextAreaBaseMixin:OnSizeChanged(w)
-	local editbox = self:GetEditBox();
-	editbox:SetWidth(w - 40);
+function TRP3_TextAreaBaseMixin:OnShow()
+	self:UpdateLayout();
+end
+
+function TRP3_TextAreaBaseMixin:OnSizeChanged()
+	self:UpdateLayout();
 end
 
 function TRP3_TextAreaBaseMixin:OnEditFocusGained()
@@ -340,13 +343,17 @@ function TRP3_TextAreaBaseMixin:OnEditFocusLost()
 	focus:Show();
 end
 
-
 function TRP3_TextAreaBaseMixin:GetEditBox()
 	return self.scroll.text;
 end
 
 function TRP3_TextAreaBaseMixin:GetFocusFrame()
 	return self.dummy;
+end
+
+function TRP3_TextAreaBaseMixin:UpdateLayout()
+	local editbox = self:GetEditBox();
+	editbox:SetWidth(self:GetWidth() - 40);
 end
 
 TRP3_TextAreaBaseEditBoxMixin = CreateFromMixins(CallbackRegistryMixin);

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -630,7 +630,7 @@
 		<Scripts>
 			<OnLoad method="OnLoad"/>
 			<OnShow method="OnShow"/>
-			<OnShow method="OnSizeChanged"/>
+			<OnSizeChanged method="OnSizeChanged"/>
 		</Scripts>
 	</Frame>
 

--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -629,6 +629,8 @@
 		</Frames>
 		<Scripts>
 			<OnLoad method="OnLoad"/>
+			<OnShow method="OnShow"/>
+			<OnShow method="OnSizeChanged"/>
 		</Scripts>
 	</Frame>
 


### PR DESCRIPTION
The "recent" changes to the TRP3_TextAreaBase template omitted the script handler for OnSizeChanged; the method was defined on the mixin but it wasn't actually hooked up properly.

This would lead to a few odd situations, including in Extended where all the text areas had zero width and were invisible.

The OnSizeChanged handler has been added now, along with one for OnShow that - while it shouldn't be needed - is being thrown in just as a safeguard against any other untested scenarios.