### PR TITLE
Add MSP PV field

### DIFF
--- a/totalRP3/Modules/Importer/MRP_API.lua
+++ b/totalRP3/Modules/Importer/MRP_API.lua
@@ -125,6 +125,14 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 				IC = TRP3_InterfaceIcons.MiscInfoGuildRank;
 			});
 		end
+		if importedProfile.PV then
+			tinsert(profile.player.characteristics.MI, {
+				ID = TRP3_API.MiscInfoType.VoiceReference,
+				NA = loc.REG_PLAYER_MISC_PRESET_VOICE_REFERENCE;
+				VA = importedProfile.PV;
+				IC = TRP3_InterfaceIcons.MiscInfoVoiceReference;
+			});
+		end
 		profile.player.character.CU = importedProfile.CU;
 		profile.player.about.T3.PH.TX = importedProfile.DE;
 		profile.player.about.T3.HI.TX = importedProfile.HI;

--- a/totalRP3/Modules/Importer/XRP_API.lua
+++ b/totalRP3/Modules/Importer/XRP_API.lua
@@ -130,6 +130,14 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 				IC = TRP3_InterfaceIcons.MiscInfoGuildRank;
 			});
 		end
+		if importedProfile.PV then
+			tinsert(profile.player.characteristics.MI, {
+				ID = TRP3_API.MiscInfoType.VoiceReference,
+				NA = loc.REG_PLAYER_MISC_PRESET_VOICE_REFERENCE;
+				VA = importedProfile.PV;
+				IC = TRP3_InterfaceIcons.MiscInfoVoiceReference;
+			});
+		end
 		profile.player.character.CU = importedProfile.CU;
 		profile.player.about.T3.PH.TX = importedProfile.DE;
 		profile.player.about.T3.HI.TX = importedProfile.HI;

--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -135,6 +135,8 @@ local function onStart()
 					msp.my['PG'] = miscData.VA;
 				elseif miscType == TRP3_API.MiscInfoType.GuildRank then
 					msp.my['PR'] = miscData.VA;
+				elseif miscType == TRP3_API.MiscInfoType.VoiceReference then
+					msp.my['PV'] = miscData.VA;
 				end
 			end
 		end
@@ -270,6 +272,7 @@ local function onStart()
 		PN = TRP3_API.GetMiscTypeInfo(TRP3_API.MiscInfoType.Pronouns),
 		PG = TRP3_API.GetMiscTypeInfo(TRP3_API.MiscInfoType.GuildName),
 		PR = TRP3_API.GetMiscTypeInfo(TRP3_API.MiscInfoType.GuildRank),
+		PV = TRP3_API.GetMiscTypeInfo(TRP3_API.MiscInfoType.VoiceReference),
 	};
 
 	local function updateMiscInfoField(profile, field, value)

--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -501,7 +501,7 @@ local function onStart()
 	updateCharacterData();
 	msp:Update();
 
-	TRP3_API.RegisterCallback(TRP3_Addon, Events.REGISTER_DATA_UPDATED, function(unitID, _, dataType)
+	TRP3_API.RegisterCallback(TRP3_Addon, Events.REGISTER_DATA_UPDATED, function(_, unitID, _, dataType)
 		if unitID == Globals.player_id then
 			if not dataType or dataType == "about" or dataType == "characteristics" or dataType == "character" or dataType == "misc" then
 				onProfileChanged();


### PR DESCRIPTION
This adds support for sending the voice reference misc. info through MSP and the "PV" field we agreed upon. Also fixed a bug that was preventing us from updating `msp.my` with new data when the user edited their profile.