### PR TITLE
Bump TOC version for 9.2.7

### DIFF
--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,4 +1,5 @@
 ## Interface: 90207
+## Interface-Wrath: 30400
 ## Interface-TBC: 20504
 ## Interface-Vanilla: 11403
 ## Title: Total RP 3

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,4 +1,4 @@
-## Interface: 90205
+## Interface: 90207
 ## Interface-TBC: 20504
 ## Interface-Vanilla: 11403
 ## Title: Total RP 3

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,4 +1,5 @@
 ## Interface: 90207
+## Interface-Wrath: 30400
 ## Interface-TBC: 20504
 ## Interface-Vanilla: 11403
 ## Title: Total RP 3: Data

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,4 +1,4 @@
-## Interface: 90205
+## Interface: 90207
 ## Interface-TBC: 20504
 ## Interface-Vanilla: 11403
 ## Title: Total RP 3: Data


### PR DESCRIPTION
Whether or not the patch actually retains this interface version bump when launched we don't yet know; a similar thing happened in 8.3.7 where the TOC increased on the PTR but was reset prior to launch.