### PR TITLE
Fix colorblind mode detection

### DIFF
--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1850,7 +1850,7 @@ end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 local function isColorBlindModeEnabled()
-	return ENABLE_COLORBLIND_MODE == "1";
+	return GetCVar("colorblindMode") == "1";
 end
 
 local REPLACE_PATTERN, NAME_PATTERN = "%%s", "([%%S%%-%%P]+)";


### PR DESCRIPTION
While this'll be fixed automatically in 10.0.2, I'd rather fix the check to use the cvar directly on Classic until it gets the tooltip changes.