### PR TITLE
Add option to disable welcome message

### DIFF
--- a/totalRP3/Core/Configuration.lua
+++ b/totalRP3/Core/Configuration.lua
@@ -384,6 +384,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	registerConfigKey("new_version_alert", true);
 	registerConfigKey("ui_sounds", true);
 	registerConfigKey("ui_animations", true);
+	registerConfigKey("disable_welcome_message", false);
 	registerConfigKey("default_color_picker", false);
 	registerConfigKey("increase_color_contrast", false);
 	registerConfigKey("date_format", "");
@@ -418,6 +419,12 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 				title = loc.CO_GENERAL_UI_ANIMATIONS,
 				configKey = "ui_animations",
 				help = loc.CO_GENERAL_UI_ANIMATIONS_TT,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_GENERAL_DISABLE_WELCOME_MESSAGE,
+				configKey = "disable_welcome_message",
+				help = loc.CO_GENERAL_DISABLE_WELCOME_MESSAGE_HELP,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1494,6 +1494,9 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	REG_PLAYER_MISC_PRESET_GUILD_RANK = "Guild rank",
 	REG_PLAYER_MISC_PRESET_VOICE_REFERENCE = "Voice reference",
 	DEFAULT_GUILD_RANK = "Member",
+
+	CO_GENERAL_DISABLE_WELCOME_MESSAGE = "Disable welcome message",
+	CO_GENERAL_DISABLE_WELCOME_MESSAGE_HELP = "Disables the welcome message displayed in the chat frame on login."
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/totalRP3.lua
+++ b/totalRP3/totalRP3.lua
@@ -48,10 +48,6 @@ local function loadingSequence()
 	MAIN_SEQUENCE_DETAIL = "TRP3_API.module.initModules";
 	TRP3_API.module.initModules();
 
-	-- Welcome \o/
-	MAIN_SEQUENCE_DETAIL = "Welcome message";
-	TRP3_API.utils.message.displayMessage(loc.GEN_WELCOME_MESSAGE:format(Globals.version_display));
-
 	MAIN_SEQUENCE_DETAIL = "AddOn_TotalRP3.Communications.broadcast.init";
 	AddOn_TotalRP3.Communications.broadcast.init();
 	MAIN_SEQUENCE_DETAIL = "TRP3_API.profile.init";
@@ -85,6 +81,13 @@ local function loadingSequence()
 	TRP3_API.configuration.constructConfigPage();
 
 	TRP3_API.events.fireEvent(TRP3_API.events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetWidth(), TRP3_MainFramePageContainer:GetHeight());
+
+	-- Welcome \o/
+	MAIN_SEQUENCE_DETAIL = "Welcome message";
+
+	if not TRP3_API.configuration.getValue("disable_welcome_message") then
+		TRP3_API.utils.message.displayMessage(loc.GEN_WELCOME_MESSAGE:format(Globals.version_display));
+	end
 
 	TRP3_API.Log("OnEnable() DONE");
 end


### PR DESCRIPTION
Some users prefer not getting spammed by fifty addons announcing their existence on login, so to appease these people this adds a setting to at least disable part of the welcome message printed on login. Note that in the event of an error we print out the version number regardless.

Unfortunately the "The profile <name> is loaded" message isn't covered by this, but that can be solved later.