### PR TITLE
Fix dashboard dropdowns displaying incorrect selected values

### DIFF
--- a/totalRP3/Modules/Dashboard/StatusPanel.lua
+++ b/totalRP3/Modules/Dashboard/StatusPanel.lua
@@ -113,9 +113,9 @@ end
 -- Calling this function will close any active dropdown menus.
 function DashboardStatusMenuMixin:InitializeMenu()
 	MSA_DropDownMenu_SetWidth(self, 170);
-	MSA_DropDownMenu_Initialize(self, function(_, ...)
-		-- Lazy binding as the method we're calling should be overridden.
-		self:OnMenuInitialize(...)
+	MSA_DropDownMenu_SetInitializeFunction(self, function(_, ...)
+		self:OnMenuInitialize(...);
+		self:RefreshMenu();
 	end);
 
 	MSA_DropDownMenu_SetSelectedValue(self, self:GetSelectedMenuItem());
@@ -234,9 +234,6 @@ end
 	item.text = self:GetMenuItemText(item.value);
 	item.tooltipText = L.DB_STATUS_RP_OOC_TT;
 	self:AddButtonToMenu(item, level);
-
-	-- Updates selected options in the dropdown menu
-	self:RefreshMenu()
 end
 
 --[[override]] function DashboardRPStatusMenuMixin:OnMenuButtonClicked(button)
@@ -309,9 +306,6 @@ end
 	item.text = self:GetMenuItemText(item.value);
 	item.tooltipText = L.DB_STATUS_RP_VOLUNTEER_TT;
 	self:AddButtonToMenu(item, level);
-
-	-- Updates selected options in the dropdown menu
-	self:RefreshMenu()
 end
 
 --[[override]] function DashboardXPStatusMenuMixin:OnMenuButtonClicked(button)

--- a/totalRP3/Modules/Dashboard/StatusPanel.lua
+++ b/totalRP3/Modules/Dashboard/StatusPanel.lua
@@ -234,6 +234,9 @@ end
 	item.text = self:GetMenuItemText(item.value);
 	item.tooltipText = L.DB_STATUS_RP_OOC_TT;
 	self:AddButtonToMenu(item, level);
+
+	-- Updates selected options in the dropdown menu
+	self:RefreshMenu()
 end
 
 --[[override]] function DashboardRPStatusMenuMixin:OnMenuButtonClicked(button)
@@ -306,6 +309,9 @@ end
 	item.text = self:GetMenuItemText(item.value);
 	item.tooltipText = L.DB_STATUS_RP_VOLUNTEER_TT;
 	self:AddButtonToMenu(item, level);
+
+	-- Updates selected options in the dropdown menu
+	self:RefreshMenu()
 end
 
 --[[override]] function DashboardXPStatusMenuMixin:OnMenuButtonClicked(button)


### PR DESCRIPTION
The menus were being initialized before they were opened, and were not correctly updating the selected values. I don't completely understand why this was happening, but my theory is that the initialization was happening before the options were created, or before the menu was open and populated, leading to them getting stuck with the old selected value instead of checking for the new values and updating accordingly.

Simply calling `self:RefreshMenu()` at the end of the menu initialization fixes this behavior. It could be a bit cleaner but that'd require some wider work on the system as a whole. This fix should be fine for now.