### PR TITLE
Fix erroneous comparisons

### DIFF
--- a/totalRP3/Core/CommunicationProtocolBroadcast.lua
+++ b/totalRP3/Core/CommunicationProtocolBroadcast.lua
@@ -86,7 +86,7 @@ Comm.broadcast.broadcast = broadcast;
 
 local function onBroadcastReceived(message, sender)
 	local header, command, arg1, arg2, arg3, arg4, arg5, arg6, arg7 = strsplit(BROADCAST_SEPARATOR, message);
-	if not header == BROADCAST_HEADER or not command then
+	if header ~= BROADCAST_HEADER or not command then
 		return; -- If not RP protocol or don't have a command
 	end
 	Comm.totalBroadcastR = Comm.totalBroadcastR + BROADCAST_HEADER:len() + message:len();

--- a/totalRP3/Modules/ModuleManagement.lua
+++ b/totalRP3/Modules/ModuleManagement.lua
@@ -52,7 +52,7 @@ TRP3_API.module.registerModule = function(moduleStructure)
 	assert(not MODULE_REGISTRATION[moduleStructure.id], "This module is already register: " .. moduleStructure.id);
 	assert(not hasBeenInit, "Module structure must be registered before Total RP 3 initialization: " .. moduleStructure.id);
 
-	if not moduleStructure.name or not type(moduleStructure.name) == "string" or moduleStructure.name:len() == 0 then
+	if not moduleStructure.name or type(moduleStructure.name) ~= "string" or moduleStructure.name:len() == 0 then
 		moduleStructure.name = moduleStructure.id;
 	end
 


### PR DESCRIPTION
Negation operators have a higher priority than relational ones; the expression (not x == y) ends up getting interpreted as ((not x) == y) rather than the intended (not (x == y)).

This is now detected by luacheck which rightly gets angry about us doing this.