### PR TITLE
Additional toolbar visibility options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - Added Plater support for RP nameplates customization. Thanks to Ghost for this addition.
+- The TRP toolbar can now be set to only show while in character with the Toolbar display conditions setting (replacing Toolbar show on login).
 - OOC characters are now hidden from the map scan.
   - You can re-enable them by checking "Show out of character players" in Register settings > Location settings. Pins with only OOC characters will appear faded.
   - Only players from this version onwards are recognized as OOC, so this may take some time to be accurate.

--- a/totalRP3/Core/Events.lua
+++ b/totalRP3/Core/Events.lua
@@ -61,6 +61,12 @@ local Events = {
 	-- Arg2 : Target mode (Character, pet, battle pet ...)
 	MOUSE_OVER_CHANGED = "MOUSE_OVER_CHANGED",
 
+	-- Notification for when the players' current roleplay status has changed.
+	--
+	-- This event will be fired at an arbitrary point during the processing
+	-- of the REGISTER_DATA_UPDATED event. Users must not make assumptions
+	-- about the ordering of callbacks between these two events. This event
+	-- should not be triggered manually by any code.
 	ROLEPLAY_STATUS_CHANGED = "ROLEPLAY_STATUS_CHANGED",
 };
 
@@ -112,13 +118,6 @@ Events.fireEvent = Events.triggerEvent;
 
 TRP3_API.Events = Events;
 TRP3_API.events = Events;
-
--- The ROLEPLAY_STATUS_CHANGED event is a filter of REGISTER_DATA_UPDATED and
--- will be triggered at an arbitrary point during the processing of the
--- REGISTER_DATA_UPDATED event.
---
--- Do *not* rely on any specific ordering of callbacks registered between these
--- events.
 
 do
 	local status = nil;

--- a/totalRP3/Core/Events.lua
+++ b/totalRP3/Core/Events.lua
@@ -60,6 +60,8 @@ local Events = {
 	-- Arg1 : Target ID
 	-- Arg2 : Target mode (Character, pet, battle pet ...)
 	MOUSE_OVER_CHANGED = "MOUSE_OVER_CHANGED",
+
+	ROLEPLAY_STATUS_CHANGED = "ROLEPLAY_STATUS_CHANGED",
 };
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -110,3 +112,25 @@ Events.fireEvent = Events.triggerEvent;
 
 TRP3_API.Events = Events;
 TRP3_API.events = Events;
+
+-- The ROLEPLAY_STATUS_CHANGED event is a filter of REGISTER_DATA_UPDATED and
+-- will be triggered at an arbitrary point during the processing of the
+-- REGISTER_DATA_UPDATED event.
+--
+-- Do *not* rely on any specific ordering of callbacks registered between these
+-- events.
+
+do
+	local status = nil;
+
+	local function OnRegisterDataUpdated()
+		local current = AddOn_TotalRP3.Player.GetCurrentUser():GetRoleplayStatus();
+
+		if status ~= current then
+			status = current;
+			eventsDispatcher:TriggerEvent("ROLEPLAY_STATUS_CHANGED", status);
+		end
+	end
+
+	eventsDispatcher:RegisterCallback("REGISTER_DATA_UPDATED", OnRegisterDataUpdated);
+end

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1458,6 +1458,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 ## Added
 
 - Added Plater support for RP nameplates customization. Thanks to Ghost for this addition.
+- The TRP toolbar can now be set to only show while in character with the Toolbar display conditions setting (replacing Toolbar show on login).
 - OOC characters are now hidden from the map scan.
   - You can re-enable them by checking "Show out of character players" in Register settings > Location settings. Pins with only OOC characters will appear faded.
   - Only players from this version onwards are recognized as OOC, so this may take some time to be accurate.

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1505,6 +1505,11 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER = "Show out of character players",
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
+	CO_TOOLBAR_VISIBLITY = "CO_TOOLBAR_VISIBLITY",
+	CO_TOOLBAR_VISIBILITY_HELP = "CO_TOOLBAR_VISIBILITY_HELP",
+	CO_TOOLBAR_VISIBILITY_1 = "Show on login",
+	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
+	CO_TOOLBAR_VISIBILITY_3 = "Hide toolbar",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1506,7 +1506,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
 	CO_TOOLBAR_VISIBILITY = "Toolbar Visibility",
-	CO_TOOLBAR_VISIBILITY_HELP = "help me",
+	CO_TOOLBAR_VISIBILITY_HELP = "Configures the conditions under which the toolbar should be shown.|n|nThe visibility of the toolbar can be forcefully toggled by running the |cff00ff00/trp switch toolbar|r slash command or by right-clicking the minimap button, which will persist until either logout or a UI reload.",
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1506,7 +1506,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
 	CO_TOOLBAR_VISIBILITY = "Display conditions",
-	CO_TOOLBAR_VISIBILITY_HELP = "Configures the conditions under which the toolbar should be shown.|n|nThe visibility of the toolbar can be forcefully toggled by running the |cff00ff00/trp switch toolbar|r slash command or by right-clicking the minimap button, which will persist until either logout or a UI reload.",
+	CO_TOOLBAR_VISIBILITY_HELP = "Configures the conditions under which the toolbar should be shown.|n|nThe visibility of the toolbar can be forcefully toggled by running the |cff00ff00/trp switch toolbar|r slash command or by right-clicking the minimap button.",
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1505,11 +1505,11 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER = "Show out of character players",
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
-	CO_TOOLBAR_VISIBLITY = "CO_TOOLBAR_VISIBLITY",
-	CO_TOOLBAR_VISIBILITY_HELP = "CO_TOOLBAR_VISIBILITY_HELP",
-	CO_TOOLBAR_VISIBILITY_1 = "Show on login",
+	CO_TOOLBAR_VISIBILITY = "Toolbar Visibility",
+	CO_TOOLBAR_VISIBILITY_HELP = "MEO_PHONE_HOME", --FIXME: don't forget to fix this later
+	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
-	CO_TOOLBAR_VISIBILITY_3 = "Hide toolbar",
+	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1509,6 +1509,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",
+	CO_TOOLBAR_LOCKOUT = "Your toolbar visibility is now being controlled by the |cff00ff00minimap button|r and the |cff00ff00/trp3 switch toolbar|r slash command. To re-enable automatic hiding, reload your UI with |cff00ff00/reload|r.",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1506,7 +1506,6 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
 	CO_TOOLBAR_VISIBILITY = "Toolbar Visibility",
-	CO_TOOLBAR_VISIBILITY_HELP = "MEO_PHONE_HOME", --FIXME: don't forget to fix this later
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1506,6 +1506,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
 	CO_TOOLBAR_VISIBILITY = "Toolbar Visibility",
+	CO_TOOLBAR_VISIBILITY_HELP = "help me",
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1505,12 +1505,11 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER = "Show out of character players",
 	CO_LOCATION_SHOW_OUT_OF_CHARACTER_TT = "If checked, show map pins for all players that are marked as out of character.",
 
-	CO_TOOLBAR_VISIBILITY = "Toolbar Visibility",
+	CO_TOOLBAR_VISIBILITY = "Display conditions",
 	CO_TOOLBAR_VISIBILITY_HELP = "Configures the conditions under which the toolbar should be shown.|n|nThe visibility of the toolbar can be forcefully toggled by running the |cff00ff00/trp switch toolbar|r slash command or by right-clicking the minimap button, which will persist until either logout or a UI reload.",
 	CO_TOOLBAR_VISIBILITY_1 = "Always show",
 	CO_TOOLBAR_VISIBILITY_2 = "Only show in-character",
 	CO_TOOLBAR_VISIBILITY_3 = "Always hidden",
-	CO_TOOLBAR_LOCKOUT = "Your toolbar visibility is now being controlled by the |cff00ff00minimap button|r and the |cff00ff00/trp3 switch toolbar|r slash command. To re-enable automatic hiding, reload your UI with |cff00ff00/reload|r.",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -243,7 +243,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 				end
 			end,
 			onModelUpdate = function(buttonStructure)
-				if get("player/character/RP") == 1 then
+				if AddOn_TotalRP3.Player.GetCurrentUser():IsInCharacter() then
 					buttonStructure.tooltip  = rpTextOn;
 					buttonStructure.tooltipSub = rpText3;
 					buttonStructure.icon = RP_ICON;

--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -5,7 +5,7 @@ TRP3_API.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 12;
+local SCHEMA_VERSION = 13;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -145,9 +145,9 @@ TRP3_API.flyway.patches["13"] = function()
 	-- Migrate the toolbar show on login setting to the new display conditions
 	if TRP3_Configuration then
 		if TRP3_Configuration["toolbar_show_on_login"] then
-			TRP3_Configuration["toolbar_visibility"] = 1; -- AlwaysShow
+			TRP3_Configuration["toolbar_visibility"] = TRP3_ToolbarVisibilityOption.AlwaysShow;
 		else
-			TRP3_Configuration["toolbar_visibility"] = 3; -- AlwaysHide
+			TRP3_Configuration["toolbar_visibility"] = TRP3_ToolbarVisibilityOption.AlwaysHidden;
 		end
 
 		TRP3_Configuration["toolbar_show_on_login"] = nil;

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -140,3 +140,16 @@ TRP3_API.flyway.patches["12"] = function()
 		TRP3_MatureFilter.whitelist = nil;
 	end
 end
+
+TRP3_API.flyway.patches["13"] = function()
+	-- Migrate the toolbar show on login setting to the new display conditions
+	if TRP3_Configuration then
+		if TRP3_Configuration["toolbar_show_on_login"] then
+			TRP3_Configuration["toolbar_visibility"] = 1; -- AlwaysShow
+		else
+			TRP3_Configuration["toolbar_visibility"] = 3; -- AlwaysHide
+		end
+
+		TRP3_Configuration["toolbar_show_on_login"] = nil;
+	end
+end

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -306,9 +306,9 @@ local function onStart()
 			title = loc.CO_TARGETFRAME_USE,
 			help = loc.CO_TARGETFRAME_USE_TT,
 			listContent = {
-				{loc.CO_TARGETFRAME_USE_1, 1},
-				{loc.CO_TARGETFRAME_USE_2, 2},
-				{loc.CO_TARGETFRAME_USE_3, 3}
+				{loc.CO_TOOLBAR_VISIBILITY_1, 1},
+				{loc.CO_TOOLBAR_VISIBILITY_2, 2},
+				{loc.CO_TOOLBAR_VISIBILITY_3, 3}
 			},
 			configKey = CONFIG_TARGET_USE,
 			listWidth = nil,

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -379,6 +379,8 @@ local function onStart()
 			onTargetChanged();
 		end
 	end);
+
+	TRP3_API.Events.registerCallback("ROLEPLAY_STATUS_CHANGED", onTargetChanged);
 end
 
 local MODULE_STRUCTURE = {

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -288,20 +288,24 @@ local function onStart()
 	end
 	TRP3_API.toolbar.updateToolbarButton = updateToolbarButton;
 
-
-	local toolbarModelRefreshFrame = CreateFrame("Frame");
-
-	-- We create a frame that will take care of refreshing the model of the buttons every half second
-	-- It will also refresh the databroker plugin
-	TRP3_API.ui.frame.createRefreshOnFrame(toolbarModelRefreshFrame, 0.5, function()
+	local function RefreshToolbarButtons()
 		for _, buttonStructure in pairs(buttonStructures) do
 			if buttonStructure.onModelUpdate then
-				buttonStructure.onModelUpdate(buttonStructure)
+				buttonStructure:onModelUpdate();
 				refreshLDBPLugin(buttonStructure);
 			end
 		end
-	end)
 
+		for _, uiButton in pairs(uiButtons) do
+			uiButton.TimeSinceLastUpdate = math.huge;
+		end
+	end
+
+	-- Holding off on making toolbutton updates more flexible for now in favour
+	-- of *just* relying on periodic updates and a few hand-selected callbacks.
+
+	C_Timer.NewTicker(0.5, RefreshToolbarButtons);
+	TRP3_API.Events.registerCallback("ROLEPLAY_STATUS_CHANGED", RefreshToolbarButtons);
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Position

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -322,6 +322,7 @@ local function onStart()
 			inherit = "TRP3_ConfigDropDown",
 			widgetName = "TRP3_ConfigToolbarVisibility",
 			title = loc.CO_TOOLBAR_VISIBILITY,
+			help = loc.CO_TOOLBAR_VISIBILITY_HELP,
 			listContent = {
 				{loc.CO_TOOLBAR_VISIBILITY_1, ToolbarVisibilityOption.AlwaysShow},
 				{loc.CO_TOOLBAR_VISIBILITY_2, ToolbarVisibilityOption.OnlyShowInCharacter},

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -23,31 +23,29 @@ function ToolbarMixin:OnLoad()
 	self.manualVisibility = nil;
 
 	TRP3_API.Events.registerCallback("CONFIGURATION_CHANGED", GenerateClosure(self.OnConfigurationChanged, self));
-	TRP3_API.Events.registerCallback("REGISTER_DATA_UPDATED", GenerateClosure(self.OnRegisterDataUpdated, self));
+	TRP3_API.Events.registerCallback("ROLEPLAY_STATUS_CHANGED", GenerateClosure(self.OnRoleplayStatusChanged, self));
 
 	self:UpdateVisibility();
 end
 
-function ToolbarMixin:OnRegisterDataUpdated(characterID)
-	if characterID == TRP3_API.globals.player_id then
+function ToolbarMixin:OnRoleplayStatusChanged()
+	local configuredVisibility = TRP3_API.configuration.getValue(CONFIG_TOOLBAR_VISIBILITY);
+
+	if configuredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then
 		self:UpdateVisibility();
 	end
 end
 
 function ToolbarMixin:OnConfigurationChanged(key)
 	if key == CONFIG_TOOLBAR_VISIBILITY then
-		self.manualVisibility = nil;
 		self:UpdateVisibility();
 	end
 end
 
 function ToolbarMixin:Toggle()
-	if self.manualVisibility == nil and self:IsVisibilityDynamic() then
-		TRP3_API.utils.message.displayMessage(TRP3_API.Ellyb.ColorManager.ORANGE(loc.CO_TOOLBAR_LOCKOUT));
-	end
-
-	self.manualVisibility = not self:IsShown();
+	self.forcedVisibility = not self:IsShown();
 	self:UpdateVisibility();
+	self.forcedVisibility = nil;
 
 	if self:IsShown() then
 		TRP3_API.ui.misc.playUISound(SOUNDKIT.IG_MAINMENU_OPEN);
@@ -56,17 +54,12 @@ function ToolbarMixin:Toggle()
 	end
 end
 
-function ToolbarMixin:IsVisibilityDynamic()
-	local configuredVisibility = TRP3_API.configuration.getValue(CONFIG_TOOLBAR_VISIBILITY);
-	return configuredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter;
-end
-
 function ToolbarMixin:UpdateVisibility()
 	local configuredVisibility = TRP3_API.configuration.getValue(CONFIG_TOOLBAR_VISIBILITY);
 	local shouldShow;
 
-	if self.manualVisibility ~= nil then
-		shouldShow = self.manualVisibility;
+	if self.forcedVisibility ~= nil then
+		shouldShow = self.forcedVisibility;
 	elseif configuredVisibility == ToolbarVisibilityOption.AlwaysHidden then
 		shouldShow = false;
 	elseif configuredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -36,6 +36,7 @@ local function onStart()
 		OnlyShowInCharacter = 2,
 		AlwaysHidden = 3,
 	};
+	local ToolbarSessionVisibility = nil;
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Toolbar Logic
@@ -304,6 +305,14 @@ local function onStart()
 			CONFIG_HIDE_TITLE,
 		}, buildToolbar);
 
+		local ShouldShowToolbar;
+
+		local function ResetToolbarVisibility(newValue, _)
+			setConfigValue(CONFIG_TOOLBAR_VISIBILITY, newValue);
+			ToolbarSessionVisibility = nil;
+			toolbar:SetShown(ShouldShowToolbar());
+		end
+
 		-- Build configuration page
 		tinsert(TRP3_API.configuration.CONFIG_FRAME_PAGE.elements, {
 			inherit = "TRP3_ConfigH1",
@@ -318,6 +327,7 @@ local function onStart()
 				{loc.CO_TOOLBAR_VISIBILITY_2, ToolbarVisibilityOption.OnlyShowInCharacter},
 				{loc.CO_TOOLBAR_VISIBILITY_3, ToolbarVisibilityOption.AlwaysHidden}
 			},
+			listCallback = ResetToolbarVisibility,
 			configKey = CONFIG_TOOLBAR_VISIBILITY,
 			listCancel = true,
 		});
@@ -370,10 +380,12 @@ local function onStart()
 
 		buildToolbar();
 
-		local function ShouldShowToolbar()
+		function ShouldShowToolbar()
 			local preferredVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY);
 
-			if preferredVisibility == ToolbarVisibilityOption.AlwaysHidden then
+			if ToolbarSessionVisibility ~= nil then
+				return ToolbarSessionVisibility;
+			elseif preferredVisibility == ToolbarVisibilityOption.AlwaysHidden then
 				return false;
 			elseif preferredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then
 				local player = AddOn_TotalRP3.Player.GetCurrentUser();
@@ -395,6 +407,13 @@ local function onStart()
 	end);
 
 	function TRP3_API.toolbar.switch()
+		if ToolbarSessionVisibility == nil and getConfigValue(CONFIG_TOOLBAR_VISIBILITY) == ToolbarVisibilityOption.OnlyShowInCharacter then
+			local message = TRP3_API.Ellyb.ColorManager.ORANGE(loc.CO_TOOLBAR_LOCKOUT);
+			Utils.message.displayMessage(message);
+			ToolbarSessionVisibility = true;
+		elseif ToolbarSessionVisibility ~= nil then
+			ToolbarSessionVisibility = not ToolbarSessionVisibility;
+		end
 		if toolbar:IsVisible() then
 			toolbar:Hide();
 			TRP3_API.ui.misc.playUISound(SOUNDKIT.IG_MAINMENU_OPEN);

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -376,7 +376,7 @@ local function onStart()
 		end
 
 		TRP3_API.events.listenToEvent(TRP3_API.events.REGISTER_DATA_UPDATED, function(unitID, _)
-			if unitID ~= Globals.player_id or toolbarVisibility ~= 2 then return end
+			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= 2 then return end
 
 			if player:IsInCharacter() then toolbar:Show() else toolbar:Hide() end
 		end)

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -35,7 +35,7 @@ local function onStart()
 		AlwaysShow = 1,
 		OnlyShowInCharacter = 2,
 		AlwaysHidden = 3,
-	}
+	};
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Toolbar Logic
@@ -371,31 +371,31 @@ local function onStart()
 
 		buildToolbar();
 
-		local player = AddOn_TotalRP3.Player.GetCurrentUser()
-		local toolbarVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY)
+		local player = AddOn_TotalRP3.Player.GetCurrentUser();
+		local toolbarVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY);
 
 		if toolbarVisibility == ToolbarVisibilityOption.OnlyShowInCharacter and player:IsInCharacter() or toolbarVisibility == ToolbarVisibilityOption.AlwaysShow then
-			toolbar:Show()
+			toolbar:Show();
 		else
-			toolbar:Hide()
+			toolbar:Hide();
 		end
 
 		TRP3_API.events.listenToEvent(TRP3_API.events.REGISTER_DATA_UPDATED, function(unitID, _)
 			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= ToolbarVisibilityOption.OnlyShowInCharacter then
-				return
+				return;
 			end
 
 			if player:IsInCharacter() then
-				toolbar:Show()
+				toolbar:Show();
 			else
-				toolbar:Hide()
+				toolbar:Hide();
 			end
 		end)
 	end);
 
 	function TRP3_API.toolbar.switch()
 		if toolbar:IsVisible() then
-			toolbar:Hide()
+			toolbar:Hide();
 			TRP3_API.ui.misc.playUISound(SOUNDKIT.IG_MAINMENU_OPEN);
 		else
 			TRP3_API.ui.misc.playUISound(SOUNDKIT.IG_MAINMENU_CLOSE);

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -20,8 +20,6 @@ TRP3_ToolbarVisibilityOption = {
 local ToolbarMixin = {};
 
 function ToolbarMixin:OnLoad()
-	self.manualVisibility = nil;
-
 	TRP3_API.Events.registerCallback("CONFIGURATION_CHANGED", GenerateClosure(self.OnConfigurationChanged, self));
 	TRP3_API.Events.registerCallback("ROLEPLAY_STATUS_CHANGED", GenerateClosure(self.OnRoleplayStatusChanged, self));
 

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -313,7 +313,6 @@ local function onStart()
 			inherit = "TRP3_ConfigDropDown",
 			widgetName = "TRP3_ConfigToolbarVisibility",
 			title = loc.CO_TOOLBAR_VISIBILITY,
-			help = loc.CO_TOOLBAR_VISIBILITY_HELP,
 			listContent = {
 				{loc.CO_TOOLBAR_VISIBILITY_1, ToolbarVisibilityOption.AlwaysShow},
 				{loc.CO_TOOLBAR_VISIBILITY_2, ToolbarVisibilityOption.OnlyShowInCharacter},
@@ -371,25 +370,27 @@ local function onStart()
 
 		buildToolbar();
 
-		local player = AddOn_TotalRP3.Player.GetCurrentUser();
-		local toolbarVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY);
+		local function ShouldShowToolbar()
+			local preferredVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY);
 
-		if toolbarVisibility == ToolbarVisibilityOption.OnlyShowInCharacter and player:IsInCharacter() or toolbarVisibility == ToolbarVisibilityOption.AlwaysShow then
-			toolbar:Show();
-		else
-			toolbar:Hide();
+			if preferredVisibility == ToolbarVisibilityOption.AlwaysHidden then
+				return false;
+			elseif preferredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then
+				local player = AddOn_TotalRP3.Player.GetCurrentUser();
+				return player:IsInCharacter();
+			else
+				return true;
+			end
 		end
+
+		toolbar:SetShown(ShouldShowToolbar())
 
 		TRP3_API.events.listenToEvent(TRP3_API.events.REGISTER_DATA_UPDATED, function(unitID, _)
 			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= ToolbarVisibilityOption.OnlyShowInCharacter then
 				return;
 			end
 
-			if player:IsInCharacter() then
-				toolbar:Show();
-			else
-				toolbar:Hide();
-			end
+			toolbar:SetShown(ShouldShowToolbar())
 		end)
 	end);
 

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -383,14 +383,14 @@ local function onStart()
 			end
 		end
 
-		toolbar:SetShown(ShouldShowToolbar())
+		toolbar:SetShown(ShouldShowToolbar());
 
 		TRP3_API.events.listenToEvent(TRP3_API.events.REGISTER_DATA_UPDATED, function(unitID, _)
 			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= ToolbarVisibilityOption.OnlyShowInCharacter then
 				return;
 			end
 
-			toolbar:SetShown(ShouldShowToolbar())
+			toolbar:SetShown(ShouldShowToolbar());
 		end)
 	end);
 

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -11,7 +11,7 @@ local CONFIG_CONTENT_PREFIX = "toolbar_content_";
 local CONFIG_HIDE_TITLE = "toolbar_hide_title";
 local CONFIG_TOOLBAR_VISIBILITY = "toolbar_visibility";
 
-local ToolbarVisibilityOption = {
+TRP3_ToolbarVisibilityOption = {
 	AlwaysShow = 1,
 	OnlyShowInCharacter = 2,
 	AlwaysHidden = 3,
@@ -31,7 +31,7 @@ end
 function ToolbarMixin:OnRoleplayStatusChanged()
 	local configuredVisibility = TRP3_API.configuration.getValue(CONFIG_TOOLBAR_VISIBILITY);
 
-	if configuredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then
+	if configuredVisibility == TRP3_ToolbarVisibilityOption.OnlyShowInCharacter then
 		self:UpdateVisibility();
 	end
 end
@@ -60,9 +60,9 @@ function ToolbarMixin:UpdateVisibility()
 
 	if self.forcedVisibility ~= nil then
 		shouldShow = self.forcedVisibility;
-	elseif configuredVisibility == ToolbarVisibilityOption.AlwaysHidden then
+	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.AlwaysHidden then
 		shouldShow = false;
-	elseif configuredVisibility == ToolbarVisibilityOption.OnlyShowInCharacter then
+	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.OnlyShowInCharacter then
 		shouldShow = AddOn_TotalRP3.Player.GetCurrentUser():IsInCharacter();
 	else
 		shouldShow = true;
@@ -338,7 +338,7 @@ local function onStart()
 		setConfigValue(CONFIG_TOOLBAR_POS_A, "TOP");
 		setConfigValue(CONFIG_TOOLBAR_POS_X, 0);
 		setConfigValue(CONFIG_TOOLBAR_POS_Y, -30);
-		setConfigValue(CONFIG_TOOLBAR_VISIBILITY, ToolbarVisibilityOption.AlwaysShow);
+		setConfigValue(CONFIG_TOOLBAR_VISIBILITY, TRP3_ToolbarVisibilityOption.AlwaysShow);
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -350,7 +350,7 @@ local function onStart()
 
 		TRP3_ToolbarTopFrameText:SetText(Globals.addon_name);
 
-		registerConfigKey(CONFIG_TOOLBAR_VISIBILITY, ToolbarVisibilityOption.AlwaysShow);
+		registerConfigKey(CONFIG_TOOLBAR_VISIBILITY, TRP3_ToolbarVisibilityOption.AlwaysShow);
 		registerConfigKey(CONFIG_ICON_SIZE, 25);
 		registerConfigKey(CONFIG_ICON_MAX_PER_LINE, 7);
 		registerConfigKey(CONFIG_HIDE_TITLE, false);
@@ -372,9 +372,9 @@ local function onStart()
 			title = loc.CO_TOOLBAR_VISIBILITY,
 			help = loc.CO_TOOLBAR_VISIBILITY_HELP,
 			listContent = {
-				{loc.CO_TOOLBAR_VISIBILITY_1, ToolbarVisibilityOption.AlwaysShow},
-				{loc.CO_TOOLBAR_VISIBILITY_2, ToolbarVisibilityOption.OnlyShowInCharacter},
-				{loc.CO_TOOLBAR_VISIBILITY_3, ToolbarVisibilityOption.AlwaysHidden}
+				{loc.CO_TOOLBAR_VISIBILITY_1, TRP3_ToolbarVisibilityOption.AlwaysShow},
+				{loc.CO_TOOLBAR_VISIBILITY_2, TRP3_ToolbarVisibilityOption.OnlyShowInCharacter},
+				{loc.CO_TOOLBAR_VISIBILITY_3, TRP3_ToolbarVisibilityOption.AlwaysHidden}
 			},
 			configKey = CONFIG_TOOLBAR_VISIBILITY,
 			listCancel = true,

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -28,8 +28,14 @@ local function onStart()
 	local CONFIG_ICON_SIZE = "toolbar_icon_size";
 	local CONFIG_ICON_MAX_PER_LINE = "toolbar_max_per_line";
 	local CONFIG_CONTENT_PREFIX = "toolbar_content_";
-	local CONFIG_TOOLBAR_VISIBILITY = "toolbar_visiblity";
 	local CONFIG_HIDE_TITLE = "toolbar_hide_title";
+	local CONFIG_TOOLBAR_VISIBILITY = "toolbar_visibility";
+
+	local ToolbarVisibilityOption = {
+		AlwaysShow = 1,
+		OnlyShowInCharacter = 2,
+		AlwaysHidden = 3,
+	}
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Toolbar Logic
@@ -275,7 +281,7 @@ local function onStart()
 		setConfigValue(CONFIG_TOOLBAR_POS_A, "TOP");
 		setConfigValue(CONFIG_TOOLBAR_POS_X, 0);
 		setConfigValue(CONFIG_TOOLBAR_POS_Y, -30);
-		setConfigValue(CONFIG_TOOLBAR_VISIBILITY, 1);
+		setConfigValue(CONFIG_TOOLBAR_VISIBILITY, ToolbarVisibilityOption.AlwaysShow);
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -287,7 +293,7 @@ local function onStart()
 
 		TRP3_ToolbarTopFrameText:SetText(Globals.addon_name);
 
-		registerConfigKey(CONFIG_TOOLBAR_VISIBILITY, 1);
+		registerConfigKey(CONFIG_TOOLBAR_VISIBILITY, ToolbarVisibilityOption.AlwaysShow);
 		registerConfigKey(CONFIG_ICON_SIZE, 25);
 		registerConfigKey(CONFIG_ICON_MAX_PER_LINE, 7);
 		registerConfigKey(CONFIG_HIDE_TITLE, false);
@@ -309,9 +315,9 @@ local function onStart()
 			title = loc.CO_TOOLBAR_VISIBILITY,
 			help = loc.CO_TOOLBAR_VISIBILITY_HELP,
 			listContent = {
-				{loc.CO_TOOLBAR_VISIBILITY_1, 1},
-				{loc.CO_TOOLBAR_VISIBILITY_2, 2},
-				{loc.CO_TOOLBAR_VISIBILITY_3, 3}
+				{loc.CO_TOOLBAR_VISIBILITY_1, ToolbarVisibilityOption.AlwaysShow},
+				{loc.CO_TOOLBAR_VISIBILITY_2, ToolbarVisibilityOption.OnlyShowInCharacter},
+				{loc.CO_TOOLBAR_VISIBILITY_3, ToolbarVisibilityOption.AlwaysHidden}
 			},
 			configKey = CONFIG_TOOLBAR_VISIBILITY,
 			listCancel = true,
@@ -368,17 +374,22 @@ local function onStart()
 		local player = AddOn_TotalRP3.Player.GetCurrentUser()
 		local toolbarVisibility = getConfigValue(CONFIG_TOOLBAR_VISIBILITY)
 
-		-- visibility: 1 = show on login, 2 = only show in-character, 3 = hide toolbar
-		if toolbarVisibility == 2 and player:IsInCharacter() or toolbarVisibility == 1 then
+		if toolbarVisibility == ToolbarVisibilityOption.OnlyShowInCharacter and player:IsInCharacter() or toolbarVisibility == ToolbarVisibilityOption.AlwaysShow then
 			toolbar:Show()
 		else
 			toolbar:Hide()
 		end
 
 		TRP3_API.events.listenToEvent(TRP3_API.events.REGISTER_DATA_UPDATED, function(unitID, _)
-			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= 2 then return end
+			if unitID ~= Globals.player_id or getConfigValue(CONFIG_TOOLBAR_VISIBILITY) ~= ToolbarVisibilityOption.OnlyShowInCharacter then
+				return
+			end
 
-			if player:IsInCharacter() then toolbar:Show() else toolbar:Hide() end
+			if player:IsInCharacter() then
+				toolbar:Show()
+			else
+				toolbar:Hide()
+			end
 		end)
 	end);
 


### PR DESCRIPTION
Originally suggested by `Tonberry#4901` in the TRP Discord.

Currently there's only two visibility options for the TRP toolbar, it's either shown on login or it's not. Here I'm adding the option to show the toolbar only when in-character, with the toolbar disappearing when the player goes out-of-character. Additionally, there's also options to show on login, and hide by default.

Users can still freely toggle the toolbar using the minimap icon or the `/trp3 switch toolbar` slash command.

![image](https://user-images.githubusercontent.com/10636803/220311551-be0997a7-865c-44cd-8d24-36e96857c353.png)

**To do:**
- [x] - Finalize strings
- [x] - Finalize visibility choices