### PR TITLE
Hardcode test for Water Elemental creature IDs

### DIFF
--- a/totalRP3/Core/Globals.lua
+++ b/totalRP3/Core/Globals.lua
@@ -89,6 +89,7 @@ TRP3_ClientFeatures = {
 	BroadcastMethod = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE and TRP3_BroadcastMethod.Yell or TRP3_BroadcastMethod.Channel),
 	WarMode = (LE_EXPANSION_LEVEL_CURRENT >= TRP3_EXPANSION_BATTLE_FOR_AZEROTH),
 	Transmogrification = (LE_EXPANSION_LEVEL_CURRENT >= TRP3_EXPANSION_CATACLYSM),
+	WaterElementalWorkaround = (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE),
 };
 
 --- RELATIONS is a list of (backwards-compatible) relationship IDs.

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -518,7 +518,20 @@ local function IsBattlePetUnit(unitToken)
 end
 
 local function IsPetUnit(unitToken)
-	return UnitPlayerControlled(unitToken) and (UnitIsOtherPlayersPet(unitToken) or UnitIsUnit(unitToken, "pet"));
+	if UnitPlayerControlled(unitToken) and (UnitIsOtherPlayersPet(unitToken) or UnitIsUnit(unitToken, "pet")) then
+		return true;
+	elseif not TRP3_ClientFeatures.WaterElementalWorkaround then
+		return false;
+	end
+
+	-- Classic Wrath seems to dispute the idea that Mages' Water Elementals
+	-- are pets, and they report nil for UnitCreatureFamily too. For these
+	-- clients we'll just hardcode the creature ID and be done with it.
+
+	local unitGUID = UnitGUID(unitToken);
+	local guidType, _, _, _, _, creatureID = string.split("-", unitGUID or "", 7);
+
+	return guidType == "Creature" and (creatureID == 510 or creatureID == 37994);
 end
 
 ---


### PR DESCRIPTION
Closes #655 (hopefully). As reportedly water elementals are still broken it's assumed one of the APIs isn't returning expected values for other players' elementals.

So we'll just hardcode the creature ID and be done with it. I don't know if these IDs are correct as the Classic PTR is offline, but...