### PR TITLE
Fix "Unknown" target names in tooltips

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -653,7 +653,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 	-- Target
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	if showTarget() and UnitName(targetType .. "target") then
+	if showTarget() and UnitExists(targetType .. "target") then
 		local name = UnitName(targetType .. "target");
 		local targetTargetID = getUnitID(targetType .. "target");
 		if targetTargetID then


### PR DESCRIPTION
If the user has a target selected and transitions through a loading screen the client appears to not be correctly resetting some state, leading to APIs like UnitName and UnitGUID returning values for the unit even though they no longer necessarily exist.

The UnitExists API reports sensible values in such a case and correctly determines that the unit doesn't really exist anymore, so we'll use that instead of assuming that UnitName will return nil.