### PR TITLE
Remove usage of C_CVar.RegisterCVar

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -441,7 +441,6 @@ stds.wow = {
 		"PlaySoundFile",
 		"RaidNotice_AddMessage",
 		"RaidWarningFrame",
-		"RegisterCVar",
 		"ReloadUI",
 		"RemoveChatWindowChannel",
 		"ResetCursor",

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -223,8 +223,9 @@ local function getCompanionVersionNumbers(profileID)
 end
 
 local function UpdateSummonedPetGUID(speciesID)
-	RegisterCVar("totalRP3_SummonedPetID", "");
-	SetCVar("totalRP3_SummonedPetID", speciesID);
+	if TRP3_Companions then
+		TRP3_Companions.summonedPetID = speciesID;
+	end
 end
 
 local function UpdateSummonedPetGUIDFromCast(unitToken, castGUID)


### PR DESCRIPTION
Instead store the summoned pet ID across reloads in our saved variables. This still gets cleared on character swaps and initial login, so there should be no functional difference.