### PR TITLE
Don't explode on nil frame names

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -148,9 +148,9 @@ function TRP3_BlizzardNamePlates:OnUnitFrameSetUp(unitframe)
 	end
 
 	local nameplate = unitframe:GetParent();
-	local frameName = nameplate:GetName() or "";
+	local frameName = nameplate:GetName();
 
-	if self.initializedNameplates[frameName] or not string.find(frameName, "^NamePlate%d+$") then
+	if self.initializedNameplates[frameName] or not frameName or not string.find(frameName, "^NamePlate%d+$") then
 		return;
 	end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -148,7 +148,7 @@ function TRP3_BlizzardNamePlates:OnUnitFrameSetUp(unitframe)
 	end
 
 	local nameplate = unitframe:GetParent();
-	local frameName = nameplate:GetName();
+	local frameName = nameplate:GetName() or "";
 
 	if self.initializedNameplates[frameName] or not string.find(frameName, "^NamePlate%d+$") then
 		return;


### PR DESCRIPTION
The interface panel sets up a preview CUF that has no name, triggering an error in our Blizzard nameplates decorator.