### PR TITLE
Add a toggle for guild membership indicators in tooltips

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1621,7 +1621,8 @@ If you wish to report %s's profile and you cannot target them you will need to o
 
 ]],
 
-	CO_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR = "Show custom guild indicator",
+	CO_TOOLTIP_SHOW_GUILD_INDICATOR = "Show guild indicator",
+	CO_TOOLTIP_GUILD_INDICATOR_HELP = "Toggles the visibility of guild membership indicators displayed to the right of the guild name.",
 };
 
 -- Bindings and FrameXML Global Strings

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1620,6 +1620,8 @@ If you wish to report %s's profile and you cannot target them you will need to o
 - "Always show target" nameplate option will now display the target nameplate even if it is OOC and "Hide out of character units" was enabled.
 
 ]],
+
+	CO_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR = "Show custom guild indicator",
 };
 
 -- Bindings and FrameXML Global Strings

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -82,7 +82,7 @@ local CONFIG_CHARACT_CURRENT_LINES = "tooltip_char_current_lines";
 local CONFIG_TOOLTIP_TITLE_COLOR = "tooltip_title_color";
 local CONFIG_TOOLTIP_MAIN_COLOR = "tooltip_main_color";
 local CONFIG_TOOLTIP_SECONDARY_COLOR = "tooltip_secondary_color";
-local CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR = "tooltip_show_custom_guild_indicator";
+local CONFIG_TOOLTIP_SHOW_GUILD_INDICATOR = "tooltip_show_guild_indicator";
 
 local ANCHOR_TAB;
 
@@ -245,8 +245,8 @@ local function ShouldDisplayCustomGuild(displayOption, customName)
 	end
 end
 
-local function ShouldDisplayCustomGuildIndicator()
-	return getConfigValue(CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR);
+local function ShouldDisplayGuildIndicator()
+	return getConfigValue(CONFIG_TOOLTIP_SHOW_GUILD_INDICATOR);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -636,7 +636,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			local displayText = string.format(loc.REG_TT_GUILD, displayRank, colors.SECONDARY:WrapTextInColorCode(displayName));
 			local displayMembership = "";
 
-			if info.misc and info.misc.ST then
+			if ShouldDisplayGuildIndicator() and info.misc and info.misc.ST then
 				if info.misc.ST["6"] == 1 then -- IC guild membership
 					displayMembership = " |cff00ff00(" .. loc.REG_TT_GUILD_IC .. ")";
 				elseif info.misc.ST["6"] == 2 then -- OOC guild membership
@@ -653,7 +653,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			local displayText = string.format(loc.REG_TT_GUILD, displayRank, colors.SECONDARY:WrapTextInColorCode(displayName));
 			local displayMembership = "";
 
-			if ShouldDisplayCustomGuildIndicator() then
+			if ShouldDisplayGuildIndicator() then
 				displayMembership = " |cff82c5ff(" .. loc.REG_TT_GUILD_CUSTOM .. ")";
 			end
 
@@ -1403,7 +1403,7 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_TOOLTIP_TITLE_COLOR, "ff8000");
 	registerConfigKey(CONFIG_TOOLTIP_MAIN_COLOR, "ffffff");
 	registerConfigKey(CONFIG_TOOLTIP_SECONDARY_COLOR, "ffc000");
-	registerConfigKey(CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR, true);
+	registerConfigKey(CONFIG_TOOLTIP_SHOW_GUILD_INDICATOR, true);
 
 	ANCHOR_TAB = {
 		{loc.CO_ANCHOR_TOP_LEFT, "ANCHOR_TOPLEFT"},
@@ -1607,8 +1607,9 @@ local function onModuleInit()
 			},
 			{
 				inherit = "TRP3_ConfigCheck",
-				title = loc.CO_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR,
-				configKey = CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR,
+				title = loc.CO_TOOLTIP_SHOW_GUILD_INDICATOR,
+				configKey = CONFIG_TOOLTIP_SHOW_GUILD_INDICATOR,
+				help=loc.CO_TOOLTIP_GUILD_INDICATOR_HELP,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -82,6 +82,7 @@ local CONFIG_CHARACT_CURRENT_LINES = "tooltip_char_current_lines";
 local CONFIG_TOOLTIP_TITLE_COLOR = "tooltip_title_color";
 local CONFIG_TOOLTIP_MAIN_COLOR = "tooltip_main_color";
 local CONFIG_TOOLTIP_SECONDARY_COLOR = "tooltip_secondary_color";
+local CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR = "tooltip_show_custom_guild_indicator";
 
 local ANCHOR_TAB;
 
@@ -242,6 +243,10 @@ local function ShouldDisplayCustomGuild(displayOption, customName)
 	else
 		return false;
 	end
+end
+
+local function ShouldDisplayCustomGuildIndicator()
+	return getConfigValue(CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -646,7 +651,11 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			local displayName = crop(customGuildName, FIELDS_TO_CROP.GUILD_NAME);
 			local displayRank = crop(customGuildRank or loc.DEFAULT_GUILD_RANK, FIELDS_TO_CROP.GUILD_RANK);
 			local displayText = string.format(loc.REG_TT_GUILD, displayRank, colors.SECONDARY:WrapTextInColorCode(displayName));
-			local displayMembership = " |cff82c5ff(" .. loc.REG_TT_GUILD_CUSTOM .. ")";
+			local displayMembership = "";
+
+			if ShouldDisplayCustomGuildIndicator() then
+				displayMembership = " |cff82c5ff(" .. loc.REG_TT_GUILD_CUSTOM .. ")";
+			end
 
 			tooltipBuilder:AddDoubleLine(displayText, displayMembership, colors.MAIN, colors.MAIN, getSubLineFontSize());
 		end
@@ -1394,6 +1403,7 @@ local function onModuleInit()
 	registerConfigKey(CONFIG_TOOLTIP_TITLE_COLOR, "ff8000");
 	registerConfigKey(CONFIG_TOOLTIP_MAIN_COLOR, "ffffff");
 	registerConfigKey(CONFIG_TOOLTIP_SECONDARY_COLOR, "ffc000");
+	registerConfigKey(CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR, true);
 
 	ANCHOR_TAB = {
 		{loc.CO_ANCHOR_TOP_LEFT, "ANCHOR_TOPLEFT"},
@@ -1594,6 +1604,11 @@ local function onModuleInit()
 				end)(),
 				listWidth = nil,
 				listCancel = false,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR,
+				configKey = CONFIG_TOOLTIP_SHOW_CUSTOM_GUILD_INDICATOR,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",


### PR DESCRIPTION
With the most recent change, a custom guild indicator was added to prevent people from masquerading as a member of another guild. This indicator, while useful, also does clutter the tooltip and some users might prefer to disable it altogether.

I think it's fine to add a client-side toggle on whether or not to display this indicator, since others will still see it. This will be *enabled* by default.

Since this wasn't discussed ahead of time, feel free to yeet this PR into oblivion if it's not something y'all are down with. :)

