### PR TITLE
Add missing 'status' subcommand to location usage

### DIFF
--- a/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
@@ -194,7 +194,7 @@ end
 
 local function LocationBroadcastCommandHelp()
 	local stem = WrapTextInColorCode("/trp3 location", "ffffffff");
-	local options = WrapTextInColorCode("<on||off||toggle>", "ffffcc00");
+	local options = WrapTextInColorCode("<on||off||status||toggle>", "ffffcc00");
 	local examples = {
 		"",  -- Empty leading line.
 		string.format(loc.SLASH_CMD_LOCATION_HELP_OFF, WrapTextInColorCode("/trp3 location off", "ffffffff")),


### PR DESCRIPTION
I'd added the "status" subcommand a bit later than the rest and didn't update the usage text accordingly.