### PR TITLE
Add support for guild names to KNP decorator

### DIFF
--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1477,7 +1477,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	NAMEPLATES_CONFIG_CUSTOMIZE_FIRST_NAMES = "Show first names only",
 	NAMEPLATES_CONFIG_CUSTOMIZE_FIRST_NAMES_HELP = "If checked, only show the first names rather than full names.|n|nThis can only be applied to player units, and will not work with profiles received from other roleplay addons.",
 	NAMEPLATES_CONFIG_CUSTOMIZE_GUILD = "Show custom guild names",
-	NAMEPLATES_CONFIG_CUSTOMIZE_GUILD_HELP = "If checked, show custom guild names on nameplates that support them.|n|nThis will not work with profiles received from other roleplay addons.",
+	NAMEPLATES_CONFIG_CUSTOMIZE_GUILD_HELP = "If checked, show custom guild names on nameplates that support them.",
 	NAMEPLATES_CONFIG_DISABLE_IN_INSTANCES = "Disable customizations in instances",
 	NAMEPLATES_CONFIG_DISABLE_IN_INSTANCES_HELP = "If checked, disables nameplate customizations while in instances.|n|nIn instanced content friendly nameplates cannot be customized.",
 	NAMEPLATES_CONFIG_DISABLE_NON_PLAYABLE_UNITS = "Disable customizations on NPC units",

--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -87,6 +87,7 @@ function TRP3_KuiNamePlates:OnNamePlateCreate(nameplate)
 	-- too much with Kui's internal state.
 
 	hooksecurefunc(nameplate, "UpdateNameText", function(...) return self:OnNameplateNameTextUpdated(...); end);
+	hooksecurefunc(nameplate, "UpdateGuildText", function(...) return self:OnNameplateGuildTextUpdated(...); end);
 
 	do
 		-- Icon widget.
@@ -154,6 +155,22 @@ function TRP3_KuiNamePlates:OnNameplateNameTextUpdated(nameplate)
 
 	self:UpdateNamePlateFullTitle(nameplate);
 	self:UpdateNamePlateIcon(nameplate);
+end
+
+function TRP3_KuiNamePlates:OnNameplateGuildTextUpdated(nameplate)
+	if not self:CanCustomizeNamePlate(nameplate) then
+		return;
+	elseif not IsNamePlateInNameOnlyMode(nameplate) then
+		return;  -- Kui only supports guild strings in name-only mode.
+	end
+
+	local displayInfo = self:GetUnitDisplayInfo(nameplate.unit);
+	local displayText = displayInfo and displayInfo.guildName or nil;
+
+	if displayText then
+		nameplate.GuildText:SetText(displayText);
+		nameplate.GuildText:Show();
+	end
 end
 
 function TRP3_KuiNamePlates:UpdateNamePlateHealthBar(nameplate)
@@ -242,6 +259,15 @@ function TRP3_KuiNamePlates:UpdateNamePlateNameText(nameplate)
 	nameplate:UpdateNameText();
 end
 
+function TRP3_KuiNamePlates:UpdateNamePlateGuildText(nameplate)
+	if not self:CanCustomizeNamePlate(nameplate) then
+		return;
+	end
+
+	-- Guilds are managed through a posthook.
+	nameplate:UpdateGuildText();
+end
+
 function TRP3_KuiNamePlates:EvaluateNamePlateVisibility(nameplate)
 	if not self:CanCustomizeNamePlate(nameplate) then
 		return;
@@ -270,6 +296,7 @@ function TRP3_KuiNamePlates:UpdateNamePlate(nameplate)
 	-- the name text being updated.
 
 	self:UpdateNamePlateNameText(nameplate);
+	self:UpdateNamePlateGuildText(nameplate);
 	self:UpdateNamePlateHealthBar(nameplate);
 	self:UpdateNamePlateVisibility(nameplate);
 end

--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -12,6 +12,14 @@ local function FormatStashToken(key)
 	return "trp3_original_" .. key;
 end
 
+local function ClearStashedFields(state)
+	for key in pairs(state) do
+		if string.find(key, "^trp3_original_") then
+			state[key] = nil;
+		end
+	end
+end
+
 local function OverrideStateField(state, field, value)
 	local token = FormatStashToken(field);
 
@@ -79,14 +87,14 @@ function TRP3_KuiNamePlates:OnModuleEnable()
 
 	self.plugin = KuiNameplates:NewPlugin("TotalRP3", 250);
 	self.plugin.Create = function(_, ...) return self:OnNamePlateCreate(...); end;
-	self.plugin.Show = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
+	self.plugin.Show = function(_, nameplate) return self:OnNamePlateShow(nameplate); end;
 	self.plugin.HealthUpdate = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
 	self.plugin.HealthColourChange = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
 	self.plugin.GlowColourChange = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
 	self.plugin.GainedTarget = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
 	self.plugin.LostTarget = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
 	self.plugin.Combat = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
-	self.plugin.Hide = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
+	self.plugin.Hide = function(_, nameplate) return self:OnNamePlateHide(nameplate); end;
 
 	self.plugin:RegisterMessage("Create");
 	self.plugin:RegisterMessage("Show");
@@ -106,6 +114,16 @@ function TRP3_KuiNamePlates:OnModuleEnable()
 
 	self.fading = KuiNameplates:GetPlugin("Fading");
 	self.fading:AddFadeRule(GenerateClosure(self.EvaluateNamePlateVisibility, self), FADE_PRIORITY, FADE_RULE_ID);
+end
+
+function TRP3_KuiNamePlates:OnNamePlateShow(nameplate)
+	ClearStashedFields(nameplate.state);
+	self:UpdateNamePlate(nameplate);
+end
+
+function TRP3_KuiNamePlates:OnNamePlateHide(nameplate)
+	ClearStashedFields(nameplate.state);
+	self:UpdateNamePlate(nameplate);
 end
 
 function TRP3_KuiNamePlates:OnNamePlateDataUpdated(_, nameplate, unitToken, displayInfo)


### PR DESCRIPTION
This requires the "Show player guilds" option be selected in KNP's settings under the "Name-only" category, and will only impact name-only mode plates for whom we've got an RP profile with the "Guild name" misc field set.