### PR TITLE
Bring README into 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Are you having an issue with Total RP 3? Check the [F.A.Q] and our [troubleshoo
 
 Total RP 3 aims to be the best way to customize and describe your role-play interactions, by bringing together the powerful customization features from Total RP 2, new features asked by our users and a much better user interface, designed with usability in mind. With this add-on, you can fully customize all the information about your characters and companion (pets, battle pets, mounts), like the name, the description or even attach an image to represent them.
 
-Our goal is to bring back the simplicity and user-friendliness of add-ons like **FlagRSP** and **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
+Our goal is to bring back the simplicity and user-friendliness of add-ons like **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
 
-Total RP 3 implements the **Mary Sue Protocol**, which is also used by roleplay addons like **MyRolePlay**, **XRP** or even **Total RP 2**. That means Total RP 3 can understand and exchange data with all these add-ons.
+Total RP 3 implements the **Mary Sue Protocol**, which is also used by roleplay addons like **MyRolePlay** and **XRP**. That means Total RP 3 can understand and exchange data with all these add-ons.
 
 Total RP 3 is also a fully modular add-on. You can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to. This is the main module which will be required to run any future expansion.
 
@@ -33,11 +33,11 @@ Total RP 3 is also a fully modular add-on. You can choose exactly which features
 - Keep track of all characters and companions you met with **the directory**, a repository of profiles you have encountered.
 - **Locate other Total RP 3 users on the world map** to see where people tend to gather. You can decide to appear on the map or not, or even appear only if you are in character.
 - A customizable **target frame**, allowing you to easily reach useful actions about your roleplay target (see their profile, play their theme song).
-- **Chat customizations** like OOC chat coloring, emote detection and full role-play names using custom colors in the chat.
+- **Chat customizations** like OOC and emote chat coloring as well as full role-play names using custom colors in the chat.
 - **NPC speeches** to make an NPC say or do something during an event.
-- Full **Mary Sue Protocol** implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP**, **Total RP 2** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
-- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**.
-- **Import your existing profiles** from **Total RP 2**, **MyRolePlay**, **XRP**, **flagRSP2** and **flagRSP(MoP)**. ([Tutorial][import])
+- Full **Mary Sue Protocol** implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
+- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**, etc.
+- **Import your existing profiles** from **Total RP 2**, **MyRolePlay** or **XRP**. ([Tutorial][import])
 - **Mature profile filtering** to warn you before opening profiles that may contain mature content.
 
 ## YouTube videos

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Total RP 3 is the brand new roleplay add-on from the creators of Total RP 1 and 2!
+# Total RP 3
 
 Download on [CurseForge].
 
@@ -12,39 +12,38 @@ Are you having an issue with Total RP 3? Check the [F.A.Q] and our [troubleshoo
 
 ## Helpful links
 
+- Join us on [Discord]!
 - Avoid losing all your profiles: sync up your saved data to an online storage. [Here’s a guide](https://github.com/Total-RP/Total-RP-3/wiki/How-to-backup-and-synchronize-your-add-ons-settings-using-a-cloud-service)!
 - Don't know how to install an add-on? Check our [installation guide]!
 - Check out [Myth's excellent TRP3 guide][myth's guide] for an in depth tour of the add-on's features. Big thanks to him!
-- Join us on [Discord]!
 
 ## Description 
 
 Total RP 3 aims to be the best way to customize and describe your role-play interactions, by bringing together the powerful customization features from Total RP 2, new features asked by our users and a much better user interface, designed with usability in mind. With this add-on, you can fully customize all the information about your characters and companion (pets, battle pets, mounts), like the name, the description or even attach an image to represent them.
 
-Our goal is to bring back the simplicity and user-friendliness of add-ons like FlagRSP and MyRoleplay but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
+Our goal is to bring back the simplicity and user-friendliness of add-ons like **FlagRSP** and **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
 
-Total RP 3 implements the Mary Sue Protocol, which is also used by roleplay addons like MyRoleplay, XRP or even Total RP 2\. That means Total RP 3 can understand and exchange data with all these add-ons.
+Total RP 3 implements the Mary Sue Protocol, which is also used by roleplay addons like **MyRolePlay**, **XRP** or even **Total RP 2**. That means Total RP 3 can understand and exchange data with all these add-ons.
 
-Also, Total RP 3 is a fully modular add-on. So even if it will greatly expand in the future, you can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to. This is the main module which will be required to run any future expansion.
+Total RP 3 is also a fully modular add-on. You can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to. This is the main module which will be required to run any future expansion.
 
 ## Main features
 
-- You can customize your characters and companions (battle pets, pets, and mounts) with a powerful **profile system** and quickly switch between profiles**.**
+- You can customize your characters and companions (battle pets, pets, and mounts) with a powerful **profile system** and quickly switch between profiles.
 - Keep track of all characters and companions you met with **the directory**, a repository of profiles you have encountered.
 - **Locate other Total RP 3 users on the world map** to see where people tend to gather. You can decide to appear on the map or not, or even appear only if you are in character.
 - A customizable **target frame**, allowing you to easily reach useful actions about your roleplay target (see their profile, play their theme song).
 - **Chat customizations** like OOC and emote detection and full role-play names using custom colors in the chat…
 - **NPC speeches** to make an NPC say or do something during an event.
-- Full Mary Sue Protocol implementation: Total RP 3 can communicate with MyRolePlay, XRP, Total RP 2 and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
+- Full Mary Sue Protocol implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP**, **Total RP 2** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
 - A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**…
-- **Import your existing profiles** from **Total RP 2**, **MyRolePlay**, **XRP**, flagRSP2 and flagRSP(MoP). ([Tutorial][import])
+- **Import your existing profiles** from **Total RP 2**, **MyRolePlay**, **XRP**, **flagRSP2** and **flagRSP(MoP)**. ([Tutorial][import])
 - **Mature profile filtering** to be warned before opening profiles that may contain mature content.
 
 ## YouTube videos
 
-- [Here's a video](https://www.youtube.com/watch?v=HYdl4wS8Bd4) made by [Tarcanus Frostbourne](https://www.youtube.com/channel/UCgvXBavFxphWlmiSD_sM6-A), host of the [LFRP Podcast](http://lookingforroleplay.com/), showing Total RP 3's main features.
-- Are you a new role-player? Check out [this great beginners guide to WoW Roleplaying](https://www.youtube.com/watch?v=iI9K8ZvVWLk) by [Bruce Forte](https://www.youtube.com/channel/UCZFoMGwB0ozmn7c82LmhsPA)!
-- [Here's a video](https://www.youtube.com/watch?v=GCP6IhzWKto) from [Inquisitor Aura](https://www.youtube.com/channel/UCpv4Lnf770BnKp-yAj23e4g) about the latest new features in Total RP 3 for Legion!
+- Are you a new role-player? Check out [this great beginners guide to Total RP 3](https://youtu.be/pVQBxD4DiPM) by [Dizhon](https://www.youtube.com/channel/UC8UncaFHm3yL1eTKCjGDNtw)!
+- [Here's a video](https://youtu.be/pJyoBQVEVO8) from [Kraken Latte](https://www.youtube.com/c/KrakenLatte) detailing the basics of TotalRP3, including the setup and backing up of your profiles.
 
 ## Total RP 3 modules spotlight
 
@@ -55,6 +54,14 @@ This awesome module brings the new creation system. Create items, readable docum
 ### [TRP3 Currently Frame](https://www.curseforge.com/wow/addons/trp3-currently-frame), by tammymg
 
 Adds a standalone frame to your UI that displays your "Currently" text and allows you to edit it easily.
+
+### [TRP3 Location Toggle](https://www.curseforge.com/wow/addons/trp3-location-toggle), by iMintty_
+
+Adds a simple button to the toolbar to toggle on and off the map scan location feature.
+
+### [RP Tags](https://www.curseforge.com/wow/addons/rp-tags), by Oraibi
+
+RP Tags adds a bunch of new tags to ElvUI's Unit Frames system to expose Total RP 3 fields, like RP names, colors, and more, to be used on the player and target frames.
 
 [CurseForge]: http://curse.totalrp3.info
 [Discord]: http://discord.totalrp3.info

--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Adds a standalone frame to your UI that displays your "Currently" text and allow
 
 Adds a simple button to the toolbar to toggle on and off the map scan location feature.
 
-### [RP Tags](https://www.curseforge.com/wow/addons/rp-tags), by Oraibi
-
-RP Tags adds a bunch of new tags to ElvUI's Unit Frames system to expose Total RP 3 fields, like RP names, colors, and more, to be used on the player and target frames.
-
 ## Total RP 3 for add-on developers
 
 Want to integrate your addon with Total RP 3, or create your own module? Check out the [wiki](https://github.com/Total-RP/Total-RP-3/wiki) for a look into TRP3's public API, and a look into how Total RP 3 works.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Are you having an issue with Total RP 3? Check the [F.A.Q] and our [troubleshoo
 
 ## Description 
 
-Total RP 3 aims to be the best way to customize and describe your role-play interactions, by bringing together the powerful customization features from Total RP 2, new features asked by our users and a much better user interface, designed with usability in mind. With this add-on, you can fully customize all the information about your characters and companion (pets, battle pets, mounts), like the name, the description or even attach an image to represent them.
+Total RP 3 aims to be the best way to customize, describe and drive your role-play interactions, by combining the powerful customization features from Total RP 2, new features requested by our users and a greatly improved user interface designed with usability in mind. With this add-on, you can fully customize all the information about your characters and companion (pets, battle pets, mounts), like the name, the description or even attach an image to represent them.
 
 Our goal is to bring back the simplicity and user-friendliness of add-ons like **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
 
@@ -32,11 +32,11 @@ Total RP 3 is also a fully modular add-on. You can choose exactly which features
 - You can customize your characters and companions (battle pets, pets, and mounts) with a powerful **profile system** and quickly switch between profiles.
 - Keep track of all characters and companions you met with **the directory**, a repository of profiles you have encountered.
 - **Locate other Total RP 3 users on the world map** to see where people tend to gather. You can decide to appear on the map or not, or even appear only if you are in character.
-- A customizable **target frame**, allowing you to easily reach useful actions about your roleplay target (see their profile, play their theme song).
-- **Chat customizations** like OOC and emote chat coloring as well as full role-play names using custom colors in the chat.
+- A customizable **target frame**, allowing you to easily access useful interactions for your roleplay target (see their profile, play their theme song).
+- **Chat customizations** like OOC and emote chat coloring as well as full role-play names using custom colors in the chat. ([Details on Chat Formatting][chatf])
 - **NPC speeches** to make an NPC say or do something during an event.
 - Full **Mary Sue Protocol** implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
-- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**, etc.
+- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**, and more!
 - **Import your existing profiles** from **Total RP 2**, **MyRolePlay** or **XRP**. ([Tutorial][import])
 - **Mature profile filtering** to warn you before opening profiles that may contain mature content.
 
@@ -63,6 +63,13 @@ Adds a simple button to the toolbar to toggle on and off the map scan location f
 
 RP Tags adds a bunch of new tags to ElvUI's Unit Frames system to expose Total RP 3 fields, like RP names, colors, and more, to be used on the player and target frames.
 
+## Total RP 3 for add-on developers
+
+Want to integrate your addon with Total RP 3, or create your own module? Check out the [wiki](https://github.com/Total-RP/Total-RP-3/wiki) for a look into TRP3's public API, and a look into how Total RP 3 works.
+
+- Learn about Total RP 3's Communication System [here](https://github.com/Total-RP/Total-RP-3/wiki/Communication-system)!
+- Check out the [Total RP 3 API Documentation](https://github.com/Total-RP/Total-RP-3/wiki/Total-RP-3%27s-API-documentation)!
+
 [CurseForge]: http://curse.totalrp3.info
 [Discord]: http://discord.totalrp3.info
 [myth's guide]: http://tinyurl.com/myths-trp3-guide
@@ -73,3 +80,4 @@ RP Tags adds a bunch of new tags to ElvUI's Unit Frames system to expose Total R
 [installation guide]: https://github.com/Total-RP/Total-RP-3/wiki/How-to-install-and-update-Total-RP-3
 [import]: https://github.com/Total-RP/Total-RP-3/wiki/How-to-import-your-existing-RP-profiles-from-another-add-on
 [MSP]: https://github.com/Total-RP/Total-RP-3/wiki/Mary-Sue-Protocol
+[chatf]: https://github.com/Total-RP/Total-RP-3/wiki/Chat-formatting-in-Total-RP-3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Total RP 3 aims to be the best way to customize and describe your role-play int
 
 Our goal is to bring back the simplicity and user-friendliness of add-ons like **FlagRSP** and **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
 
-Total RP 3 implements the Mary Sue Protocol, which is also used by roleplay addons like **MyRolePlay**, **XRP** or even **Total RP 2**. That means Total RP 3 can understand and exchange data with all these add-ons.
+Total RP 3 implements the **Mary Sue Protocol**, which is also used by roleplay addons like **MyRolePlay**, **XRP** or even **Total RP 2**. That means Total RP 3 can understand and exchange data with all these add-ons.
 
 Total RP 3 is also a fully modular add-on. You can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to. This is the main module which will be required to run any future expansion.
 
@@ -33,12 +33,12 @@ Total RP 3 is also a fully modular add-on. You can choose exactly which features
 - Keep track of all characters and companions you met with **the directory**, a repository of profiles you have encountered.
 - **Locate other Total RP 3 users on the world map** to see where people tend to gather. You can decide to appear on the map or not, or even appear only if you are in character.
 - A customizable **target frame**, allowing you to easily reach useful actions about your roleplay target (see their profile, play their theme song).
-- **Chat customizations** like OOC and emote detection and full role-play names using custom colors in the chat…
+- **Chat customizations** like OOC chat coloring, emote detection and full role-play names using custom colors in the chat.
 - **NPC speeches** to make an NPC say or do something during an event.
-- Full Mary Sue Protocol implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP**, **Total RP 2** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
-- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**…
+- Full **Mary Sue Protocol** implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP**, **Total RP 2** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
+- A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**.
 - **Import your existing profiles** from **Total RP 2**, **MyRolePlay**, **XRP**, **flagRSP2** and **flagRSP(MoP)**. ([Tutorial][import])
-- **Mature profile filtering** to be warned before opening profiles that may contain mature content.
+- **Mature profile filtering** to warn you before opening profiles that may contain mature content.
 
 ## YouTube videos
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Total RP 3 aims to be the best way to customize, describe and drive your role-p
 
 Our goal is to bring back the simplicity and user-friendliness of add-ons like **MyRolePlay** but without sacrificing your freedom when defining your roleplay characters and adding neat features that you'll never want to live without anymore.
 
-Total RP 3 implements the **Mary Sue Protocol**, which is also used by roleplay addons like **MyRolePlay** and **XRP**. That means Total RP 3 can understand and exchange data with all these add-ons.
+Total RP 3 can understand and exchange data with roleplay addons like **MyRolePlay** and **XRP**, allowing you to consult profiles coming from these addons seamlessly.
 
-Total RP 3 is also a fully modular add-on. You can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to. This is the main module which will be required to run any future expansion.
+Total RP 3 is also a fully modular add-on. You can choose exactly which features you want to use and won't be bothered by a complex user interface if you don't want to.
 
 ## Main features
 
@@ -35,7 +35,7 @@ Total RP 3 is also a fully modular add-on. You can choose exactly which features
 - A customizable **target frame**, allowing you to easily access useful interactions for your roleplay target (see their profile, play their theme song).
 - **Chat customizations** like OOC and emote chat coloring as well as full role-play names using custom colors in the chat. ([Details on Chat Formatting][chatf])
 - **NPC speeches** to make an NPC say or do something during an event.
-- Full **Mary Sue Protocol** implementation: Total RP 3 can communicate with **MyRolePlay**, **XRP** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
+- Total RP 3 can communicate with **MyRolePlay**, **XRP** and other MSP add-ons so you can view other players information even if they are using another roleplaying add-on. ([Details on the MSP implementation][MSP])
 - A customizable **toolbar** with useful actions like switching from switching from one profile to another, switching from **IC to OOC**, from **AFK to DND**, **switching languages**, and more!
 - **Import your existing profiles** from **Total RP 2**, **MyRolePlay** or **XRP**. ([Tutorial][import])
 - **Mature profile filtering** to warn you before opening profiles that may contain mature content.


### PR DESCRIPTION
Reworded various parts of the README, corrected links that pointed to old or outdated locations, resolves #394.

Added developer section at the bottom for anyone bold enough to integrate their addon with TRP3.

Added more modules under 'module spotlight' to bring the README up to parity with the Curseforge page.

As mentioned on #394, the README will need to be copied over to the Curseforge page.