### PR TITLE
Don't expect color markup in player name strings

### DIFF
--- a/totalRP3/Modules/ChatFrame/Prat.lua
+++ b/totalRP3/Modules/ChatFrame/Prat.lua
@@ -55,9 +55,9 @@ Prat:AddModuleToLoad(function()
 		local unitID = TRP3_API.utils.str.unitInfoToID(name, realm);
 		local characterName = unitID;
 
-		--- Extract the color used by Prat so we use it by default
-		---@type ColorMixin
-		local characterColor = TRP3_API.CreateColorFromHexMarkup(message.PLAYER);
+		-- Extract the color if present used by Prat so we use it by default;
+		-- can be nil.
+		local characterColor = TRP3_API.ParseColorFromHexMarkup(message.PLAYER);
 
 		-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 		if realm == TRP3_API.globals.player_realm_id or TRP3_API.configuration.getValue("remove_realm") then


### PR DESCRIPTION
Fixes #756, or at least it should if the battle.net client ever gets past the "Initializing" step and lets me test it. I'm just gonna trust @Ghostamoose who claims that it works.

As Prat doesn't always stick a color in the player name field the softer "Parse" variant of the color utils should be used which will return nil if no color is found rather than erroring out. The rest of the code already looks equipped to handle this case.