### PR TITLE
Disable UnitPopup integrations for 10.0.0

### DIFF
--- a/totalRP3/Modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/Modules/UnitPopups/UnitPopups.lua
@@ -6,6 +6,10 @@ local L = TRP3_API.loc;
 
 local GenerateConfigurationPage;
 
+local function ShouldIgnoreDeveloperAdvice()
+	return TRP3_API.configuration.getValue("UnitPopups_IgnoreDeveloperAdvice");
+end
+
 local function ShouldDisableOutOfCharacter()
 	return TRP3_API.configuration.getValue("UnitPopups_DisableOutOfCharacter");
 end
@@ -56,7 +60,9 @@ function UnitPopupsModule:OnModuleInitialize()
 end
 
 function UnitPopupsModule:OnModuleEnable()
-	hooksecurefunc("UnitPopup_ShowMenu", function(...) return self:OnUnitPopupShown(...); end);
+	if ShouldIgnoreDeveloperAdvice() then
+		hooksecurefunc("UnitPopup_ShowMenu", function(...) return self:OnUnitPopupShown(...); end);
+	end
 end
 
 function UnitPopupsModule:OnUnitPopupShown(dropdownMenu, menuType)
@@ -222,6 +228,11 @@ TRP3_API.module.registerModule({
 --
 
 UnitPopupsModule.Configuration = {
+	UnitPopups_IgnoreDeveloperAdvice = {
+		key = "UnitPopups_IgnoreDeveloperAdvice",
+		default = false,
+	},
+
 	DisableOutOfCharacter = {
 		key = "UnitPopups_DisableOutOfCharacter",
 		default = false,
@@ -274,17 +285,23 @@ function GenerateConfigurationPage()
 				title = L.UNIT_POPUPS_CONFIG_PAGE_HELP,
 			},
 			{
-				inherit = "TRP3_ConfigButton",
-				title = L.UNIT_POPUPS_CONFIG_ENABLE_MODULE,
-				text = DISABLE,
-				OnClick = function()
-					TRP3_API.popup.showConfirmPopup(L.UNIT_POPUPS_MODULE_DISABLE_WARNING, function()
-						local current = TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"];
-						TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"] = not current;
-						ReloadUI();
-					end);
-				end,
+				inherit = "TRP3_ConfigParagraph",
+				title = L.UNIT_POPUPS_CONFIG_PAGE_MODULE_OUT_ORDER_SORRY_FOR_ANY_INCONVENIENCE,
 			},
+			-- TODO: Uncomment this when the taint issues are fixed; this is
+			--       temporarily hidden to make the UI less confusing.
+			-- {
+			-- 	inherit = "TRP3_ConfigButton",
+			-- 	title = L.UNIT_POPUPS_CONFIG_ENABLE_MODULE,
+			-- 	text = DISABLE,
+			-- 	OnClick = function()
+			-- 		TRP3_API.popup.showConfirmPopup(L.UNIT_POPUPS_MODULE_DISABLE_WARNING, function()
+			-- 			local current = TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"];
+			-- 			TRP3_Configuration.MODULE_ACTIVATION["trp3_unitpopups"] = not current;
+			-- 			ReloadUI();
+			-- 		end);
+			-- 	end,
+			-- },
 			{
 				inherit = "TRP3_ConfigH1",
 				title = L.UNIT_POPUPS_CONFIG_VISIBILITY_HEADER,
@@ -294,24 +311,28 @@ function GenerateConfigurationPage()
 				title = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER,
 				help = L.UNIT_POPUPS_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP,
 				configKey = "UnitPopups_DisableOutOfCharacter",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT,
 				help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_COMBAT_HELP,
 				configKey = "UnitPopups_DisableInCombat",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES,
 				help = L.UNIT_POPUPS_CONFIG_DISABLE_IN_INSTANCES_HELP,
 				configKey = "UnitPopups_DisableInInstances",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES,
 				help = L.UNIT_POPUPS_CONFIG_DISABLE_ON_UNIT_FRAMES_HELP,
 				configKey = "UnitPopups_DisableOnUnitFrames",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigH1",
@@ -322,24 +343,28 @@ function GenerateConfigurationPage()
 				title = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT,
 				help = L.UNIT_POPUPS_CONFIG_SHOW_HEADER_TEXT_HELP,
 				configKey = "UnitPopups_ShowHeaderText",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR,
 				help = L.UNIT_POPUPS_CONFIG_SHOW_SEPARATOR_HELP,
 				configKey = "UnitPopups_ShowSeparator",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE,
 				help = L.UNIT_POPUPS_CONFIG_SHOW_OPEN_PROFILE_HELP,
 				configKey = "UnitPopups_ShowOpenProfile",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS,
 				help = L.UNIT_POPUPS_CONFIG_SHOW_CHARACTER_STATUS_HELP,
 				configKey = "UnitPopups_ShowCharacterStatus",
+				dependentOnOptions = { "UnitPopups_IgnoreDeveloperAdvice" },
 			},
 		},
 	};

--- a/totalRP3/Tools/Locale.lua
+++ b/totalRP3/Tools/Locale.lua
@@ -1737,11 +1737,6 @@ Classic users: Companion profiles may have to be relinked due to API changes.
 
 ]],
 
-	------------------------------------------------------------------------------------------------
-	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
-	--- THEN MOVE IT UP ONCE IMPORTED
-	------------------------------------------------------------------------------------------------
-
 	WHATS_NEW_24_14 = [[# Changelog version 2.3.13
 
 	## Fixed
@@ -1750,6 +1745,13 @@ Classic users: Companion profiles may have to be relinked due to API changes.
 		- Fixed some more profile modifications.
 
 ]],
+
+	------------------------------------------------------------------------------------------------
+	--- PLACE LOCALIZATION NOT ALREADY UPLOADED TO CURSEFORGE HERE
+	--- THEN MOVE IT UP ONCE IMPORTED
+	------------------------------------------------------------------------------------------------
+
+	UNIT_POPUPS_CONFIG_PAGE_MODULE_OUT_ORDER_SORRY_FOR_ANY_INCONVENIENCE = "|cffffcc00Note: |r Due to issues with Edit Mode in patch 10.0.0 the unit popups module has been |cffffff00disabled|r. Sorry for any inconvenience!",
 
 };
 


### PR DESCRIPTION
In an attempt to try and fend off any questions on why, the settings page for the module will have some text added to explain the reasoning.

For development purposes (and for users who really don't care about edit mode and will have fully custom UIs) a temporary config variable has been added to bypass disabling the module.