### PR TITLE
Remove check for sanitization option in upgrades

### DIFF
--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -44,11 +44,9 @@ end
 TRP3_API.flyway.patches["5"] = function()
 	-- Sanitize existing profiles
 	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_FINISH, function()
-		if TRP3_API.configuration.getValue("register_sanitization") then
-			local sanitizeFullProfile = TRP3_API.register.sanitizeFullProfile;
-			for _, profile in pairs(TRP3_Register.profiles) do
-				sanitizeFullProfile(profile);
-			end
+		local sanitizeFullProfile = TRP3_API.register.sanitizeFullProfile;
+		for _, profile in pairs(TRP3_Register.profiles) do
+			sanitizeFullProfile(profile);
 		end
 	end)
 end


### PR DESCRIPTION
The profile sanitization toggle was removed in one of our recent updates, but as it turns out there's a flyway patch that executes on new installations that attempts to query for the (now removed) config key.

As the key doesn't exist, the check no longer makes sense. yeet.