### PR TITLE
Relocate 'toggle your stuff' message to header

### DIFF
--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1485,7 +1485,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	NAMEPLATES_CONFIG_MAX_NAME_CHARS_HELP = "The maximum number of characters to display for names and prefix titles. Names exceeding this length will be cropped.",
 	NAMEPLATES_CONFIG_MAX_TITLE_CHARS = "Maximum title length",
 	NAMEPLATES_CONFIG_MAX_TITLE_CHARS_HELP = "The maximum number of characters to display for full titles. Titles exceeding this length will be cropped.",
-	NAMEPLATES_CONFIG_PAGE_SETTINGS_MAY_REQUIRE_TOGGLE_HELP = "You may need to toggle your nameplates for any settings changes below to take effect.",
+	NAMEPLATES_CONFIG_PAGE_SETTINGS_MAY_REQUIRE_TOGGLE_HELP = "You may need to toggle your nameplates for any settings changes to take effect.",
 	NAMEPLATES_CONFIG_SHOW_TARGET_UNIT = "Always show target unit",
 	NAMEPLATES_CONFIG_SHOW_TARGET_UNIT_HELP = "If checked, your current target will always have its nameplate visible.",
 

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -1436,7 +1436,6 @@ If you wish to report %s's profile and you cannot target them you will need to o
 ]],
 
 	CO_MODULES_SUPPORTS_HOTRELOAD = "This module supports hot reload.",
-	NAMEPLATES_CONFIG_REQUIRES_TOGGLE = "This may require you to toggle your nameplates to take effect.",
 	NAMEPLATES_CONFIG_PAGE_HELP = "Please note that only |cff449fe0Blizzard|r, |cff9966ffKui|r, and |cffa8deffPlater|r nameplates are currently supported. Refer to the help tip on each setting below for additional information.",
 	PLATER_NAMEPLATES_MODULE_NAME = "Plater Nameplates",
 	PLATER_NAMEPLATES_MODULE_DESCRIPTION = "Enables the customization of Plater nameplates.",
@@ -1486,6 +1485,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	NAMEPLATES_CONFIG_MAX_NAME_CHARS_HELP = "The maximum number of characters to display for names and prefix titles. Names exceeding this length will be cropped.",
 	NAMEPLATES_CONFIG_MAX_TITLE_CHARS = "Maximum title length",
 	NAMEPLATES_CONFIG_MAX_TITLE_CHARS_HELP = "The maximum number of characters to display for full titles. Titles exceeding this length will be cropped.",
+	NAMEPLATES_CONFIG_PAGE_SETTINGS_MAY_REQUIRE_TOGGLE_HELP = "You may need to toggle your nameplates for any settings changes below to take effect.",
 	NAMEPLATES_CONFIG_SHOW_TARGET_UNIT = "Always show target unit",
 	NAMEPLATES_CONFIG_SHOW_TARGET_UNIT_HELP = "If checked, your current target will always have its nameplate visible.",
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Settings.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Settings.lua
@@ -92,7 +92,7 @@ function TRP3_NamePlatesUtil.RegisterSettings()
 		elements = {
 			{
 				inherit = "TRP3_ConfigParagraph",
-				title = L.NAMEPLATES_CONFIG_PAGE_HELP,
+				title = L.NAMEPLATES_CONFIG_PAGE_HELP .. "|n|n" .. L.NAMEPLATES_CONFIG_PAGE_SETTINGS_MAY_REQUIRE_TOGGLE_HELP,
 			},
 			{
 				inherit = "TRP3_ConfigH1",
@@ -101,31 +101,31 @@ function TRP3_NamePlatesUtil.RegisterSettings()
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_DISABLE_IN_COMBAT,
-				help = L.NAMEPLATES_CONFIG_DISABLE_IN_COMBAT_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_DISABLE_IN_COMBAT_HELP,
 				configKey = MapSettingToConfigKey("DisableInCombat"),
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_DISABLE_IN_INSTANCES,
-				help = L.NAMEPLATES_CONFIG_DISABLE_IN_INSTANCES_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_DISABLE_IN_INSTANCES_HELP,
 				configKey = MapSettingToConfigKey("DisableInInstances"),
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER,
-				help = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER_HELP,
 				configKey = MapSettingToConfigKey("DisableOutOfCharacter"),
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER_UNITS,
-				help = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER_UNITS_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_DISABLE_OUT_OF_CHARACTER_UNITS_HELP,
 				configKey = MapSettingToConfigKey("DisableOutOfCharacterUnits"),
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_DISABLE_NON_PLAYABLE_UNITS,
-				help = L.NAMEPLATES_CONFIG_DISABLE_NON_PLAYABLE_UNITS_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_DISABLE_NON_PLAYABLE_UNITS_HELP,
 				configKey = MapSettingToConfigKey("DisableNonPlayableUnits"),
 			},
 			{
@@ -137,7 +137,7 @@ function TRP3_NamePlatesUtil.RegisterSettings()
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_HIDE_OUT_OF_CHARACTER_UNITS,
-				help = L.NAMEPLATES_CONFIG_HIDE_OUT_OF_CHARACTER_UNITS_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_HIDE_OUT_OF_CHARACTER_UNITS_HELP,
 				configKey = MapSettingToConfigKey("HideOutOfCharacterUnits"),
 			},
 			{
@@ -183,7 +183,7 @@ function TRP3_NamePlatesUtil.RegisterSettings()
 			{
 				inherit = "TRP3_ConfigCheck",
 				title = L.NAMEPLATES_CONFIG_CUSTOMIZE_HEALTH_COLORS,
-				help = L.NAMEPLATES_CONFIG_CUSTOMIZE_HEALTH_COLORS_HELP .. "\n\n" .. L.NAMEPLATES_CONFIG_REQUIRES_TOGGLE,
+				help = L.NAMEPLATES_CONFIG_CUSTOMIZE_HEALTH_COLORS_HELP,
 				configKey = MapSettingToConfigKey("CustomizeHealthColors"),
 			},
 			{


### PR DESCRIPTION
Rather than hide it away in the tooltip for multiple settings we'll just blanket state up-front that you might need to toggle things.