### PR TITLE
Allow basic "/trp3 profile" macro conditionals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -393,6 +393,7 @@ stds.wow = {
 		"ScrollingEdit_OnLoad",
 		"ScrollingEdit_OnTextChanged",
 		"SecondsToClock",
+		"SecureCmdOptionParse",
 		"SendChatMessage",
 		"SetCursor",
 		"SetCVar",

--- a/totalRP3/core/impl/profiles.lua
+++ b/totalRP3/core/impl/profiles.lua
@@ -645,6 +645,10 @@ function TRP3_API.profile.init()
 
 			local profileName = table.concat(args, " ");
 
+			if string.sub(profileName, 1, 1) == "[" then
+				profileName = SecureCmdOptionParse(profileName);
+			end
+
 			for profileID, profile in pairs(profiles) do
 				if profile.profileName == profileName then
 					selectProfile(profileID);


### PR DESCRIPTION
This commit adds the ability to use macro conditionals in the `/trp3 profile` command, such as the following:

	/trp3 profile [combat] Profile A; Profile B

This only uses the WoW-builtin option parser so doesn't have the advanced features we previously wanted for automation like checking IC/OOC status, but this should enable _some_ use cases as we're probably not going to implement that any time soon.

This may break existing usages of the command for profiles that begin with an "[", but those should be few and far between you'd hope.