### PR TITLE
Migrate to C_AddOns.GetAddOnMetadata

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -189,6 +189,12 @@ stds.wow = {
 			},
 		},
 
+		C_AddOns = {
+			fields = {
+				"GetAddOnMetadata",
+			},
+		},
+
 		C_BattleNet = {
 			fields = {
 				"GetAccountInfoByGUID",

--- a/totalRP3/Modules/Importer/MRP_API.lua
+++ b/totalRP3/Modules/Importer/MRP_API.lua
@@ -52,6 +52,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	end
 
 	MRP.addOnVersion = function()
+		local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata;
 		return "MyRolePlay - " .. GetAddOnMetadata("MyRolePlay", "Version");
 	end
 

--- a/totalRP3/Modules/Importer/XRP_API.lua
+++ b/totalRP3/Modules/Importer/XRP_API.lua
@@ -56,6 +56,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	end
 
 	XRP.addOnVersion = function()
+		local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata;
 		return "XRP - " .. GetAddOnMetadata("xrp", "Version");
 	end
 


### PR DESCRIPTION
The old function is deprecated in 10.1 and will be removed eventually; there will be a compatibility alias added until 11.0 however.