### PR TITLE
Add option to hide minimize/maximize button

### DIFF
--- a/totalRP3/Core/Configuration.lua
+++ b/totalRP3/Core/Configuration.lua
@@ -384,6 +384,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 	registerConfigKey("ui_sounds", true);
 	registerConfigKey("ui_animations", true);
 	registerConfigKey("disable_welcome_message", false);
+	registerConfigKey("hide_maximize_button", false);
 	registerConfigKey("default_color_picker", false);
 	registerConfigKey("color_contrast_level", TRP3_API.ColorContrastOption.Default);
 	registerConfigKey("date_format", "");
@@ -424,6 +425,12 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 				title = loc.CO_GENERAL_DISABLE_WELCOME_MESSAGE,
 				configKey = "disable_welcome_message",
 				help = loc.CO_GENERAL_DISABLE_WELCOME_MESSAGE_HELP,
+			},
+			{
+				inherit = "TRP3_ConfigCheck",
+				title = loc.CO_GENERAL_HIDE_MAXIMIZE_BUTTON,
+				configKey = "hide_maximize_button",
+				help = loc.CO_GENERAL_HIDE_MAXIMIZE_BUTTON_HELP,
 			},
 			{
 				inherit = "TRP3_ConfigCheck",

--- a/totalRP3/Core/UIMain.lua
+++ b/totalRP3/Core/UIMain.lua
@@ -165,26 +165,18 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	});
 
 	-- Resizing
-	TRP3_MainFrame.Resize.onResizeStop = function()
-		TRP3_MainFrame.Minimize:Hide();
-		TRP3_MainFrame.Maximize:Show();
-		TRP3_Addon:TriggerEvent(TRP3_Addon.Events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetWidth(), TRP3_MainFramePageContainer:GetHeight());
+	TRP3_MainFrame.Resize.onResizeStop = function(width, height)
+		TRP3_MainFrame:ResizeWindow(width, height);
 	end;
 
 	TRP3_MainFrame.Maximize:SetScript("OnClick", function()
-		TRP3_MainFrame.Maximize:Hide();
-		TRP3_MainFrame.Minimize:Show();
-		TRP3_MainFrame:SetSize(UIParent:GetWidth(), UIParent:GetHeight());
-		C_Timer.After(0.25, function()
-			TRP3_Addon:TriggerEvent(TRP3_Addon.Events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetWidth(), TRP3_MainFramePageContainer:GetHeight());
-		end);
+		TRP3_MainFrame:MaximizeWindow();
+		TRP3_API.navigation.delayedRefresh();
 	end);
 
 	TRP3_MainFrame.Minimize:SetScript("OnClick", function()
-		TRP3_MainFrame:SetSize(768, 500);
-		C_Timer.After(0.25, function()
-			TRP3_MainFrame.Resize.onResizeStop();
-		end);
+		TRP3_MainFrame:RestoreWindow();
+		TRP3_API.navigation.delayedRefresh();
 	end);
 
 	TRP3_API.ui.frame.setupMove(TRP3_MainFrame);

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1644,6 +1644,9 @@ If you wish to report %s's profile and you cannot target them you will need to o
 - Fixed an issue with the Plater RP nameplates getting stuck on screen.
 
 ]],
+
+	CO_GENERAL_HIDE_MAXIMIZE_BUTTON = "Hide maximize button",
+	CO_GENERAL_HIDE_MAXIMIZE_BUTTON_HELP = "Hides the minimize and maximize buttons on the Total RP 3 window.",
 };
 
 -- Bindings and FrameXML Global Strings

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -1,0 +1,76 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local WindowState = {
+	Normal = 1,
+	Maximized = 2,
+};
+
+TRP3_MainFrameMixin = {};
+
+function TRP3_MainFrameMixin:OnLoad()
+	self.windowState = WindowState.Normal;
+	TRP3_Addon.RegisterCallback(self, "CONFIGURATION_CHANGED", "OnConfigurationChanged");
+end
+
+function TRP3_MainFrameMixin:OnConfigurationChanged(_, key)
+	if key == "hide_maximize_button" then
+		self:UpdateWindowStateButtons();
+	end
+end
+
+function TRP3_MainFrameMixin:OnShow()
+	self:UpdateWindowStateButtons();
+end
+
+function TRP3_MainFrameMixin:OnSizeChanged()
+	TRP3_Addon:TriggerEvent(TRP3_Addon.Events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetSize());
+end
+
+function TRP3_MainFrameMixin:OnWindowStateChanged(oldState, newState)  -- luacheck: no unused
+	self:UpdateWindowStateButtons();
+end
+
+function TRP3_MainFrameMixin:MaximizeWindow()
+	self:SetSize(UIParent:GetSize());
+	self:SetWindowState(WindowState.Maximized);
+end
+
+function TRP3_MainFrameMixin:RestoreWindow()
+	self:SetSize(768, 500);
+	self:SetWindowState(WindowState.Normal);
+end
+
+function TRP3_MainFrameMixin:ResizeWindow(width, height)
+	self:SetSize(width, height);
+	self:SetWindowState(WindowState.Normal);
+end
+
+function TRP3_MainFrameMixin:GetWindowState()
+	return self.windowState or WindowState.Normal;
+end
+
+function TRP3_MainFrameMixin:SetWindowState(state)
+	assert(type(state) == "number", "bad argument #2 to 'SetWindowState': expected number");
+
+	local oldState = self.windowState;
+	local newState = state;
+
+	if oldState == newState then
+		return;
+	end
+
+	self.windowState = newState;
+	self:OnWindowStateChanged(oldState, newState);
+end
+
+local function ShouldShowWindowStateButtons()
+	return not TRP3_API.configuration.getValue("hide_maximize_button");
+end
+
+function TRP3_MainFrameMixin:UpdateWindowStateButtons()
+	local state = self:GetWindowState();
+
+	self.Minimize:SetShown(state == WindowState.Maximized and ShouldShowWindowStateButtons());
+	self.Maximize:SetShown(state == WindowState.Normal and ShouldShowWindowStateButtons());
+end

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -4,6 +4,7 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="Main.lua"/>
 
 	<Button name="TRP3_TutorialButton" virtual="true" frameStrata="DIALOG" hidden="true">
 		<Size x="46" y="46"/>
@@ -242,7 +243,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" hidden="true" movable="true">
+	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameMixin" hidden="true" movable="true">
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
@@ -404,6 +405,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Frame>
 
 		</Frames>
+		<Scripts>
+			<OnLoad method="OnLoad" inherit="prepend"/>
+			<OnShow method="OnShow"/>
+			<OnSizeChanged method="OnSizeChanged"/>
+		</Scripts>
 	</Frame>
 
 	<Frame name="TRP3_DEBUG_CODE_FRAME" inherits="TRP3_TextArea" parent="UIParent" hidden="true">


### PR DESCRIPTION
Fixes #689. Realistically there's a lot of UI work that we're not going to get around to any time soon. As most of the UI behaves terribly while maximized, we may as well give people an option to avoid having to suffer if they accidentally click the accursed buttons.