### PR TITLE
Fix tooltip coloring with certain unicode inputs

### DIFF
--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -869,7 +869,7 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 	if showCompanionFullTitle() then
 		local fullTitle = "";
 		if info.TI then
-			fullTitle = strconcat("< ", info.TI, " |r>");
+			fullTitle = strconcat("< ", info.TI, " >");
 		end
 		if fullTitle and fullTitle ~= "" then
 
@@ -1047,7 +1047,7 @@ local function writeTooltipForMount(ownerID, companionFullID, mountName)
 	if showCompanionFullTitle() then
 		local fullTitle = "";
 		if info.TI then
-			fullTitle = strconcat("< ", info.TI, " |r>");
+			fullTitle = strconcat("< ", info.TI, " >");
 		end
 		if fullTitle and fullTitle ~= "" then
 			if getConfigValue(CONFIG_CROP_TEXT) then

--- a/totalRP3/modules/register/main/register_tooltip.lua
+++ b/totalRP3/modules/register/main/register_tooltip.lua
@@ -316,21 +316,29 @@ local function AddSpace(self)
 	tinsert(self._content, lineStructure);
 end
 
+local function GenerateColoredTooltipLine(text, r, g, b)
+	-- Workaround for issue #606 where certain unicode character ranges make
+	-- GameTooltip:AddLine not respect colors. We wrap the text in an
+	-- enclosing pair of color sequences to force it to be respected.
+	return string.format("|cff%.2x%.2x%.2x%s|r", r * 255, g * 255, b * 255, text);
+end
+
 local function Build(self)
 	local size = #self._content;
 	local tooltipLineIndex = 1;
 	for lineIndex, line in ipairs(self._content) do
 		if line.type == BUILDER_TYPE_LINE then
-			-- Potential fix for SetFont call on a nil line
 			if line.text == "" then line.text = " " end
-			self.tooltip:AddLine(line.text, line.red, line.green, line.blue, line.lineWrap);
+			local text = GenerateColoredTooltipLine(line.text, line.red, line.green, line.blue);
+			self.tooltip:AddLine(text, 1, 1, 1, line.lineWrap);
 			setLineFont(self.tooltip, tooltipLineIndex, line.lineSize);
 			tooltipLineIndex = tooltipLineIndex + 1;
 		elseif line.type == BUILDER_TYPE_DOUBLELINE then
-			-- Potential fix for SetFont call on a nil line
 			if line.textL == "" then line.textL = " " end
 			if line.textR == "" then line.textR = " " end
-			self.tooltip:AddDoubleLine(line.textL, line.textR, line.redL, line.greenL, line.blueL, line.redR, line.greenR, line.blueR);
+			local textL = GenerateColoredTooltipLine(line.textL, line.redL, line.greenL, line.blueL);
+			local textR = GenerateColoredTooltipLine(line.textR, line.redR, line.greenR, line.blueR);
+			self.tooltip:AddDoubleLine(textL, textR, 1, 1, 1, 1, 1, 1);
 			setDoubleLineFont(self.tooltip, tooltipLineIndex, line.lineSize);
 			tooltipLineIndex = tooltipLineIndex + 1;
 		elseif line.type == BUILDER_TYPE_SPACE and showSpacing() and lineIndex ~= size then
@@ -521,7 +529,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 				fullTitle = crop(fullTitle, FIELDS_TO_CROP.TITLE);
 			end
 
-			tooltipBuilder:AddLine(strconcat("< ", fullTitle, " |r>"), 1, 0.50, 0, getSubLineFontSize(), true);
+			tooltipBuilder:AddLine(strconcat("< ", fullTitle, " >"), 1, 0.50, 0, getSubLineFontSize(), true);
 		end
 	end
 


### PR DESCRIPTION
The GameTooltip:AddLine() API appears to improperly apply the supplied color to the displayed text if given an input string that contains characters from specific unicode character sets, such as "𣆀".

We can work around this by wrapping each line in color sequence markup to force the color to be applied. By doing so, we supply the color white to the AddLine API as it's no longer needed.

Related to the lamentations within #606.