### PR TITLE
Default guild rank text on display

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -620,8 +620,12 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 
 	if guildDisplayOption ~= TooltipGuildDisplayOption.Hidden then
 		local customGuildInfo = player:GetCustomGuildMembership();
-		local customGuildName = string.trim(customGuildInfo.name);
-		local customGuildRank = string.trim(customGuildInfo.rank);
+		local customGuildName = customGuildInfo.name and string.trim(customGuildInfo.name) or nil;
+		local customGuildRank = customGuildInfo.rank and string.trim(customGuildInfo.rank) or nil;
+
+		if customGuildRank == "" then
+			customGuildRank = nil;
+		end
 
 		local originalGuildName, originalGuildRank = GetGuildInfo(targetType);
 
@@ -645,11 +649,6 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		if ShouldDisplayCustomGuild(guildDisplayOption, customGuildName) then
 			local displayName = crop(customGuildName, FIELDS_TO_CROP.GUILD_NAME);
 			local displayRank = crop(customGuildRank or loc.DEFAULT_GUILD_RANK, FIELDS_TO_CROP.GUILD_RANK);
-
-			if displayRank == "" then
-				displayRank = loc.DEFAULT_GUILD_RANK;
-			end
-
 			local displayText = string.format(loc.REG_TT_GUILD, displayRank, colors.SECONDARY:WrapTextInColorCode(displayName));
 			local displayMembership = " |cff82c5ff(" .. loc.REG_TT_GUILD_CUSTOM .. ")";
 

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -217,7 +217,7 @@ local TooltipGuildDisplayOption = {
 };
 
 local function ShouldDisplayOriginalGuild(displayOption, originalName, customName)
-	if displayOption == TooltipGuildDisplayOption.Hidden or not originalName then
+	if displayOption == TooltipGuildDisplayOption.Hidden or not originalName or originalName == "" then
 		return false;
 	elseif displayOption == TooltipGuildDisplayOption.ShowWithOriginalGuild then
 		return true;
@@ -231,7 +231,7 @@ local function ShouldDisplayOriginalGuild(displayOption, originalName, customNam
 end
 
 local function ShouldDisplayCustomGuild(displayOption, customName)
-	if displayOption == TooltipGuildDisplayOption.Hidden or not customName then
+	if displayOption == TooltipGuildDisplayOption.Hidden or not customName or customName == "" then
 		return false;
 	elseif displayOption == TooltipGuildDisplayOption.ShowWithOriginalGuild then
 		return false;
@@ -620,8 +620,8 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 
 	if guildDisplayOption ~= TooltipGuildDisplayOption.Hidden then
 		local customGuildInfo = player:GetCustomGuildMembership();
-		local customGuildName = customGuildInfo.name;
-		local customGuildRank = customGuildInfo.rank;
+		local customGuildName = string.trim(customGuildInfo.name);
+		local customGuildRank = string.trim(customGuildInfo.rank);
 
 		local originalGuildName, originalGuildRank = GetGuildInfo(targetType);
 
@@ -645,6 +645,11 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		if ShouldDisplayCustomGuild(guildDisplayOption, customGuildName) then
 			local displayName = crop(customGuildName, FIELDS_TO_CROP.GUILD_NAME);
 			local displayRank = crop(customGuildRank or loc.DEFAULT_GUILD_RANK, FIELDS_TO_CROP.GUILD_RANK);
+
+			if displayRank == "" then
+				displayRank = loc.DEFAULT_GUILD_RANK;
+			end
+
 			local displayText = string.format(loc.REG_TT_GUILD, displayRank, colors.SECONDARY:WrapTextInColorCode(displayName));
 			local displayMembership = " |cff82c5ff(" .. loc.REG_TT_GUILD_CUSTOM .. ")";
 


### PR DESCRIPTION
If the user puts in a blank or space-only string to force the guild rank to be hidden, we'll default it to "Member" in the tooltip.

Hiding the rank information in this way doesn't really work too well in contexts that isn't the tooltip; for example rank information isn't shown in nameplates so the standalone guild name string can look quite out of place. Additionally other addons aren't beholden to even honor an empty rank string either and may default (or just entirely omit) ranks causing the same issue as nameplates.