### PR TITLE
Fix extraneous linebreaks after block elements

### DIFF
--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -982,7 +982,17 @@ Utils.str.toHTML = function(text, noColor, noBrackets)
 		if not line:find("<") then
 			line = "<P>" .. line .. "</P>";
 		end
-		line = line:gsub("\n","<br/>");
+
+		-- Replace newlines with <br/> tags unless following the immediate
+		-- start or end of a block element. This assumes no inline elements
+		-- have been added yet (namely - images).
+		line = line:gsub("()>?()\n", function(pos1, pos2)
+			if pos1 ~= pos2 then
+				return ">";
+			else
+				return "<br/>";
+			end
+		end);
 
 		-- Image tag. Specifiers after the height are optional, so they
 		-- must be suitably defaulted and validated.


### PR DESCRIPTION
Fixes #588 (probably). When converting things to HTML we end up leaving a lot of stray newline characters at the start and/or end of block-level elements, which causes inconsistencies as described in the ticket.

This fix attempts to normalize newlines a little bit; if there is a newline immediately proceeding a ">" character (before inline image elements have been inserted) we assume this is a newline following either the opening or closing tag of a block-level element such as a paragraph or header. In this case, we chomp the (single!) newline character and don't convert it to a break element.

This does squash things up a bit more, but it is _consistent_. People may need to make adjustments to their profiles to re-add additional line-breaks where necessary however, which might be a blocker - it'd be worth checking the before/after on a set of 
real profiles.

For a visual comparison, here's before with the example described in #588:
![Before](https://user-images.githubusercontent.com/287102/173561409-0dcbf964-c100-4eff-9623-40421c629c3a.png)
And after:
![After](https://user-images.githubusercontent.com/287102/173561454-e81cf901-cdb4-4040-885a-78804c2410b6.png)

The full test document used is as follows:

```
# Implied paragraph test:

Foo
Bar

FooBar

# Without line breaks:

{h1}Header{/h1}{p}This is my custom paragraph{/p}{p}This is my second custom paragraph{/p}{p}This is my third custom paragraph{/p}

# With singular breaks:

{h1}Header{/h1}
{p}This is my custom paragraph{/p}
{p}This is my second custom paragraph{/p}
{p}This is my third custom paragraph{/p}

# With double linebreaks:

{h1}Header{/h1}

{p}This is my custom paragraph{/p}

{p}This is my second custom paragraph{/p}

{p}This is my third custom paragraph{/p}

# Long test:

{p}
This is a paragraph that has an opening newline.
This line is separated by a single explicit newline.

This one by two.


This one by three! We're going to leave a single newline after this.
{/p}And then open a new paragraph implicitly right after the tag.


{p}
Now let's open a new paragraph and leave two newlines at the end of this sentence.


{/p}With some run-on text too.


# Ticket test:

Fascination
----------------
{h3}.*. Demonology{/h3}
{p}
Hobbies
-----------
{/p}
{h3}.*. Something expensive{/h3}
{h2:c}The Meta{/h2}
{p:r}
Test Title
------------
{/p}
{h3:r}Test Text .*.{/h3}
```

