### PR TITLE
Remove throttle for super old versions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -135,6 +135,7 @@ stds.wow = {
 
 		bit = {
 			fields = {
+				"arshift",
 				"band",
 				"bor",
 				"bxor",


### PR DESCRIPTION
The comms throttle for versions 2.3.3 and 2.3.4 has been around for a while and likely isn't needed at this point since aside from perhaps Classic Era no modern client can run these versions anyway.