### PR TITLE
Integrate LibDropDownExtension for UnitPopup module

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -29,6 +29,7 @@ externals:
   totalRP3/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   totalRP3/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   totalRP3/Libs/LibDeflate: https://github.com/SafeteeWoW/LibDeflate
+  totalRP3/Libs/LibDropDownExtension: https://github.com/Vladinator/wow-addon-libdropdownextension
   totalRP3/Libs/LibMSP: https://github.com/wow-rp-addons/LibMSP
   totalRP3/Libs/LibRPMedia: https://github.com/wow-rp-addons/LibRPMedia
   totalRP3/Libs/LibStub: https://repos.curseforge.com/wow/libstub/trunk

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -31,6 +31,7 @@ Libs\LibCompress\lib.xml
 Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
 Libs\LibDBIcon-1.0\lib.xml
 Libs\LibDeflate\lib.xml
+Libs\LibDropDownExtension\LibDropDownExtension.lua
 Libs\LibMSP\LibMSP.xml
 Libs\LibRPMedia\LibRPMedia-1.0.xml
 Libs\MSA-DropDownMenu-1.0\MSA-DropDownMenu-1.0.xml


### PR DESCRIPTION
This reworks our UnitPopup module to instead go through LibDropDownExtension. The library modifies unit popup menus through a slightly different mechanism of creating its own buttons and resizing the host menu, which avoids the edit mode taint issues that our old approach had since 10.0.

One downside is that LibDropDownExtension has a bug whereby check-style menu entries don't correctly set up the anchors for the text to display it beside the check texture - instead they overlap. As such the menu entry for toggling IC/OOC status has been disabled when right-clicking the players' own unitframe.