### PR TITLE
Automation Tweaks

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1589,7 +1589,6 @@ If you wish to report %s's profile and you cannot target them you will need to o
 	AUTOMATION_ERROR_INVALID_OPTION = "invalid option '%1$s' (expected any of the following: %s)",
 	AUTOMATION_ERROR_INVALID_PROFILE = "unable to find a profile named '%s'",
 	AUTOMATION_MODULE_DESCRIPTION = "Allows configuring actions such as profile swaps and roleplay status changes to occur automatically.",
-	AUTOMATION_MODULE_MESSAGE_PREFIX = "TRP3 Automation",
 	AUTOMATION_MODULE_NAME = "Automation",
 	AUTOMATION_MODULE_SETTINGS_HELP = "Select an action from the dropdown below and then enter a macro condition string into the displayed text field.",
 	AUTOMATION_MODULE_SETTINGS_TITLE = "Automation settings",

--- a/totalRP3/Modules/Automation/Automation.lua
+++ b/totalRP3/Modules/Automation/Automation.lua
@@ -84,7 +84,8 @@ function TRP3_Automation:OnEnable()
 	-- actions at the end of the current frame if any of these fire.
 
 	self.monitor:RegisterEvent("PLAYER_ENTERING_WORLD");
-	self.monitor:RegisterEvent("UPDATE_SHAPESHIFT_FORM");
+	-- Disabled due to a client performance issue in Classic Wrath.
+	-- self.monitor:RegisterEvent("UPDATE_SHAPESHIFT_FORM");
 	self.monitor:RegisterEvent("UPDATE_STEALTH");
 	self.monitor:RegisterEvent("PLAYER_TARGET_CHANGED");
 	self.monitor:RegisterEvent("PLAYER_FOCUS_CHANGED");

--- a/totalRP3/Modules/Automation/Automation.lua
+++ b/totalRP3/Modules/Automation/Automation.lua
@@ -10,11 +10,11 @@ local AUTOMATION_MESSAGE_THROTTLE = 5;
 local BaseContext = {};
 
 function BaseContext:Error(message)
-	TRP3_Automation:OnContextMessage(message);
+	TRP3_Automation:OnContextError(message);
 end
 
 function BaseContext:Errorf(format, ...)
-	TRP3_Automation:OnContextMessage(string.format(format, ...));
+	TRP3_Automation:OnContextError(string.format(format, ...));
 end
 
 function BaseContext:Print(message)
@@ -117,14 +117,18 @@ function TRP3_Automation:OnDirtyUpdate()
 	self:ProcessAllActions();
 end
 
-function TRP3_Automation:OnContextMessage(message)
+function TRP3_Automation:OnContextError(message)
 	local expirationTime = self.messageCooldowns[message] or -math.huge;
 	local currentTime = GetTime();
 
 	if expirationTime <= currentTime then
 		self.messageCooldowns[message] = currentTime + AUTOMATION_MESSAGE_THROTTLE;
-		self.Print(L.AUTOMATION_MODULE_MESSAGE_PREFIX, message);
+		TRP3_Addon:Print(message);
 	end
+end
+
+function TRP3_Automation:OnContextMessage(message)
+	TRP3_Addon:Print(message);
 end
 
 function TRP3_Automation:LoadSettings(settings)

--- a/totalRP3/Modules/Automation/Automation_Settings.lua
+++ b/totalRP3/Modules/Automation/Automation_Settings.lua
@@ -79,6 +79,7 @@ function TRP3_AutomationSettingsMixin:OnTestButtonClicked()
 	local expression = self:GetEditorInputText();
 	local result = TRP3_AutomationUtil.ParseMacroOption(expression);
 
+	TRP3_Automation:ResetMessageCooldowns();
 	TRP3_Addon:Printf(L.AUTOMATION_TEST_OUTPUT, string.format("|cff33ff99%s|r", result));
 end
 


### PR DESCRIPTION
Few small tweaks;

- The messages printed when automation changes are applied (like "oh here I changed your equipment set bro") are no longer filtered by the same cooldown applied to errors.
- The cooldown for errors is reset when the test button is clicked for debugging macro expression errors a bit more easily.
- The `UPDATE_SHAPESHIFT_FORM` event is no longer monitored as on Classic Wrath this is broken in such a way that it can fire hundreds of times in a single frame randomly.