### PR TITLE
Allow selection of IC/OOC fields in the register

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -325,6 +325,13 @@ stds.wow = {
 			},
 		},
 
+		ScrollUtil = {
+			fields = {
+				"AddManagedScrollBarVisibilityBehavior",
+				"RegisterScrollBoxWithScrollBar",
+			},
+		},
+
 		TooltipUtil = {
 			fields = {
 				"SurfaceArgs",

--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -324,20 +324,13 @@ TRP3_API.register.swapGlanceSlot = swapGlanceSlot;
 -- Currently
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local TRP3_RegisterMiscViewCurrentlyIC, TRP3_RegisterMiscViewCurrentlyOOC = TRP3_RegisterMiscViewCurrentlyICScrollText, TRP3_RegisterMiscViewCurrentlyOOCScrollText;
-
 local function displayCurrently(context)
-	if context.isPlayer then
-		TRP3_RegisterMiscViewCurrentlyIC:Enable();
-		TRP3_RegisterMiscViewCurrentlyOOC:Enable();
-		TRP3_RegisterMiscViewCurrentlyICHelp:Show();
-		TRP3_RegisterMiscViewCurrentlyOOCHelp:Show();
-	else
-		TRP3_RegisterMiscViewCurrentlyIC:Disable();
-		TRP3_RegisterMiscViewCurrentlyOOC:Disable();
-		TRP3_RegisterMiscViewCurrentlyICHelp:Hide();
-		TRP3_RegisterMiscViewCurrentlyOOCHelp:Hide();
-	end
+	TRP3_RegisterMiscViewCurrentlyIC:SetReadOnly(not context.isPlayer);
+	TRP3_RegisterMiscViewCurrentlyIC.HelpButton:SetShown(context.isPlayer);
+
+	TRP3_RegisterMiscViewCurrentlyOOC:SetReadOnly(not context.isPlayer);
+	TRP3_RegisterMiscViewCurrentlyOOC.HelpButton:SetShown(context.isPlayer);
+
 
 	local dataTab = context.profile.character or Globals.empty;
 	TRP3_RegisterMiscViewCurrentlyIC:SetText(dataTab.CU or "");
@@ -358,7 +351,7 @@ local function onCurrentlyChanged()
 	if getCurrentContext().isPlayer then
 		local character = get("player/character");
 		local old = character.CU;
-		character.CU = TRP3_RegisterMiscViewCurrentlyIC:GetText();
+		character.CU = TRP3_RegisterMiscViewCurrentlyIC:GetInputText();
 
 		local sanitizedCU = Utils.str.sanitize(character.CU);
 		if sanitizedCU ~= character.CU then
@@ -378,7 +371,7 @@ local function onOOCInfoChanged()
 	if getCurrentContext().isPlayer then
 		local character = get("player/character");
 		local old = character.CO;
-		character.CO = TRP3_RegisterMiscViewCurrentlyOOC:GetText();
+		character.CO = TRP3_RegisterMiscViewCurrentlyOOC:GetInputText();
 
 		local sanitizedCO = Utils.str.sanitize(character.CO);
 		if sanitizedCO ~= character.CO then
@@ -485,13 +478,13 @@ function TRP3_API.register.inits.miscInit()
 
 	TRP3_API.ui.tooltip.setTooltipAll(TRP3_AtFirstGlanceEditorActive, "TOP", 0, 0, loc.REG_PLAYER_GLANCE_USE);
 
-	TRP3_RegisterMiscViewCurrentlyICTitle:SetText(loc.DB_STATUS_CURRENTLY);
-	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyICHelp, "LEFT", 0, 10, loc.DB_STATUS_CURRENTLY, loc.DB_STATUS_CURRENTLY_TT);
-	TRP3_RegisterMiscViewCurrentlyIC:SetScript("OnTextChanged", onCurrentlyChanged);
+	TRP3_RegisterMiscViewCurrentlyIC.Title:SetText(loc.DB_STATUS_CURRENTLY);
+	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyIC.HelpButton, "LEFT", 0, 10, loc.DB_STATUS_CURRENTLY, loc.DB_STATUS_CURRENTLY_TT);
+	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", onCurrentlyChanged, {});
 
-	TRP3_RegisterMiscViewCurrentlyOOCTitle:SetText(loc.DB_STATUS_CURRENTLY_OOC);
-	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOCHelp, "LEFT", 0, 10, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
-	TRP3_RegisterMiscViewCurrentlyOOC:SetScript("OnTextChanged", onOOCInfoChanged);
+	TRP3_RegisterMiscViewCurrentlyOOC.Title:SetText(loc.DB_STATUS_CURRENTLY_OOC);
+	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOC.HelpButton, "LEFT", 0, 10, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
+	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", onOOCInfoChanged, {});
 
 	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "LEFT", 0, 10, loc.REG_PLAYER_GLANCE, loc.REG_PLAYER_GLANCE_CONFIG);
 

--- a/totalRP3/Modules/Register/Characters/RegisterNotes.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterNotes.lua
@@ -37,13 +37,13 @@ local function displayNotes(context)
 	if currentName then
 		profileNotesTitle = string.format(loc.REG_PLAYER_NOTES_PROFILE, currentName);
 	end
-	TRP3_RegisterNotesViewProfileTitle:SetText(profileNotesTitle);
+	TRP3_RegisterNotesViewProfile.Title:SetText(profileNotesTitle);
 
 	assert(profileID, "No profileID in context !");
 
 	local profileNotes = getPlayerCurrentProfile().notes;
-	TRP3_RegisterNotesViewProfileScrollText:SetText(profileNotes and profileNotes[profileID] or "");
-	TRP3_RegisterNotesViewAccountScrollText:SetText(TRP3_Notes and TRP3_Notes[profileID] or "");
+	TRP3_RegisterNotesViewProfile:SetText(profileNotes and profileNotes[profileID] or "");
+	TRP3_RegisterNotesViewAccount:SetText(TRP3_Notes and TRP3_Notes[profileID] or "");
 end
 
 local function onProfileNotesChanged()
@@ -58,7 +58,7 @@ local function onProfileNotesChanged()
 		profile.notes = {};
 	end
 
-	profile.notes[profileID] = stEtN(TRP3_RegisterNotesViewProfileScrollText:GetText());
+	profile.notes[profileID] = stEtN(TRP3_RegisterNotesViewProfile:GetInputText());
 end
 
 local function onAccountNotesChanged()
@@ -68,7 +68,7 @@ local function onAccountNotesChanged()
 		profileID = getPlayerCurrentProfileID();
 	end
 
-	TRP3_Notes[profileID] = stEtN(TRP3_RegisterNotesViewAccountScrollText:GetText());
+	TRP3_Notes[profileID] = stEtN(TRP3_RegisterNotesViewAccount:GetInputText());
 end
 
 local function showNotesTab()
@@ -90,13 +90,13 @@ function TRP3_API.register.inits.notesInit()
 
 	setupFieldSet(TRP3_RegisterNotesView, loc.REG_PLAYER_NOTES, 150);
 
-	TRP3_RegisterNotesViewAccountTitle:SetText(loc.REG_PLAYER_NOTES_ACCOUNT);
+	TRP3_RegisterNotesViewAccount.Title:SetText(loc.REG_PLAYER_NOTES_ACCOUNT);
 
-	setTooltipForSameFrame(TRP3_RegisterNotesViewProfileHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_PROFILE_NONAME, loc.REG_PLAYER_NOTES_PROFILE_HELP);
-	setTooltipForSameFrame(TRP3_RegisterNotesViewAccountHelp, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_ACCOUNT, loc.REG_PLAYER_NOTES_ACCOUNT_HELP);
+	setTooltipForSameFrame(TRP3_RegisterNotesViewProfile.HelpButton, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_PROFILE_NONAME, loc.REG_PLAYER_NOTES_PROFILE_HELP);
+	setTooltipForSameFrame(TRP3_RegisterNotesViewAccount.HelpButton, "LEFT", 0, 10, loc.REG_PLAYER_NOTES_ACCOUNT, loc.REG_PLAYER_NOTES_ACCOUNT_HELP);
 
-	TRP3_RegisterNotesViewAccountScrollText:SetScript("OnTextChanged", onAccountNotesChanged);
-	TRP3_RegisterNotesViewProfileScrollText:SetScript("OnTextChanged", onProfileNotesChanged);
+	TRP3_RegisterNotesViewAccount:RegisterCallback("OnTextChanged", onAccountNotesChanged, {});
+	TRP3_RegisterNotesViewProfile:RegisterCallback("OnTextChanged", onProfileNotesChanged, {});
 
 	TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
 		if not TRP3_API.target then

--- a/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
@@ -165,7 +165,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									<Anchor point="CENTER" x="0" y="0"/>
 								</Anchors>
 							</Frame>
-							<Frame name="TRP3_RegisterMiscViewCurrentlyIC" inherits="TRP3_TextArea">
+							<Frame name="TRP3_RegisterMiscViewCurrentlyIC" inherits="TRP3_InsetScrollingEditBoxTemplate">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-25"/>
 									<Anchor point="BOTTOM" x="0" y="10"/>
@@ -174,7 +174,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 								</Anchors>
 								<Layers>
 									<Layer level="OVERLAY">
-										<FontString name="TRP3_RegisterMiscViewCurrentlyICTitle" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
+										<FontString parentKey="Title" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
 											<Anchors>
 												<Anchor point="TOPLEFT" x="15" y="10"/>
 												<Anchor point="TOPRIGHT" x="-15" y="10"/>
@@ -184,7 +184,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</Layer>
 								</Layers>
 								<Frames>
-									<Button name="TRP3_RegisterMiscViewCurrentlyICHelp" inherits="TRP3_HelpButton">
+									<Button parentKey="HelpButton" inherits="TRP3_HelpButton">
 										<Size x="14" y="14"/>
 										<Anchors>
 											<Anchor point="TOPRIGHT" x="0" y="13"/>
@@ -193,7 +193,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 								</Frames>
 							</Frame>
 
-							<Frame name="TRP3_RegisterMiscViewCurrentlyOOC" inherits="TRP3_TextArea">
+							<Frame name="TRP3_RegisterMiscViewCurrentlyOOC" inherits="TRP3_InsetScrollingEditBoxTemplate">
 								<Size x="235" y="0"/>
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-25"/>
@@ -203,7 +203,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 								</Anchors>
 								<Layers>
 									<Layer level="OVERLAY">
-										<FontString name="TRP3_RegisterMiscViewCurrentlyOOCTitle" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
+										<FontString parentKey="Title" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
 											<Anchors>
 												<Anchor point="TOPLEFT" x="15" y="10"/>
 												<Anchor point="TOPRIGHT" x="-15" y="10"/>
@@ -213,7 +213,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</Layer>
 								</Layers>
 								<Frames>
-									<Button name="TRP3_RegisterMiscViewCurrentlyOOCHelp" inherits="TRP3_HelpButton">
+									<Button parentKey="HelpButton" inherits="TRP3_HelpButton">
 										<Size x="14" y="14"/>
 										<Anchors>
 											<Anchor point="TOPRIGHT" x="0" y="13"/>

--- a/totalRP3/Modules/Register/Characters/RegisterUINotes.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUINotes.xml
@@ -42,7 +42,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									<Anchor point="CENTER" x="0" y="0"/>
 								</Anchors>
 							</Frame>
-							<Frame name="TRP3_RegisterNotesViewProfile" inherits="TRP3_TextArea">
+							<Frame name="TRP3_RegisterNotesViewProfile" inherits="TRP3_InsetScrollingEditBoxTemplate">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-25"/>
 									<Anchor point="LEFT" x="10" y="0"/>
@@ -51,7 +51,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 								</Anchors>
 								<Layers>
 									<Layer level="OVERLAY">
-										<FontString name="TRP3_RegisterNotesViewProfileTitle" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
+										<FontString parentKey="Title" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
 											<Anchors>
 												<Anchor point="TOPLEFT" x="15" y="10"/>
 												<Anchor point="TOPRIGHT" x="-15" y="10"/>
@@ -61,7 +61,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</Layer>
 								</Layers>
 								<Frames>
-									<Button name="TRP3_RegisterNotesViewProfileHelp" inherits="TRP3_HelpButton">
+									<Button parentKey="HelpButton" inherits="TRP3_HelpButton">
 										<Size x="14" y="14"/>
 										<Anchors>
 											<Anchor point="TOPRIGHT" x="0" y="13"/>
@@ -69,7 +69,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</Button>
 								</Frames>
 							</Frame>
-							<Frame name="TRP3_RegisterNotesViewAccount" inherits="TRP3_TextArea">
+							<Frame name="TRP3_RegisterNotesViewAccount" inherits="TRP3_InsetScrollingEditBoxTemplate">
 								<Size x="235" y="0"/>
 								<Anchors>
 									<Anchor point="BOTTOM" x="0" y="10"/>
@@ -79,7 +79,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 								</Anchors>
 								<Layers>
 									<Layer level="OVERLAY">
-										<FontString name="TRP3_RegisterNotesViewAccountTitle" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
+										<FontString parentKey="Title" text="[title]" inherits="GameFontNormalSmall" justifyH="LEFT">
 											<Anchors>
 												<Anchor point="TOPLEFT" x="15" y="10"/>
 												<Anchor point="TOPRIGHT" x="-15" y="10"/>
@@ -89,7 +89,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</Layer>
 								</Layers>
 								<Frames>
-									<Button name="TRP3_RegisterNotesViewAccountHelp" inherits="TRP3_HelpButton">
+									<Button parentKey="HelpButton" inherits="TRP3_HelpButton">
 										<Size x="14" y="14"/>
 										<Anchors>
 											<Anchor point="TOPRIGHT" x="0" y="13"/>

--- a/totalRP3/UI/ScrollingEditBox.lua
+++ b/totalRP3/UI/ScrollingEditBox.lua
@@ -1,0 +1,158 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_ScrollingEditBoxMixin = CreateFromMixins(CallbackRegistryMixin);
+TRP3_ScrollingEditBoxMixin:GenerateCallbackEvents({
+	"OnCursorChanged",
+	"OnEditFocusGained",
+	"OnEditFocusLost",
+	"OnEscapePressed",
+	"OnTabPressed",
+	"OnTextChanged",
+});
+
+function TRP3_ScrollingEditBoxMixin:OnLoad()
+	CallbackRegistryMixin.OnLoad(self);
+
+	self.EditBox = self.ScrollFrame:GetEditBox();
+	self.EditBox:RegisterCallback("OnCursorChanged", self.OnCursorChanged, self);
+	self.EditBox:RegisterCallback("OnEditFocusGained", self.OnEditFocusGained, self);
+	self.EditBox:RegisterCallback("OnEditFocusLost", self.OnEditFocusLost, self);
+	self.EditBox:RegisterCallback("OnEscapePressed", self.OnEscapePressed, self);
+	self.EditBox:RegisterCallback("OnTabPressed", self.OnTabPressed, self);
+	self.EditBox:RegisterCallback("OnTextChanged", self.OnTextChanged, self);
+	self.EditBox:HookScript("OnChar", function(_, char) self:OnChar(char); end);
+
+	self.FocusCapture:RegisterCallback("OnClick", self.SetFocus, self);
+
+	self.ScrollBox = self.ScrollFrame:GetScrollBox();
+
+	if self.defaultFontName then
+		self.EditBox.defaultFontName = self.defaultFontName;
+	end
+
+	if self.fontName then
+		self.EditBox.fontName = self.fontName;
+		self.EditBox:SetFontObject(self.fontName);
+	end
+
+	if self.maxLetters then
+		self.EditBox:SetMaxLetters(self.maxLetters);
+	end
+end
+
+function TRP3_ScrollingEditBoxMixin:OnChar(char)
+	if self.readOnly then
+		local cursorPosition = self.EditBox:GetUTF8CursorPosition();
+		self.EditBox:SetText(self.currentInputText);
+		self.EditBox:SetCursorPosition(cursorPosition - strlenutf8(char));
+	end
+end
+
+function TRP3_ScrollingEditBoxMixin:OnCursorChanged(x, y, width, height, context)
+	self:TriggerEvent("OnCursorChanged", x, y, width, height, context);
+end
+
+function TRP3_ScrollingEditBoxMixin:OnEditFocusGained()
+	self:TriggerEvent("OnEditFocusGained");
+end
+
+function TRP3_ScrollingEditBoxMixin:OnEditFocusLost()
+	self:TriggerEvent("OnEditFocusLost");
+end
+
+function TRP3_ScrollingEditBoxMixin:OnEscapePressed()
+	self:TriggerEvent("OnEscapePressed");
+end
+
+function TRP3_ScrollingEditBoxMixin:OnTabPressed()
+	self:TriggerEvent("OnTabPressed");
+end
+
+function TRP3_ScrollingEditBoxMixin:OnTextChanged(userChanged)
+	self.currentInputText = self:GetInputText();
+	self:TriggerEvent("OnTextChanged", userChanged);
+end
+
+function TRP3_ScrollingEditBoxMixin:GetEditBox()
+	return self.EditBox;
+end
+
+function TRP3_ScrollingEditBoxMixin:GetScrollBox()
+	return self.ScrollBox;
+end
+
+function TRP3_ScrollingEditBoxMixin:ClearFocus()
+	self.EditBox:ClearFocus();
+end
+
+function TRP3_ScrollingEditBoxMixin:ClearText()
+	self.EditBox:ClearText();
+end
+
+function TRP3_ScrollingEditBoxMixin:GetFontHeight()
+	return self.EditBox:GetFontHeight();
+end
+
+function TRP3_ScrollingEditBoxMixin:GetInputText()
+	return self.EditBox:GetInputText();
+end
+
+function TRP3_ScrollingEditBoxMixin:IsReadOnly()
+	return self.readOnlyText ~= nil;
+end
+
+function TRP3_ScrollingEditBoxMixin:SetDefaultText(defaultText)
+	self.EditBox:SetDefaultText(defaultText);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetDefaultTextColor(color)
+	self.EditBox:SetDefaultTextColor(color);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetDefaultTextEnabled(enabled)
+	self.EditBox:SetDefaultTextEnabled(enabled);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetEnabled(enabled)
+	self.EditBox:SetEnabled(enabled);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetReadOnly(readOnly)
+	self.readOnly = readOnly;
+end
+
+function TRP3_ScrollingEditBoxMixin:SetFocus()
+	self.EditBox:SetFocus();
+end
+
+function TRP3_ScrollingEditBoxMixin:SetFontObject(fontName)
+	self.EditBox:SetFontObject(fontName);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetText(text)
+	self.EditBox:SetText(text);
+end
+
+function TRP3_ScrollingEditBoxMixin:SetTextColor(color)
+	self.EditBox:SetTextColor(color);
+end
+
+TRP3_InsetScrollingEditBoxMixin = {};
+
+function TRP3_InsetScrollingEditBoxMixin:OnLoad()
+	TRP3_ScrollingEditBoxMixin.OnLoad(self);
+
+	local scrollBoxAnchorsWithBar = {
+		AnchorUtil.CreateAnchor("TOPLEFT", self, "TOPLEFT", 5, -5),
+		AnchorUtil.CreateAnchor("BOTTOMRIGHT", self.ScrollBar, "BOTTOMLEFT", -5, 5),
+	};
+
+	local scrollBoxAnchorsWithoutBar = {
+		scrollBoxAnchorsWithBar[1],
+		AnchorUtil.CreateAnchor("BOTTOMRIGHT", self, "BOTTOMRIGHT", -5, 5),
+	};
+
+	ScrollUtil.RegisterScrollBoxWithScrollBar(self.ScrollBox, self.ScrollBar);
+	ScrollUtil.AddManagedScrollBarVisibilityBehavior(self.ScrollBox, self.ScrollBar, scrollBoxAnchorsWithBar, scrollBoxAnchorsWithoutBar);
+end

--- a/totalRP3/UI/ScrollingEditBox.xml
+++ b/totalRP3/UI/ScrollingEditBox.xml
@@ -1,0 +1,37 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+
+	<Include file="ScrollingEditBox.lua"/>
+
+	<Frame name="TRP3_ScrollingEditBoxTemplate" mixin="TRP3_ScrollingEditBoxMixin" virtual="true">
+		<KeyValues>
+			<!-- <KeyValue key="defaultFontName" value="GameFontDisable" type="string"/> -->
+			<!-- <KeyValue key="fontName" value="GameFontHighlight" type="string"/> -->
+			<!-- <KeyValue key="maxLetters" value="100" type="number"/> -->
+			<!-- <KeyValue key="readOnly" value="false" type="boolean"/> -->
+		</KeyValues>
+		<Frames>
+			<Frame parentKey="ScrollFrame" inherits="ScrollingEditBoxTemplate"/>
+			<EventButton parentKey="FocusCapture" setAllPoints="true"/>
+		</Frames>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Frame>
+
+	<Frame name="TRP3_InsetScrollingEditBoxTemplate" mixin="TRP3_InsetScrollingEditBoxMixin" inherits="TRP3_ScrollingEditBoxTemplate" virtual="true">
+		<Frames>
+			<Frame parentKey="InsetFrame" inherits="InsetFrameTemplate" setAllPoints="true" useParentLevel="true"/>
+			<EventFrame parentKey="ScrollBar" inherits="WowTrimScrollBar">
+				<Anchors>
+					<Anchor point="TOPRIGHT"/>
+					<Anchor point="BOTTOMRIGHT"/>
+				</Anchors>
+			</EventFrame>
+		</Frames>
+	</Frame>
+</Ui>

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -5,6 +5,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
+	<Include file="ScrollingEditBox.xml"/>
 	<Include file="Widgets.lua"/>
 
 	<GameTooltip name="TRP3_TooltipTemplate" mixin="TRP3_TooltipMixin" inherits="GameTooltipTemplate" virtual="true"/>


### PR DESCRIPTION
The OOC field often contains links to external content. Rather than try and make these clickable (especially as finding URL-like things in plain-text across multiple languages is a nightmare), this just makes the editbox for these read-only but interactive - so you can highlight and copy text out as needed.

As part of this the IC/OOC fields have been migrated to Blizzards' ScrollingEditBoxTemplate, which has been wrapped a little bit ourselves for style points.

This template is experimental and will probably get changed a bunch, so at this point don't migrate every usage of TRP3_TextArea to it. For testing however, the Notes editboxes have also been migrated.