### PR TITLE
More strict checks for profile existence

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -764,7 +764,7 @@ function TRP3_API.register.init()
 		if unitID == Globals.player_id and (not dataType or dataType == "characteristics") then
 			menuItemID = "main_12_player_character";
 			menuItemText = get("player/characteristics/FN") or Globals.player;
-		elseif profileID then
+		elseif TRP3_API.register.getProfileOrNil(profileID) then
 			local player = AddOn_TotalRP3.Player.CreateFromProfileID(profileID);
 
 			menuItemID = TRP3_API.register.MENU_LIST_ID_TAB .. profileID;


### PR DESCRIPTION
There's a rare condition where the profile ID can be non-nil but also invalid for use with the CreateFromProfileID function. This is assumed to be related to event dispatch orders, so for now we'll just work around the issue by checking if the profile actually exists rather than assuming it does from the presence of the ID.