### PR TITLE
Add tooltip to truncated settings texts

### DIFF
--- a/totalRP3/core/ui/configuration.xml
+++ b/totalRP3/core/ui/configuration.xml
@@ -25,50 +25,60 @@
 
 	<Frame name="TRP3_ConfigH1" virtual="true">
 		<Size x="0" y="35"/>
-		<Layers>
-			<Layer level="OVERLAY">
-				<FontString name="$parentTitle" inherits="GameFontNormalHuge" justifyH="LEFT" text="[h1_title]">
-					<Size x="0" y="10"/>
-					<Anchors>
-						<Anchor point="LEFT" x="0" y="0"/>
-						<Anchor point="RIGHT" x="0" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
-			</Layer>
-		</Layers>
+		<Frames>
+			<Frame name="$parentTitle" parentKey="Title" inherits="TRP3_TruncatedTextTemplate">
+				<Size y="10"/>
+				<Anchors>
+					<Anchor point="LEFT"/>
+					<Anchor point="RIGHT"/>
+				</Anchors>
+				<Layers>
+					<Layer level="OVERLAY">
+						<FontString parentKey="Text" inherits="GameFontNormalHuge" setAllPoints="true" justifyH="LEFT" wordwrap="true">
+							<Color r="0.95" g="0.95" b="0.95"/>
+						</FontString>
+					</Layer>
+				</Layers>
+			</Frame>
+		</Frames>
 	</Frame>
 
 	<Frame name="TRP3_ConfigParagraph" virtual="true">
 		<Size x="0" y="65"/>
-		<Layers>
-			<Layer level="OVERLAY">
-				<FontString name="$parentTitle" inherits="GameFontNormalSmall" justifyH="LEFT" wordwrap="true">
-					<Anchors>
-						<Anchor point="LEFT" x="0" y="0"/>
-						<Anchor point="RIGHT" x="0" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
-			</Layer>
-		</Layers>
+		<Frames>
+			<Frame name="$parentTitle" parentKey="Title" inherits="TRP3_TruncatedTextTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT"/>
+					<Anchor point="BOTTOMRIGHT"/>
+				</Anchors>
+				<Layers>
+					<Layer level="OVERLAY">
+						<FontString parentKey="Text" inherits="GameFontNormalSmall" setAllPoints="true" justifyH="LEFT" wordwrap="true">
+							<Color r="0.95" g="0.95" b="0.95"/>
+						</FontString>
+					</Layer>
+				</Layers>
+			</Frame>
+		</Frames>
 	</Frame>
 
 	<Frame name="TRP3_ConfigNote" virtual="true">
 		<Size x="0" y="35"/>
-		<Layers>
-			<Layer level="OVERLAY">
-				<FontString name="$parentTitle" inherits="GameFontNormal" justifyH="LEFT" text="[title]">
-					<Size x="360" y="10"/>
-					<Anchors>
-						<Anchor point="LEFT" x="25" y="0"/>
-						<Anchor point="RIGHT" x="-150" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
-			</Layer>
-		</Layers>
 		<Frames>
+			<Frame name="$parentTitle" parentKey="Title" inherits="TRP3_TruncatedTextTemplate">
+				<Size y="10"/>
+				<Anchors>
+					<Anchor point="LEFT" x="25" y="0"/>
+					<Anchor point="RIGHT" x="-150" y="0"/>
+				</Anchors>
+				<Layers>
+					<Layer level="OVERLAY">
+						<FontString parentKey="Text" inherits="GameFontNormal" setAllPoints="true" justifyH="LEFT">
+							<Color r="0.95" g="0.95" b="0.95"/>
+						</FontString>
+					</Layer>
+				</Layers>
+			</Frame>
 			<Button name="$parentHelp" inherits="TRP3_HelpButton">
 				<Size x="14" y="14"/>
 				<Anchors>

--- a/totalRP3/core/ui/widgets.lua
+++ b/totalRP3/core/ui/widgets.lua
@@ -261,8 +261,10 @@ TRP3_BACKDROP_MIXED_ACHIEVEMENT_TOOLTIP_415_16_3333 = {
 TRP3_TruncatedTextMixin = CreateFromMixins(FontableFrameMixin);
 
 function TRP3_TruncatedTextMixin:OnLoad()
-	self.Text = self:CreateFontString(nil, self.fontStringLayer, self.fontStringTemplate, self.fontStringSubLayer);
-	self.Text:SetAllPoints(self);
+	if not self.Text then
+		self.Text = self:CreateFontString(nil, self.fontStringLayer, self.fontStringTemplate, self.fontStringSubLayer);
+		self.Text:SetAllPoints(self);
+	end
 
 	if self.fontStringColor then
 		self.Text:SetTextColor(self.fontStringColor);


### PR DESCRIPTION
If the text for any configuration settings is truncated due to content being too long, we'll show a tooltip in the same way we do for long misc. info fields.

![Long setting](https://user-images.githubusercontent.com/287102/173401167-344842df-a99f-45e1-9973-18232c7f87d6.png)

The main reasoning for this is #607, but this also probably happens a lot in the German localization.