### PR TITLE
Add custom guild indicator and setting to disable in tooltips

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1527,6 +1527,16 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	CM_ALT_MAC = "Option",
 	SHORTCUT_INSTRUCTION = "%s: %s",
 
+	REG_TT_GUILD_CUSTOM = "Custom guild",
+	CO_TOOLTIP_GUILD_HIDDEN = "Hidden",
+	CO_TOOLTIP_GUILD_SHOW_WITH_ORIGINAL = "Show original",
+	CO_TOOLTIP_GUILD_SHOW_WITH_CUSTOM = "Show custom",
+	CO_TOOLTIP_GUILD_SHOW_WITH_ALL = "Show all",
+	CO_TOOLTIP_GUILD_TT = "Customizes how guild membership is displayed in the tooltip.",
+	CO_TOOLTIP_GUILD_TT_HIDDEN = "Does not show any guild membership in the tooltip.",
+	CO_TOOLTIP_GUILD_TT_SHOW_WITH_ORIGINAL = "Shows guild membership in the tooltip, but does not replace the name or rank if customized in the players' profile.",
+	CO_TOOLTIP_GUILD_TT_SHOW_WITH_CUSTOM = "Shows guild membership in the tooltip, replacing the name or rank if customized in the players' profile.",
+	CO_TOOLTIP_GUILD_TT_SHOW_WITH_ALL = "Shows both original and custom guild memberships on separate lines in the tooltip.",
 };
 
 -- Bindings and FrameXML Global Strings


### PR DESCRIPTION
There's been a few requests to make custom guilds a bit clear in tooltips. For now I'd like to just experiment with this indicator that's always shown if any guild-related field (rank or name) gets overridden. Also the changelog mentioned a setting to disable guild customizations in tooltips, but that was missing - it only existed for nameplates. We now have the technology, however and can allow users to display either no guild info, custom guild info, or both guild info lines.

![image](https://user-images.githubusercontent.com/287102/227245489-4557868e-fac4-4019-9843-d0cc910bafd6.png)


![image](https://user-images.githubusercontent.com/287102/227245298-195a8b43-0498-43a7-b1a2-87342bd1c5bd.png)

