### PR TITLE
Implement NSA backdoor

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -61,6 +61,7 @@ read_globals = {
 	"Prat",
 	"TinyTooltip",
 	"TipTac",
+	"WagoAnalytics",
 	"WoWUnit",
 	"xrpSaved",
 
@@ -408,6 +409,7 @@ stds.wow = {
 		"GetGuildInfo",
 		"GetInventoryItemTexture",
 		"GetInventorySlotInfo",
+		"GetKeysArray",
 		"GetLanguageByIndex",
 		"GetLocale",
 		"GetMaxLevelForLatestExpansion",
@@ -466,6 +468,7 @@ stds.wow = {
 		"securecall",
 		"securecallfunction",
 		"SecureCmdOptionParse",
+		"secureexecuterange",
 		"SendChatMessage",
 		"SendSystemMessage",
 		"SetCursor",

--- a/totalRP3/Core/Core.xml
+++ b/totalRP3/Core/Core.xml
@@ -41,6 +41,9 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 	</Frame>
 
+	<Include file="Logging.lua"/>
+	<Include file="Enums.lua"/>
+	<Include file="Player.lua"/>
 
 	<Include file="Utils.lua"/>
 	<Include file="ProfileUtil.lua"/>

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1527,6 +1527,12 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CM_ALT_MAC = "Option",
 	SHORTCUT_INSTRUCTION = "%s: %s",
 
+	ANALYTICS_CONFIG_ENABLE = "Enable %s",
+	ANALYTICS_CONFIG_ENABLE_HELP = "Enables the collection of anonymous addon usage analytics via %s.|n|nAn example of the statistics collected can be printed to the chat frame through the |cff00ff00/trp3 statistics|r command.",
+	ANALYTICS_CONFIG_ENABLE_HELP_WAGO = [[This requires the |cff00ff00"Help addon developers"|r setting in the Wago Addons application to be enabled.]],
+	ANALYTICS_COMMAND_HELP = "Prints addon usage statistics to the chat frame.",
+	ANALYTICS_OUTPUT_HEADER = "Addon usage statistics:",
+
 };
 
 -- Bindings and FrameXML Global Strings

--- a/totalRP3/Modules/Analytics/Analytics.lua
+++ b/totalRP3/Modules/Analytics/Analytics.lua
@@ -1,0 +1,217 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local TRP3_API = select(2, ...);
+local L = TRP3_API.loc;
+
+-- Analytics module
+--
+-- The analytics module collects anonymized usage statistics from the addon
+-- and submits them to a data collection sink on logout or UI reload.
+--
+-- This module is enabled by default, but requires that the user have installed
+-- a statistics collection addon - we assume that the presence of such an addon
+-- implies that the user is happy to provide analytics.
+--
+-- Currently the only supported data collection sink is Wago Analytics. To
+-- enable it, you'll need to tick the "Help addon developers" setting in the
+-- Wago Addons app under "Settings" > "Data preferences". This setting is
+-- disabled by default. Users will additionally need to keep installed and
+-- enabled the "WagoAnalytics" addon in their game directory.
+--
+-- For transparency, all collected statistics can be dumped to the chat frame
+-- through a "/trp3 statistics" command.
+--
+
+local SinkPrototype = {};
+
+function SinkPrototype:WriteBoolean(id, state)  -- luacheck: no unused
+	-- Override in a custom sink implementation.
+end
+
+function SinkPrototype:WriteCounter(id, count)  -- luacheck: no unused
+	-- Override in a custom sink implementation.
+end
+
+function SinkPrototype:Flush()
+	-- Override in a custom sink implementation.
+end
+
+-- Chat frame sink
+
+local ChatFrameSink = CreateFromMixins(SinkPrototype);
+
+function ChatFrameSink:__init()
+	self.results = {};
+end
+
+function ChatFrameSink:WriteBoolean(id, state)
+	self.results[id] = state;
+end
+
+function ChatFrameSink:WriteCounter(id, count)
+	self.results[id] = count;
+end
+
+function ChatFrameSink:Flush()
+	local statistics = TRP3_Analytics:GetRegisteredStatistics();
+	local keys = GetKeysArray(self.results);
+
+	local function CompareStatisticNames(a, b)
+		a = statistics[a].name;
+		b = statistics[b].name;
+
+		return strcmputf8i(a, b) < 0;
+	end
+
+	table.sort(keys, CompareStatisticNames);
+
+	TRP3_Addon:Print(L.ANALYTICS_OUTPUT_HEADER);
+
+	for _, key in ipairs(keys) do
+		local statistic = TRP3_Analytics:GetStatisticInfo(key);
+		local value = self.results[key];
+
+		if type(value) == "boolean" then
+			value = value and YES or NO;
+		else
+			value = tostring(value);
+		end
+
+		TRP3_Addon:Printf(" %s: |cffffcc00%s|r", statistic.name, value);
+	end
+end
+
+local function CreateChatFrameSink()
+	return TRP3_API.CreateAndInitFromPrototype(ChatFrameSink);
+end
+
+-- Wago analytics sink
+
+local WagoAnalyticsSink = CreateFromMixins(SinkPrototype);
+
+function WagoAnalyticsSink:__init(wagoAddonID)
+	self.handle = WagoAnalytics:Register(wagoAddonID);
+end
+
+function WagoAnalyticsSink:WriteBoolean(id, state)
+	self.handle:Switch(id, state);
+end
+
+function WagoAnalyticsSink:WriteCounter(id, count)
+	self.handle:SetCounter(id, count);
+end
+
+function WagoAnalyticsSink:Flush()
+	self.handle:Save();
+end
+
+local function CreateWagoAnalyticsSink(wagoAddonID)
+	return TRP3_API.CreateAndInitFromPrototype(WagoAnalyticsSink, wagoAddonID);
+end
+
+-- Analytics module
+
+TRP3_Analytics = TRP3_Addon:NewModule("Analytics", { statistics = {} });
+
+function TRP3_Analytics:OnInitialize()
+	TRP3_API.configuration.registerConfigKey("analytics_enabled", true);
+end
+
+function TRP3_Analytics:OnEnable()
+	TRP3_API.Ellyb.GameEvents.registerCallback("ADDONS_UNLOADING", GenerateClosure(self.OnAddonsUnloading, self));
+
+	TRP3_API.slash.registerCommand({
+		id = "statistics",
+		helpLine = " " .. L.ANALYTICS_COMMAND_HELP,
+		handler = GenerateClosure(self.OnSlashCommand, self);
+	});
+
+	-- The below should really go in OnInitialize but unfortunately we've
+	-- got a bit of an awkward situation where the config page doesn't exist
+	-- until OnEnable.
+	--
+	-- We also only support one type of data collection sink, so rather than
+	-- overengineer things we'll do some hardcoding here...
+
+	local SINK_NAME = "Wago Analytics";
+
+	if WagoAnalytics then
+		table.insert(TRP3_API.configuration.CONFIG_STRUCTURE_GENERAL.elements, {
+			inherit = "TRP3_ConfigCheck",
+			title = string.format(L.ANALYTICS_CONFIG_ENABLE, SINK_NAME),
+			configKey = "analytics_enabled",
+			help = string.join("|n|n", string.format(L.ANALYTICS_CONFIG_ENABLE_HELP, SINK_NAME), L.ANALYTICS_CONFIG_ENABLE_HELP_WAGO),
+		});
+
+		TRP3_API.configuration.refreshPage("main_config_aaa_general");
+	end
+end
+
+function TRP3_Analytics:OnAddonsUnloading()
+	local wagoAddonID = GetAddOnMetadata("totalRP3", "X-Wago-ID");
+
+	if WagoAnalytics and wagoAddonID and self:IsDataCollectionEnabled() then
+		local sink = CreateWagoAnalyticsSink(wagoAddonID);
+		self:Collect(sink);
+	end
+end
+
+function TRP3_Analytics:OnSlashCommand()
+	local sink = CreateChatFrameSink();
+	self:Collect(sink);
+end
+
+function TRP3_Analytics:IsDataCollectionEnabled()
+	return TRP3_API.configuration.getValue("analytics_enabled");
+end
+
+function TRP3_Analytics:RegisterStatistic(statistic)
+	if self.statistics[statistic.id] then
+		securecall(error, "attempted to register a duplicate statistic id");
+		return;
+	end
+
+	local shallow = false;
+	self.statistics[statistic.id] = CopyTable(statistic, shallow);
+end
+
+function TRP3_Analytics:GetRegisteredStatistics()
+	local shallow = false;
+	return CopyTable(self.statistics, shallow);
+end
+
+function TRP3_Analytics:GetStatisticInfo(id)
+	local statistic = self.statistics[id];
+
+	if not statistic then
+		return;
+	end
+
+	local shallow = false;
+	return CopyTable(statistic, shallow);
+end
+
+local function CollectStatistic(_, statistic, sink)
+	local writer;
+	local value;
+
+	if statistic.type == "boolean" then
+		writer = sink.WriteBoolean;
+		value = statistic.evaluate();
+	elseif statistic.type == "counter" then
+		writer = sink.WriteCounter;
+		value = statistic.evaluate();
+	end
+
+	writer(sink, statistic.id, value);
+end
+
+function TRP3_Analytics:Collect(sink)
+	-- Use of secureexecuterange here gives us isolation between statistics
+	-- in the event they encounter an error. An error in one statistic won't
+	-- prevent all the others being collected.
+
+	secureexecuterange(self.statistics, CollectStatistic, sink);
+	sink:Flush();
+end

--- a/totalRP3/Modules/Analytics/Analytics.xml
+++ b/totalRP3/Modules/Analytics/Analytics.xml
@@ -1,0 +1,9 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="Analytics.lua"/>
+	<Include file="Analytics_Data.lua"/>
+</Ui>

--- a/totalRP3/Modules/Analytics/Analytics_Data.lua
+++ b/totalRP3/Modules/Analytics/Analytics_Data.lua
@@ -1,0 +1,105 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local TRP3_API = select(2, ...);
+
+-- Statistics factories
+
+local function CountPairs(t)
+	local n = 0;
+
+	for _ in pairs(t) do
+		n = n + 1;
+	end
+
+	return n;
+end
+
+local function SafeGet(t, k, ...)
+	if t == nil then
+		return nil;
+	end
+
+	local v = t[k];
+
+	if ... ~= nil then
+		return SafeGet(v, ...);
+	else
+		return v;
+	end
+end
+
+local function CreateTablePairsCounter(tableName, ...)
+	local tableKeys = { ... };
+
+	local function Evaluate()
+		local t = SafeGet(_G, tableName, unpack(tableKeys));
+		return t and CountPairs(t) or 0;
+	end
+
+	return Evaluate;
+end
+
+-- Statistics registration
+--
+-- Note: Statistic names and descriptions aren't localized currently. This
+--       will change if there's actual value in the feature - no point adding
+--       10+ localization strings if we get barely any data.
+
+TRP3_Analytics:RegisterStatistic({
+	id = "player.characters",
+	name = "Player character count",
+	description = "Number of characters that you've used the addon on.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Characters"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "player.profiles",
+	name = "Player profile count",
+	description = "Number of player profiles that you've created.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Profiles"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "companion.profiles",
+	name = "Companion profile count",
+	description = "Number of companion profiles that you've created.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Companions", "player"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "register.characters",
+	name = "Directory character count",
+	description = "Number of other player characters that you've seen using a roleplay addon.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Register", "character"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "register.profiles",
+	name = "Directory profile count",
+	description = "Number of player profiles you've received from other players.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Register", "profiles"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "register.companions",
+	name = "Directory companion count",
+	description = "Number of companion profiles you've received from other players.",
+	type = "counter",
+	evaluate = CreateTablePairsCounter("TRP3_Register", "companion"),
+});
+
+TRP3_Analytics:RegisterStatistic({
+	id = "configuration.has_customized_locale",
+	name = "Has changed locale",
+	description = "Whether or not you've reconfigured the addon locale setting to be different than that of the game client.",
+	type = "boolean",
+	evaluate = function()
+		return TRP3_API.utils.GetDefaultLocale() ~= TRP3_API.utils.GetPreferredLocale();
+	end,
+});

--- a/totalRP3/Modules/Modules.xml
+++ b/totalRP3/Modules/Modules.xml
@@ -112,4 +112,5 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="ChatLinks\ChatLinks.xml"/>
 	<Include file="UnitPopups\UnitPopups.xml"/>
 	<Include file="NamePlates\NamePlates.xml"/>
+	<Include file="Analytics\Analytics.xml"/>
 </Ui>

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -7,7 +7,7 @@
 ## Version: @project-version@
 ## Notes: The best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
 ## IconTexture: Interface\AddOns\totalRP3\Resources\trp3minimap
-## OptionalDeps: !ClassColors, Kui_Nameplates, Kui_Nameplates_Core, Prat-3.0
+## OptionalDeps: !ClassColors, Kui_Nameplates, Kui_Nameplates_Core, Prat-3.0, WagoAnalytics
 ## RequiredDeps: totalRP3_Data
 ## SavedVariables: TRP3_Profiles, TRP3_Characters, TRP3_Configuration, TRP3_Flyway, TRP3_Presets, TRP3_Companions, TRP3_MatureFilter, TRP3_Colors, TRP3_Notes
 ## AddonCompartmentFunc: TRP3_OnAddonCompartmentClick


### PR DESCRIPTION
This integrates Wago Analytics as a module and collects a few very basic (and almost useless) anonymized statistics.

This is intended purely as a pilot - my feeling is that the number of users actually using the Wago app and who have the (off-by-default) analytics setting enabled probably measures in the tens of users.

However - I would quite like to be proven wrong there, so this implements a very minimal core with about 7 statistics and we can evaluate \<x> months down the line if there's any value in collecting anything else.

The analytics collection is notably enabled by default - however this is only because analytics are collected only if there's another installed addon that will accept them.

As WagoAnalytics is not installed by default (requiring that the user go through the Wago app and enable a checkbox first), it feels sensible that we can assume the presence of the WagoAnalytics addon indicates that the user is happy with us using the thing.

To avoid a mass panic about NSA spyware the setting to control analytics is only shown if WagoAnalytics is currently loaded - as otherwise people will see the setting and probably get angry.

Additionally there's a "/trp3 statistics" command that will print all the collected stats to the chat frame. This is mentioned in the help text of the setting, so should provide some transparency about what is being collected.