### PR TITLE
Cache configured locale in Data addon

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -62,6 +62,9 @@ read_globals = {
 	"WoWUnit",
 	"xrpSaved",
 
+	-- Common protocol globals
+	"GAME_LOCALE",
+
 	-- XRP Globals
 	"XRP_AE",
 	"XRP_AG",
@@ -319,6 +322,7 @@ stds.wow = {
 		"CreateTextureMarkup",
 		"CreateVector2D",
 		"DisableAddOn",
+		"EventRegistry",
 		"FCF_GetCurrentChatFrame",
 		"FindInTableIf",
 		"FormatLargeNumber",

--- a/totalRP3/Libs/Ellyb/Locales.lua
+++ b/totalRP3/Libs/Ellyb/Locales.lua
@@ -51,4 +51,4 @@ Vous pouvez copier ce lien en utilisant le raccourci clavier %s pour ensuite le 
 	COPY_SYSTEM_MESSAGE = "Copié dans le presse-papiers.",
 })
 
-Ellyb.loc:SetCurrentLocale(GetLocale(), true);
+Ellyb.loc:SetCurrentLocale(TRP3_AddonLocale, true);

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1962,11 +1962,9 @@ Please use TRP3_API.loc:GetLocale(localeID) and locale:AddText(key, value) to in
 	}
 end
 
--- The default locale for any lookups in script bodies is based on the client
--- locale; this may change later based on the "addon locale" setting and cause
--- differences, but for the majority of users it should go unnoticed.
---
--- Long term we should look at fixing those things; primary area being module
--- names and descriptions which are looked up in script bodies.
+-- The default locale for any lookups in script bodies is based on the addon
+-- locale global managed by the Data addon, which will prefer (in-order) the
+-- the previously configured state of the AddonLocale setting, the unofficial
+-- GAME_LOCALE global variable, or finally the default client locale.
 
-TRP3_API.loc:SetCurrentLocale(GetLocale(), true);
+TRP3_API.loc:SetCurrentLocale(TRP3_AddonLocale, true);

--- a/totalRP3_Data/totalRP3_Data.lua
+++ b/totalRP3_Data/totalRP3_Data.lua
@@ -28,7 +28,8 @@ end
 local function OnAddonLoaded(owner, addonName)
 	if addonName == ADDON_NAME then
 		TRP3_AddonLocale = TRP3_AddonLocale or GetDefaultLocale();
-		EventRegistry:UnregisterCallback(owner, "ADDON_LOADED");
+		EventRegistry:UnregisterCallback("ADDON_LOADED", owner);
+		EventRegistry:UnregisterFrameEvent("ADDON_LOADED");
 	end
 end
 

--- a/totalRP3_Data/totalRP3_Data.lua
+++ b/totalRP3_Data/totalRP3_Data.lua
@@ -1,6 +1,57 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
--- This is a dummy addon in order to separate data from other players from the main saved variable.
--- We decided to do this due to the WoW bug happening when a save variable file is too large: can't be load and loss of all data.
--- By keeping the data external data aside from our own, we reduce de chances to lose our beautiful descriptions when the register is too large for example.
+local ADDON_NAME = ...;
+
+local function GetDefaultLocale()
+	-- GAME_LOCALE is an opt-in variable honored by other localization systems
+	-- and may be set by generic "change all addon locale"-style addons and
+	-- scripts. We give it higher precedence than the client locale if defined.
+
+	return GAME_LOCALE or GetLocale();
+end
+
+local function GetSuggestedLocale()
+	local locale;
+
+	if type(TRP3_Configuration) == "table" then
+		locale = TRP3_Configuration.AddonLocale;  -- This may be nil.
+	end
+
+	if type(locale) ~= "string" then
+		locale = GetDefaultLocale();
+	end
+
+	return locale;
+end
+
+local function OnAddonLoaded(owner, addonName)
+	if addonName == ADDON_NAME then
+		TRP3_AddonLocale = TRP3_AddonLocale or GetDefaultLocale();
+		EventRegistry:UnregisterCallback(owner, "ADDON_LOADED");
+	end
+end
+
+local function OnAddonsUnloading()
+	-- When persisting locales if the suggested one is also the default for the
+	-- client we don't store it. This is to accommodate cases where the locale
+	-- hasn't been explicitly configured by the user, where we'll instead want
+	-- to use the (possibly new) default locale on the following startup.
+
+	local defaultLocale = GetDefaultLocale();
+	local suggestedLocale = GetSuggestedLocale();
+
+	if suggestedLocale == defaultLocale then
+		TRP3_AddonLocale = nil;
+	else
+		TRP3_AddonLocale = suggestedLocale;
+	end
+end
+
+-- In 3.4.1+ we may be able to use RegisterFrameEventAndCallback, and
+-- can drop the empty-table 'owner' argument.
+
+EventRegistry:RegisterFrameEvent("ADDON_LOADED");
+EventRegistry:RegisterFrameEvent("ADDONS_UNLOADING");
+EventRegistry:RegisterCallback("ADDON_LOADED", OnAddonLoaded, {});
+EventRegistry:RegisterCallback("ADDONS_UNLOADING", OnAddonsUnloading, {});

--- a/totalRP3_Data/totalRP3_Data.lua
+++ b/totalRP3_Data/totalRP3_Data.lua
@@ -3,6 +3,8 @@
 
 local ADDON_NAME = ...;
 
+local EFFECTIVE_LOCALE  -- Set to the default locale during ADDON_LOADED.
+
 local function GetDefaultLocale()
 	-- GAME_LOCALE is an opt-in variable honored by other localization systems
 	-- and may be set by generic "change all addon locale"-style addons and
@@ -11,7 +13,7 @@ local function GetDefaultLocale()
 	return GAME_LOCALE or GetLocale();
 end
 
-local function GetSuggestedLocale()
+local function GetPreferredLocale()
 	local locale;
 
 	if type(TRP3_Configuration) == "table" then
@@ -27,6 +29,7 @@ end
 
 local function OnAddonLoaded(owner, addonName)
 	if addonName == ADDON_NAME then
+		EFFECTIVE_LOCALE = GetDefaultLocale()
 		TRP3_AddonLocale = TRP3_AddonLocale or GetDefaultLocale();
 		EventRegistry:UnregisterCallback("ADDON_LOADED", owner);
 		EventRegistry:UnregisterFrameEvent("ADDON_LOADED");
@@ -34,18 +37,18 @@ local function OnAddonLoaded(owner, addonName)
 end
 
 local function OnAddonsUnloading()
-	-- When persisting locales if the suggested one is also the default for the
-	-- client we don't store it. This is to accommodate cases where the locale
-	-- hasn't been explicitly configured by the user, where we'll instead want
-	-- to use the (possibly new) default locale on the following startup.
+	-- When persisting locales if the suggested one is also the effective one
+	-- for this session we don't store it. This is to accommodate cases where
+	-- the locale hasn't been explicitly configured by the user, where we'll
+	-- instead want to use the (possibly new) default locale on the following
+	-- startup.
 
-	local defaultLocale = GetDefaultLocale();
-	local suggestedLocale = GetSuggestedLocale();
+	local preferredLocale = GetPreferredLocale();
 
-	if suggestedLocale == defaultLocale then
+	if preferredLocale == EFFECTIVE_LOCALE then
 		TRP3_AddonLocale = nil;
 	else
-		TRP3_AddonLocale = suggestedLocale;
+		TRP3_AddonLocale = preferredLocale;
 	end
 end
 

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -6,7 +6,7 @@
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@
 ## Notes: The best data storage for the best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
-## SavedVariables: TRP3_Register
+## SavedVariables: TRP3_AddonLocale, TRP3_Register
 ## LoadOnDemand: 1
 
 ## X-Category: Roleplay


### PR DESCRIPTION
This changeset modifies our handling of localization during early load.

Due to providing a configurable addon locale setting, we've got issues where any localization lookups that occur before the ADDON_LOADED event fire will always default to the client locale, which may differ from the configured setting. This is particularly noticeable with module registrations, but it also complicates the use of strings within UI elements that get created early on.

While personally I'd quite like to remove the setting entirely due to the massive complications this causes, we have a workaround at our fingertips that resolves part of the problem.

The Data addon has gained a new saved variable (TRP3_AddonLocale) which will mirror the AddonLocale setting when saved variables are written. This is only set if the configured locale is not the client default, otherwise it will be reset to nil.

On the following startup if the value stored in TRP3_AddonLocale is not nil it will be honored by the localization system when early setup occurs in the script body. If it is nil, it'll be set to the default locale of the client and match todays' behavior for early startup.

As an extension to this, we also now honor the custom GAME_LOCALE global variable. This is accepted by other localization addons for the purposes of testing translations, but may also be set by addons or scripts that intentionally mass-override locales for other addons. The value assigned to this global has a higher priority than the default client locale.

If we were to remove the setting, I suspect we'd really just need to support GAME_LOCALE and call it a day.