### PR TITLE
Persist name-only mode state in local settings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -200,6 +200,13 @@ stds.wow = {
 			},
 		},
 
+		C_CVar = {
+			fields = {
+				"GetCVarBool",
+				"SetCVar",
+			},
+		},
+
 		C_FriendList = {
 			fields = {
 				"IsFriend",

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -144,6 +144,7 @@ function TRP3_BlizzardNamePlates:OnModuleEnable()
 	self.initializedNameplates = {};
 
 	TRP3_NamePlates.RegisterCallback(self, "OnNamePlateDataUpdated");
+	TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(TRP3_NamePlatesUtil.IsNameOnlyModePreferred());
 
 	hooksecurefunc("CompactUnitFrame_SetUpFrame", function(...) return self:OnUnitFrameSetUp(...); end);
 	hooksecurefunc(NamePlateDriverFrame, "UpdateNamePlateOptions", function() return self:OnUpdateNamePlateOptions(); end);
@@ -379,7 +380,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateFullTitle(nameplate)
 	-- spuriously disappear if name only mode isn't enabled because of our
 	-- visibility overrides on the level frame widget.
 
-	local isNameOnly = (GetCVar("nameplateShowOnlyNames") ~= "0");
+	local isNameOnly = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
 
 	if unitframe.LevelFrame and isNameOnly then
 		unitframe.LevelFrame:SetShown(unitframe.healthBar:IsShown());

--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -368,8 +368,6 @@ function TRP3_NamePlatesUtil.GenerateConfigurationPage()
 					local desiredState = not preferredState;
 					local effectiveState = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
 
-					TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(desiredState)
-
 					if desiredState ~= preferredState then
 						TRP3_NamePlatesUtil.SetNameOnlyModePreferred(desiredState);
 					end

--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -70,7 +70,7 @@ function TRP3_NamePlatesUtil.IsNameOnlyModePreferred()
 end
 
 function TRP3_NamePlatesUtil.SetNameOnlyModePreferred(preferred)
-	return TRP3_API.configuration.setValue("NamePlates_EnableNameOnlyMode", preferred);
+	TRP3_API.configuration.setValue("NamePlates_EnableNameOnlyMode", preferred);
 end
 
 function TRP3_NamePlatesUtil.IsNameOnlyModeEnabled()

--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -373,8 +373,11 @@ function TRP3_NamePlatesUtil.GenerateConfigurationPage()
 					end
 
 					if desiredState ~= effectiveState then
-						TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(desiredState);
-						TRP3_API.popup.showConfirmPopup(L.CO_UI_RELOAD_WARNING, ReloadUI);
+						if desiredState then
+							TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(desiredState);
+						else
+							TRP3_API.popup.showConfirmPopup(L.CO_UI_RELOAD_WARNING, ReloadUI);
+						end
 					end
 
 					UpdateNameOnlyModeCheckButton(button);

--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -65,6 +65,29 @@ function TRP3_NamePlatesUtil.GetUnitCharacterID(unitToken)
 	return characterID;
 end
 
+function TRP3_NamePlatesUtil.IsNameOnlyModePreferred()
+	return TRP3_API.configuration.getValue("NamePlates_EnableNameOnlyMode");
+end
+
+function TRP3_NamePlatesUtil.SetNameOnlyModePreferred(preferred)
+	return TRP3_API.configuration.setValue("NamePlates_EnableNameOnlyMode", preferred);
+end
+
+function TRP3_NamePlatesUtil.IsNameOnlyModeEnabled()
+	return C_CVar.GetCVarBool("nameplateShowOnlyNames");
+end
+
+function TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(enabled)
+	-- Effective configuration of the name-only mode state acts as a latch;
+	-- we only ever enable the cvar based on the users' preferred state at
+	-- load, and won't subsequently disable it until the user reloads the UI.
+
+	if enabled then
+		C_CVar.SetCVar("nameplateShowOnlyNames", "1");
+	end
+end
+
+
 --
 -- Configuration Data
 --
@@ -149,7 +172,33 @@ TRP3_NamePlatesUtil.Configuration = {
 		key = "NamePlates_EnableClassColorFallback",
 		default = true,
 	},
+
+	EnableNameOnlyMode = {
+		key = "NamePlates_EnableNameOnlyMode",
+		default = false,
+	},
 };
+
+local function UpdateNameOnlyModeCheckButton(button)
+	-- The checkbutton for name-only mode is a faux tri-state checkbutton
+	-- to deal with changes in 10.0.5 where the name-only mode cvar no longer
+	-- persists across client restarts.
+	--
+	-- Internally we store a desired preference for name-only mode in our
+	-- saved variables and assign this to the cvar on load. For the UI however
+	-- we visually track the current "effective" state of the cvar, which may
+	-- be set by other installed addons.
+	--
+	-- If name-only mode is currently active from any addon, we'll display the
+	-- checkbutton in a checked state. If the user didn't enable name-only
+	-- mode through our settings, the check will be desaturated.
+
+	local preferredState = TRP3_NamePlatesUtil.IsNameOnlyModePreferred();
+	local effectiveState = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
+
+	button:SetChecked(effectiveState);
+	button:GetCheckedTexture():SetDesaturated(preferredState ~= effectiveState);
+end
 
 function TRP3_NamePlatesUtil.GenerateConfigurationPage()
 	return {
@@ -306,16 +355,31 @@ function TRP3_NamePlatesUtil.GenerateConfigurationPage()
 				title = L.NAMEPLATES_CONFIG_BLIZZARD_NAME_ONLY,
 				help = L.NAMEPLATES_CONFIG_BLIZZARD_NAME_ONLY_HELP,
 				OnShow = function(button)
-					button:SetChecked(GetCVar("nameplateShowOnlyNames") ~= "0");
+					UpdateNameOnlyModeCheckButton(button);
 				end,
 				OnClick = function(button)
-					local value = button:GetChecked() and "1" or "0";
-					local current = GetCVar("nameplateShowOnlyNames");
+					-- When updating our setting we need to invert the current
+					-- state of our internal tracking variable for name-only
+					-- mode and *not* rely on the checked state of the button,
+					-- as the checked state is a visual representation of the
+					-- effective name-only state only.
 
-					if current ~= value then
-						SetCVar("nameplateShowOnlyNames", value);
+					local preferredState = TRP3_NamePlatesUtil.IsNameOnlyModePreferred();
+					local desiredState = not preferredState;
+					local effectiveState = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
+
+					TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(desiredState)
+
+					if desiredState ~= preferredState then
+						TRP3_NamePlatesUtil.SetNameOnlyModePreferred(desiredState);
+					end
+
+					if desiredState ~= effectiveState then
+						TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(desiredState);
 						TRP3_API.popup.showConfirmPopup(L.CO_UI_RELOAD_WARNING, ReloadUI);
 					end
+
+					UpdateNameOnlyModeCheckButton(button);
 				end,
 			},
 		}


### PR DESCRIPTION
An upcoming client build will be restoring the name-only mode cvar however won't persist it across client restarts, meaning that we'll need to store its state ourselves and restore it on load.

This commit attempts to implement that in such a way that we'll hopefully avoid confusing users and won't conflict with any other addons attempting to control the cvar.

The checkbox in the UI will represent the current effective state of name-only mode, showing a check if the cvar is enabled or not. If the state of the cvar doesn't match our locally saved state, the check will be desaturated - similar to how tristate checkbuttons work in the addon list. Clicking the checkbutton operates on our locally saved state, toggling based off that and not the effective one.

The cvar itself will only ever be enabled from us at runtime; if the user attempts to disable name-only mode within our settings they'll need to do a UI reload for the change to take effect. This is the same as the existing behaviour anyway, however the specific reason we won't toggle the cvar back to an off state is to avoid edge cases where we disable name-only mode after other addons in the environment have also tried to enable it.

On addon load we'll only set the cvar for name-only mode from within the Blizzard nameplates decorator. As such - if the user has Plater or Kui installed, we'll leave it to them to configure name-only mode. This might change based upon feedback.