### PR TITLE
Hide OOC characters on map scan by default

### DIFF
--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1493,6 +1493,10 @@ If you wish to report %s's profile and you cannot target them you will need to o
 
 ]],
 
+
+CO_LOCATION_SHOW_OUT_OF_CHARACTER = "Show out of character players",
+CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
+
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/Modules/Map/MapPoiMixins.lua
+++ b/totalRP3/Modules/Map/MapPoiMixins.lua
@@ -45,9 +45,7 @@ local GroupedCoalescedMapPinMixin = {};
 local WHITE = Ellyb.ColorManager.WHITE;
 local TOOLTIP_CATEGORY_SEPARATOR = [[|TInterface\Common\UI-TooltipDivider-Transparent:8:128:0:0:8:8:0:128:0:8:255:255:255|t]];
 
---- Custom sorting function that compares entries. The resulting order is
----  in order of their category priority (descending), or if equal, their
----  sortable name equivalent (ascending).
+--- Custom sorting function that compares entries.
 local function sortMarkerEntries(a, b)
 	local categoryA = a.categoryPriority or math.huge;
 	local categoryB = b.categoryPriority or math.huge;
@@ -58,11 +56,21 @@ local function sortMarkerEntries(a, b)
 		categoryB = "";
 	end
 
+	if categoryA ~= categoryB then
+		return categoryA < categoryB;
+	end
+
+	local orderA = a.sortOrder or 0;
+	local orderB = b.sortOrder or 0;
+
+	if orderA ~= orderB then
+		return orderA < orderB;
+	end
+
 	local nameA = a.sortName or "";
 	local nameB = b.sortName or "";
 
-	return (categoryA < categoryB)
-		or (categoryA == categoryB and nameA < nameB);
+	return nameA < nameB;
 end
 
 local function ExecuteOnAllPins(map, func)


### PR DESCRIPTION
Closes #475. This adds a new configurable option to hide OOC players from the map scan results. Per the ticket, this option is enabled by default.

For compatibility with existing clients on the network we treat all incoming scan responses that don't supply a roleplay status value as being in-character.

To additionally differentiate between IC and OOC characters in the scan results, the pin tooltip will now additionally display an "(OOC)" suffix for characters. For lone pins, they will also be faded out.