### PR TITLE
Make window buttons look prettier in Retail

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -516,7 +516,6 @@ stds.wow = {
 		"UIDROPDOWNMENU_INIT_MENU",
 		"UIDROPDOWNMENU_MENU_LEVEL",
 		"UIDROPDOWNMENU_MENU_VALUE",
-		"UIPanelCloseButton_SetBorderAtlas",
 		"UnitAffectingCombat",
 		"UnitAura",
 		"UnitBattlePetLevel",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -325,6 +325,12 @@ stds.wow = {
 			},
 		},
 
+		C_Texture = {
+			fields = {
+				"GetAtlasInfo",
+			},
+		},
+
 		C_Timer = {
 			fields = {
 				"After",

--- a/totalRP3/Modules/ChatLinks/ChatLinks.xml
+++ b/totalRP3/Modules/ChatLinks/ChatLinks.xml
@@ -11,42 +11,30 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Button name="TRP3_ChatLinkActionButton" inherits="UIPanelButtonTemplate" virtual="true" hidden="true" mixin="TRP3_ChatLinkActionButtonMixin">
 		<Size x="100" y="20"/>
 		<Scripts>
-			<OnLoad method="OnLoad" />
-			<OnClick method="OnClick" />
+			<OnLoad method="OnLoad"/>
+			<OnClick method="OnClick"/>
 		</Scripts>
 	</Button>
 
 	<GameTooltip name="TRP3_RefTooltip" inherits="TRP3_TooltipTemplate" parent="UIParent" enableMouse="true" toplevel="true" movable="true" frameStrata="TOOLTIP" hidden="true" mixin="TRP3_ChatLinkTooltipMixin">
-		<Size>
-			<AbsDimension x="128" y="64"/>
-		</Size>
+		<Size x="128" y="64"/>
 		<Anchors>
-			<Anchor point="BOTTOM">
-				<Offset>
-					<AbsDimension x="0" y="80"/>
-				</Offset>
-			</Anchor>
+			<Anchor point="BOTTOM" y="80"/>
 		</Anchors>
 		<Frames>
-			<Button>
-				<Size>
-					<AbsDimension x="32" y="32"/>
-				</Size>
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT">
-						<Offset>
-							<AbsDimension x="1" y="0"/>
-						</Offset>
-					</Anchor>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
 				<Scripts>
 					<OnClick>
 						TRP3_RefTooltip:Hide();
 					</OnClick>
 				</Scripts>
-				<NormalTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Up"/>
-				<PushedTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Down"/>
-				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
 
 			<Button parentKey="Button1" inherits="TRP3_ChatLinkActionButton">
@@ -76,8 +64,8 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Button>
 		</Frames>
 		<Scripts>
-			<OnLoad method="OnLoad" inherit="prepend" />
-			<OnUpdate method="OnUpdate" />
+			<OnLoad method="OnLoad" inherit="prepend"/>
+			<OnUpdate method="OnUpdate"/>
 		</Scripts>
 	</GameTooltip>
 

--- a/totalRP3/Modules/Dashboard/Dashboard.xml
+++ b/totalRP3/Modules/Dashboard/Dashboard.xml
@@ -179,10 +179,17 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Layer>
 		</Layers>
 		<Frames>
-			<Button parentKey="Close" inherits="UIPanelCloseButton">
+			<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
+				<Scripts>
+					<OnClick function="HideParentPanel"/>
+				</Scripts>
 			</Button>
 			<EditBox parentKey="name" inherits="TRP3_TitledHelpEditBox">
 				<Size y="18"/>

--- a/totalRP3/Modules/Modules.xml
+++ b/totalRP3/Modules/Modules.xml
@@ -44,14 +44,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Anchor point="TOPLEFT" x="13" y="-7"/>
 				</Anchors>
 			</Button>
-			<Button name="$parentAction">
-				<Size x="32" y="32"/>
+			<Button name="$parentAction" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="MinimizeButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="-4" y="-4"/>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
-				<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up"/>
-				<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down"/>
-				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
 		</Frames>
 	</Frame>

--- a/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
@@ -275,9 +275,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 			</Frame>
 
-			<Button inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="0" y="0"/>
+					<Anchor point="TOPRIGHT"/>
 				</Anchors>
 				<Scripts>
 					<OnClick>
@@ -297,7 +301,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<KeyValue key="minHeight" value="150" type="number"/>
 				</KeyValues>
 				<Anchors>
-					<Anchor point="BOTTOMRIGHT" x="0" y="0"/>
+					<Anchor point="BOTTOMRIGHT"/>
 				</Anchors>
 			</Button>
 		</Frames>

--- a/totalRP3/Modules/Register/Filter/RegisterMatureFilter.xml
+++ b/totalRP3/Modules/Register/Filter/RegisterMatureFilter.xml
@@ -146,7 +146,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
 		<Frames>
-			<Button inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
@@ -229,7 +233,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</Layer>
 				</Layers>
 				<Frames>
-					<Button inherits="UIPanelCloseButton">
+					<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+						<Size x="24" y="24"/>
+						<KeyValues>
+							<KeyValue key="styleName" value="CloseButton" type="string"/>
+						</KeyValues>
 						<Anchors>
 							<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 						</Anchors>

--- a/totalRP3/UI/Browsers/Colors.xml
+++ b/totalRP3/UI/Browsers/Colors.xml
@@ -28,7 +28,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 		</Layers>
 		<Frames>
-			<Button inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>

--- a/totalRP3/UI/Browsers/Companions.xml
+++ b/totalRP3/UI/Browsers/Companions.xml
@@ -15,7 +15,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
 		<Frames>
-			<Button name="TRP3_CompanionBrowserClose" inherits="UIPanelCloseButton">
+			<Button name="TRP3_CompanionBrowserClose" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>

--- a/totalRP3/UI/Browsers/Icons.xml
+++ b/totalRP3/UI/Browsers/Icons.xml
@@ -45,7 +45,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</OnHide>
 		</Scripts>
 		<Frames>
-			<Button name="TRP3_IconBrowserClose" inherits="UIPanelCloseButton">
+			<Button name="TRP3_IconBrowserClose" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>

--- a/totalRP3/UI/Browsers/Images.xml
+++ b/totalRP3/UI/Browsers/Images.xml
@@ -15,7 +15,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
 		<Frames>
-			<Button inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>

--- a/totalRP3/UI/Browsers/Musics.xml
+++ b/totalRP3/UI/Browsers/Musics.xml
@@ -66,7 +66,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
 		<Frames>
-			<Button inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>

--- a/totalRP3/UI/Browsers/PetBrowser.lua
+++ b/totalRP3/UI/Browsers/PetBrowser.lua
@@ -156,7 +156,6 @@ function TRP3_PetBrowserMixin:OnLoad()
 	self.tooltipFrame    = self.tooltipFrame or TRP3_MainTooltip;
 
 	-- Dynamic UI styling.
-	UIPanelCloseButton_SetBorderAtlas(self.CloseButton, "UI-Frame-GenericMetal-ExitButtonBorder", -1, 1);
 	self.AcceptButton:SetText(L.UI_PET_BROWSER_ACCEPT);
 
 	-- Icon grid layout setup.

--- a/totalRP3/UI/Browsers/PetBrowser.xml
+++ b/totalRP3/UI/Browsers/PetBrowser.xml
@@ -184,7 +184,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<OnClick>CallMethodOnNearestAncestor(self, "Accept");</OnClick>
 				</Scripts>
 			</Button>
-			<Button parentKey="CloseButton" inherits="UIPanelCloseButtonNoScripts">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT" x="-8" y="-8"/>
 				</Anchors>

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -74,3 +74,69 @@ function TRP3_MainFrameMixin:UpdateWindowStateButtons()
 	self.Minimize:SetShown(state == WindowState.Maximized and ShouldShowWindowStateButtons());
 	self.Maximize:SetShown(state == WindowState.Normal and ShouldShowWindowStateButtons());
 end
+
+local function ResetTexCoords(texture)
+	texture:SetTexCoord(0, 1, 0, 1);
+end
+
+local function MirrorTexCoordsAlongHorizontalAxis(region)
+	local x1, y1, x2, y2, x3, y3, x4, y4 = region:GetTexCoord();
+	region:SetTexCoord(x3, y3, x4, y4, x1, y1, x2, y2);
+end
+
+TRP3_WindowCloseButtonArtMixin = {};
+
+function TRP3_WindowCloseButtonArtMixin:OnLoad()
+	if C_Texture.GetAtlasInfo("RedButton-Exit") then
+		ResetTexCoords(self:GetNormalTexture());
+		ResetTexCoords(self:GetPushedTexture());
+		ResetTexCoords(self:GetDisabledTexture());
+		ResetTexCoords(self:GetHighlightTexture());
+		self:SetNormalAtlas("RedButton-Exit");
+		self:SetPushedAtlas("RedButton-Exit-Pressed");
+		self:SetDisabledAtlas("RedButton-Exit-Disabled");
+		self:SetHighlightAtlas("RedButton-Highlight", "ADD");
+	end
+end
+
+TRP3_WindowMaximizeButtonArtMixin = {};
+
+function TRP3_WindowMaximizeButtonArtMixin:OnLoad()
+	if C_Texture.GetAtlasInfo("RedButton-Expand") then
+		ResetTexCoords(self:GetNormalTexture());
+		ResetTexCoords(self:GetPushedTexture());
+		ResetTexCoords(self:GetDisabledTexture());
+		ResetTexCoords(self:GetHighlightTexture());
+		self:SetNormalAtlas("RedButton-Expand");
+		self:SetPushedAtlas("RedButton-Expand-Pressed");
+		self:SetDisabledAtlas("RedButton-Expand-Disabled");
+		self:SetHighlightAtlas("RedButton-Highlight", "ADD");
+	end
+end
+
+TRP3_WindowMinimizeButtonArtMixin = {};
+
+function TRP3_WindowMinimizeButtonArtMixin:OnLoad()
+	if C_Texture.GetAtlasInfo("RedButton-Condense") then
+		ResetTexCoords(self:GetNormalTexture());
+		ResetTexCoords(self:GetPushedTexture());
+		ResetTexCoords(self:GetDisabledTexture());
+		ResetTexCoords(self:GetHighlightTexture());
+		self:SetNormalAtlas("RedButton-Condense");
+		self:SetPushedAtlas("RedButton-Condense-Pressed");
+		self:SetDisabledAtlas("RedButton-Condense-Disabled");
+		self:SetHighlightAtlas("RedButton-Highlight", "ADD");
+	end
+end
+
+TRP3_WindowResizeButtonArtMixin = {};
+
+function TRP3_WindowResizeButtonArtMixin:OnLoad()
+	TRP3_WindowMinimizeButtonArtMixin.OnLoad(self);
+	TRP3_API.ui.frame.initResize(self);
+
+	if C_Texture.GetAtlasInfo("RedButton-Condense") then
+		MirrorTexCoordsAlongHorizontalAxis(self:GetNormalTexture());
+		MirrorTexCoordsAlongHorizontalAxis(self:GetPushedTexture());
+	end
+end

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -11,6 +11,7 @@ TRP3_MainFrameMixin = {};
 function TRP3_MainFrameMixin:OnLoad()
 	self.windowState = WindowState.Normal;
 	TRP3_Addon.RegisterCallback(self, "CONFIGURATION_CHANGED", "OnConfigurationChanged");
+	TRP3_API.ui.frame.initResize(self.Resize);
 end
 
 function TRP3_MainFrameMixin:OnConfigurationChanged(_, key)
@@ -133,7 +134,6 @@ TRP3_WindowResizeButtonArtMixin = {};
 
 function TRP3_WindowResizeButtonArtMixin:OnLoad()
 	TRP3_WindowMinimizeButtonArtMixin.OnLoad(self);
-	TRP3_API.ui.frame.initResize(self);
 
 	if C_Texture.GetAtlasInfo("RedButton-Condense") then
 		MirrorTexCoordsAlongHorizontalAxis(self:GetNormalTexture());

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -138,5 +138,6 @@ function TRP3_WindowResizeButtonArtMixin:OnLoad()
 	if C_Texture.GetAtlasInfo("RedButton-Condense") then
 		MirrorTexCoordsAlongHorizontalAxis(self:GetNormalTexture());
 		MirrorTexCoordsAlongHorizontalAxis(self:GetPushedTexture());
+		MirrorTexCoordsAlongHorizontalAxis(self:GetDisabledTexture());
 	end
 end

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -4,7 +4,6 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
-	<Include file="StyledButton.xml"/>
 	<Include file="Main.lua"/>
 
 	<Button name="TRP3_TutorialButton" virtual="true" frameStrata="DIALOG" hidden="true">

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -4,83 +4,8 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="StyledButton.xml"/>
 	<Include file="Main.lua"/>
-
-	<Button name="TRP3_WindowCloseButtonArtTemplate" mixin="TRP3_WindowCloseButtonArtMixin" virtual="true">
-		<Size x="24" y="24"/>
-		<NormalTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Up">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</NormalTexture>
-		<PushedTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Down">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</PushedTexture>
-		<DisabledTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Disabled">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</DisabledTexture>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</HighlightTexture>
-		<Scripts>
-			<OnLoad method="OnLoad"/>
-		</Scripts>
-	</Button>
-
-	<Button name="TRP3_WindowMaximizeButtonArtTemplate" mixin="TRP3_WindowMaximizeButtonArtMixin" virtual="true">
-		<Size x="24" y="24"/>
-		<NormalTexture file="Interface\Buttons\UI-Panel-BiggerButton-Up">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</NormalTexture>
-		<PushedTexture file="Interface\Buttons\UI-Panel-BiggerButton-Down">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</PushedTexture>
-		<DisabledTexture file="Interface\Buttons\UI-Panel-BiggerButton-Disabled">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</DisabledTexture>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</HighlightTexture>
-		<Scripts>
-			<OnLoad method="OnLoad"/>
-		</Scripts>
-	</Button>
-
-	<Button name="TRP3_WindowMinimizeButtonArtTemplate" mixin="TRP3_WindowMinimizeButtonArtMixin" virtual="true">
-		<Size x="24" y="24"/>
-		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</NormalTexture>
-		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</PushedTexture>
-		<DisabledTexture file="Interface\Buttons\UI-Panel-SmallerButton-Disabled">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</DisabledTexture>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</HighlightTexture>
-		<Scripts>
-			<OnLoad method="OnLoad"/>
-		</Scripts>
-	</Button>
-
-	<Button name="TRP3_WindowResizeButtonArtTemplate" mixin="TRP3_WindowResizeButtonArtMixin" virtual="true">
-		<Size x="24" y="24"/>
-		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up">
-			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
-		</NormalTexture>
-		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down">
-			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
-		</PushedTexture>
-		<DisabledTexture file="Interface\Buttons\UI-Panel-SmallerButton-Disabled">
-			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
-		</DisabledTexture>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
-			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
-		</HighlightTexture>
-		<Scripts>
-			<OnLoad method="OnLoad"/>
-		</Scripts>
-	</Button>
 
 	<Button name="TRP3_TutorialButton" virtual="true" frameStrata="DIALOG" hidden="true">
 		<Size x="46" y="46"/>
@@ -278,31 +203,45 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 		<Frames>
 			<!-- CLOSE MAIN FRAME -->
-			<Button parentKey="Close" inherits="TRP3_WindowCloseButtonArtTemplate">
+			<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="TOPRIGHT"/>
 				</Anchors>
 			</Button>
 
 			<!-- MaxiButton -->
-			<Button parentKey="Maximize" inherits="TRP3_WindowMaximizeButtonArtTemplate">
+			<Button parentKey="Maximize" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="MaximizeButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="RIGHT" relativeKey="$parent.Close" relativePoint="LEFT"/>
 				</Anchors>
 			</Button>
 
 			<!-- MiniButton -->
-			<Button parentKey="Minimize" inherits="TRP3_WindowMinimizeButtonArtTemplate" hidden="true">
+			<Button parentKey="Minimize" inherits="TRP3_StyledButtonTemplate" hidden="true">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="MinimizeButton" type="string"/>
+				</KeyValues>
 				<Anchors>
 					<Anchor point="RIGHT" relativeKey="$parent.Close" relativePoint="LEFT"/>
 				</Anchors>
 			</Button>
 
 			<!-- RESIZING BUTTON -->
-			<Button parentKey="Resize" inherits="TRP3_WindowResizeButtonArtTemplate">
+			<Button parentKey="Resize" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
 				<KeyValues>
 					<KeyValue key="minWidth" value="768" type="number"/>
 					<KeyValue key="minHeight" value="500" type="number"/>
+					<KeyValue key="styleName" value="ResizeButton" type="string"/>
 				</KeyValues>
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT"/>

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -385,9 +385,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							</Layer>
 						</Layers>
 						<Frames>
-							<Button parentKey="Close" inherits="UIPanelCloseButton">
+							<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+								<Size x="24" y="24"/>
+								<KeyValues>
+									<KeyValue key="styleName" value="CloseButton" type="string"/>
+								</KeyValues>
 								<Anchors>
-									<Anchor point="TOPRIGHT" x="0" y="0"/>
+									<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 								</Anchors>
 								<Scripts>
 									<OnClick>

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -6,6 +6,82 @@
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="Main.lua"/>
 
+	<Button name="TRP3_WindowCloseButtonArtTemplate" mixin="TRP3_WindowCloseButtonArtMixin" virtual="true">
+		<Size x="24" y="24"/>
+		<NormalTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Up">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</NormalTexture>
+		<PushedTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Down">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</PushedTexture>
+		<DisabledTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Disabled">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</DisabledTexture>
+		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</HighlightTexture>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Button>
+
+	<Button name="TRP3_WindowMaximizeButtonArtTemplate" mixin="TRP3_WindowMaximizeButtonArtMixin" virtual="true">
+		<Size x="24" y="24"/>
+		<NormalTexture file="Interface\Buttons\UI-Panel-BiggerButton-Up">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</NormalTexture>
+		<PushedTexture file="Interface\Buttons\UI-Panel-BiggerButton-Down">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</PushedTexture>
+		<DisabledTexture file="Interface\Buttons\UI-Panel-BiggerButton-Disabled">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</DisabledTexture>
+		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</HighlightTexture>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Button>
+
+	<Button name="TRP3_WindowMinimizeButtonArtTemplate" mixin="TRP3_WindowMinimizeButtonArtMixin" virtual="true">
+		<Size x="24" y="24"/>
+		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</NormalTexture>
+		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</PushedTexture>
+		<DisabledTexture file="Interface\Buttons\UI-Panel-SmallerButton-Disabled">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</DisabledTexture>
+		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</HighlightTexture>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Button>
+
+	<Button name="TRP3_WindowResizeButtonArtTemplate" mixin="TRP3_WindowResizeButtonArtMixin" virtual="true">
+		<Size x="24" y="24"/>
+		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up">
+			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
+		</NormalTexture>
+		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down">
+			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
+		</PushedTexture>
+		<DisabledTexture file="Interface\Buttons\UI-Panel-SmallerButton-Disabled">
+			<TexCoords left="0.875" right="0.125" top="0.125" bottom="0.875"/>
+		</DisabledTexture>
+		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD">
+			<TexCoords left="0.125" right="0.875" top="0.125" bottom="0.875"/>
+		</HighlightTexture>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Button>
+
 	<Button name="TRP3_TutorialButton" virtual="true" frameStrata="DIALOG" hidden="true">
 		<Size x="46" y="46"/>
 		<Layers>
@@ -202,42 +278,34 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 		<Frames>
 			<!-- CLOSE MAIN FRAME -->
-			<Button parentKey="Close" inherits="UIPanelCloseButton">
+			<Button parentKey="Close" inherits="TRP3_WindowCloseButtonArtTemplate">
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="4" y="4"/>
+					<Anchor point="TOPRIGHT"/>
 				</Anchors>
 			</Button>
 
 			<!-- MaxiButton -->
-			<Button parentKey="Maximize">
+			<Button parentKey="Maximize" inherits="TRP3_WindowMaximizeButtonArtTemplate">
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="-16" y="4"/>
+					<Anchor point="RIGHT" relativeKey="$parent.Close" relativePoint="LEFT"/>
 				</Anchors>
-				<Size x="32" y="32"/>
-				<NormalTexture file="Interface\Buttons\UI-Panel-BiggerButton-Up"/>
-				<PushedTexture file="Interface\Buttons\UI-Panel-BiggerButton-Down"/>
-				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
 
 			<!-- MiniButton -->
-			<Button parentKey="Minimize" hidden="true">
+			<Button parentKey="Minimize" inherits="TRP3_WindowMinimizeButtonArtTemplate" hidden="true">
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="-16" y="4"/>
+					<Anchor point="RIGHT" relativeKey="$parent.Close" relativePoint="LEFT"/>
 				</Anchors>
-				<Size x="32" y="32"/>
-				<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up"/>
-				<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down"/>
-				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
 
 			<!-- RESIZING BUTTON -->
-			<Button parentKey="Resize" inherits="TRP3_ResizeButton">
+			<Button parentKey="Resize" inherits="TRP3_WindowResizeButtonArtTemplate">
 				<KeyValues>
 					<KeyValue key="minWidth" value="768" type="number"/>
 					<KeyValue key="minHeight" value="500" type="number"/>
 				</KeyValues>
 				<Anchors>
-					<Anchor point="BOTTOMRIGHT" x="4" y="-4"/>
+					<Anchor point="BOTTOMRIGHT"/>
 				</Anchors>
 			</Button>
 		</Frames>

--- a/totalRP3/UI/Profiles.xml
+++ b/totalRP3/UI/Profiles.xml
@@ -246,9 +246,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 
 		<Frames>
-			<Button parentKey="Close" inherits="UIPanelCloseButton">
+			<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="0" y="0"/>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
 				<Scripts>
 					<OnClick>
@@ -301,9 +305,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Layers>
 
 		<Frames>
-			<Button parentKey="Close" inherits="UIPanelCloseButton">
+			<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="0" y="0"/>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
 				<Scripts>
 					<OnClick>

--- a/totalRP3/UI/StyledButton.lua
+++ b/totalRP3/UI/StyledButton.lua
@@ -1,0 +1,103 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local StyledButtonSetup = {
+	{ pieceName = "NormalTexture" },
+	{ pieceName = "PushedTexture" },
+	{ pieceName = "DisabledTexture" },
+	{ pieceName = "HighlightTexture" },
+};
+
+local function UnpackTexCoords(tbl)
+	local left = tbl.leftTexCoord or 0;
+	local right = tbl.rightTexCoord or 1;
+	local top = tbl.topTexCoord or 0;
+	local bottom = tbl.bottomTexCoord or 1;
+
+	return left, right, top, bottom;
+end
+
+local function GetPieceTexture(container, pieceName)
+	local piece;
+
+	if container.GetStyledButtonPiece then
+		piece = container:GetStyledButtonPiece(pieceName);
+	end
+
+	if not piece then
+		piece = container[pieceName];
+	end
+
+	if not piece then
+		piece = container["Get" .. pieceName](container);
+	end
+
+	return piece;
+end
+
+local function SetupPieceTextureCoordinates(piece, pieceLayout)
+	local left, right, top, bottom = UnpackTexCoords(pieceLayout);
+
+	if pieceLayout.mirrorHorizontal then
+		left, right = right, left;
+	end
+
+	if pieceLayout.mirrorVertical then
+		top, bottom = bottom, top;
+	end
+
+	piece:SetTexCoord(left, right, top, bottom);
+end
+
+local function SetupStyledButtonPiece(piece, setupInfo, pieceLayout)  -- luacheck: no unused (setupInfo)
+	SetupPieceTextureCoordinates(piece, pieceLayout);
+
+	if pieceLayout.atlas then
+		piece:SetAtlas(pieceLayout.atlas);
+	elseif pieceLayout.file then
+		piece:SetTexture(pieceLayout.file);
+	end
+
+	piece:SetBlendMode(pieceLayout.blendMode or "BLEND");
+end
+
+TRP3_StyledButtonKits = {};
+TRP3_StyledButtonUtil = {};
+
+function TRP3_StyledButtonUtil.ApplyStyle(container, styleInfo)
+	for _, setupInfo in ipairs(StyledButtonSetup) do
+		local pieceName = setupInfo.pieceName;
+		local pieceLayout = styleInfo[pieceName];
+		local piece = GetPieceTexture(container, pieceName);
+
+		if pieceLayout then
+			SetupStyledButtonPiece(piece, setupInfo, pieceLayout);
+		end
+	end
+end
+
+function TRP3_StyledButtonUtil.ApplyStyleByName(container, styleName)
+	local styleInfo = TRP3_StyledButtonUtil.GetStyle(styleName);
+	assert(styleInfo, "unknown button style");
+	TRP3_StyledButtonUtil.ApplyStyle(container, styleInfo);
+end
+
+function TRP3_StyledButtonUtil.GetStyle(styleName)
+	return TRP3_StyledButtonKits[styleName];
+end
+
+function TRP3_StyledButtonUtil.RegisterStyle(styleName, styleInfo)
+	-- Duplicate registrations permitted to allow replacing styles.
+	TRP3_StyledButtonKits[styleName] = CopyTable(styleInfo);
+end
+
+TRP3_StyledButtonMixin = {};
+
+function TRP3_StyledButtonMixin:OnLoad()
+	local styleName = self.styleName;
+	local styleInfo = TRP3_StyledButtonUtil.GetStyle(styleName);
+
+	if styleInfo then
+		TRP3_StyledButtonUtil.ApplyStyle(self, styleInfo);
+	end
+end

--- a/totalRP3/UI/StyledButton.xml
+++ b/totalRP3/UI/StyledButton.xml
@@ -1,0 +1,25 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="StyledButton.lua"/>
+	<Include file="StyledButtonData.lua"/>
+
+	<Button name="TRP3_StyledButtonScriptTemplate" mixin="TRP3_StyledButtonMixin" virtual="true">
+		<KeyValues>
+			<!-- <KeyValue key="styleName" value="CloseButton" type="string"/> -->
+		</KeyValues>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Button>
+
+	<Button name="TRP3_StyledButtonTemplate" inherits="TRP3_StyledButtonScriptTemplate" virtual="true">
+		<NormalTexture parentKey="NormalTexture" setAllPoints="true"/>
+		<HighlightTexture parentKey="HighlightTexture" setAllPoints="true"/>
+		<PushedTexture parentKey="PushedTexture" setAllPoints="true"/>
+		<DisabledTexture parentKey="DisabledTexture" setAllPoints="true"/>
+	</Button>
+</Ui>

--- a/totalRP3/UI/StyledButtonData.lua
+++ b/totalRP3/UI/StyledButtonData.lua
@@ -1,0 +1,78 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local function ApplyHorizontalMirroring(styleInfo)
+	for _, pieceLayout in pairs(styleInfo) do
+		pieceLayout.mirrorHorizontal = true;
+	end
+
+	return styleInfo;
+end
+
+local function ApplyTextureCoordinates(styleInfo, left, right, top, bottom)
+	for _, pieceLayout in pairs(styleInfo) do
+		pieceLayout.leftTexCoord = left;
+		pieceLayout.rightTexCoord = right;
+		pieceLayout.topTexCoord = top;
+		pieceLayout.bottomTexCoord = bottom;
+	end
+
+	return styleInfo;
+end
+
+local function GenerateWindowButtonStyle(textureKit)
+	local normalAtlas = string.format("RedButton-%s", textureKit);
+	local pushedAtlas = string.format("RedButton-%s-Pressed", textureKit);
+	local disabledAtlas = string.format("RedButton-%s-Disabled", textureKit);
+	local highlightAtlas = "RedButton-Highlight";
+	local styleInfo;
+
+	if C_Texture.GetAtlasInfo(normalAtlas) then
+		styleInfo = {
+			NormalTexture = { atlas = normalAtlas },
+			PushedTexture = { atlas = pushedAtlas },
+			DisabledTexture = { atlas = disabledAtlas },
+			HighlightTexture = { atlas = highlightAtlas, blendMode = "ADD" },
+		};
+	end
+
+	return styleInfo;
+end
+
+local function GenerateUIPanelButtonStyle(textureKit)
+	local normalTexture = string.format([[Interface\Buttons\UI-Panel-%s-Up]], textureKit);
+	local pushedTexture = string.format([[Interface\Buttons\UI-Panel-%s-Down]], textureKit);
+	local disabledTexture = string.format([[Interface\Buttons\UI-Panel-%s-Disabled]], textureKit);
+	local highlightTexture = [[Interface\Buttons\UI-Panel-MinimizeButton-Highlight]];
+
+	local styleInfo = {
+		NormalTexture = { file = normalTexture },
+		PushedTexture = { file = pushedTexture },
+		DisabledTexture = { file = disabledTexture },
+		HighlightTexture = { file = highlightTexture, blendMode = "ADD" },
+	};
+
+	ApplyTextureCoordinates(styleInfo, 0.125, 0.875, 0.125, 0.875);
+	return styleInfo;
+end
+
+do
+	local styleInfo = GenerateWindowButtonStyle("Exit") or GenerateUIPanelButtonStyle("MinimizeButton");
+	TRP3_StyledButtonUtil.RegisterStyle("CloseButton", styleInfo);
+end
+
+do
+	local styleInfo = GenerateWindowButtonStyle("Expand") or GenerateUIPanelButtonStyle("BiggerButton");
+	TRP3_StyledButtonUtil.RegisterStyle("MaximizeButton", styleInfo);
+end
+
+do
+	local styleInfo = GenerateWindowButtonStyle("Condense") or GenerateUIPanelButtonStyle("SmallerButton");
+	TRP3_StyledButtonUtil.RegisterStyle("MinimizeButton", styleInfo);
+end
+
+do
+	local styleInfo = GenerateWindowButtonStyle("Condense") or GenerateUIPanelButtonStyle("SmallerButton");
+	ApplyHorizontalMirroring(styleInfo);
+	TRP3_StyledButtonUtil.RegisterStyle("ResizeButton", styleInfo);
+end

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -239,11 +239,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Scripts>
 	</Button>
 
-	<Button name="TRP3_ActionButton" virtual="true">
-		<Size x="32" y="32"/>
-		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up"/>
-		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down"/>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
+	<Button name="TRP3_ActionButton" inherits="TRP3_StyledButtonTemplate" virtual="true">
+		<Size x="24" y="24"/>
+		<KeyValues>
+			<KeyValue key="styleName" value="MinimizeButton" type="string"/>
+		</KeyValues>
 		<Scripts>
 			<OnEnter>
 				TRP3_RefreshTooltipForFrame(self);

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -7,6 +7,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Include file="ScrollingEditBox.xml"/>
 	<Include file="FocusRegion.xml"/>
+	<Include file="StyledButton.xml"/>
 	<Include file="UIButton.xml"/>
 	<Include file="Widgets.lua"/>
 

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -914,20 +914,16 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	</Frame>
 
 	<!-- Resize button -->
-	<Button name="TRP3_ResizeButton" virtual="true">
-		<Size x="32" y="32"/>
+	<Button name="TRP3_ResizeButton" inherits="TRP3_StyledButtonTemplate" virtual="true">
+		<Size x="24" y="24"/>
+		<KeyValues>
+			<KeyValue key="styleName" value="ResizeButton" type="string"/>
+		</KeyValues>
 		<Scripts>
-			<OnLoad>
+			<OnLoad inherit="prepend">
 				TRP3_API.ui.frame.initResize(self);
 			</OnLoad>
 		</Scripts>
-		<NormalTexture file="Interface\Buttons\UI-Panel-SmallerButton-Up">
-			<TexCoords left="1" right="0" top="0" bottom="1"/>
-		</NormalTexture>
-		<PushedTexture file="Interface\Buttons\UI-Panel-SmallerButton-Down">
-			<TexCoords left="1" right="0" top="0" bottom="1"/>
-		</PushedTexture>
-		<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 	</Button>
 
 	<Slider name="TRP3_Scrollbar" virtual="true">
@@ -1083,14 +1079,17 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Layer>
 		</Layers>
 		<Frames>
-			<Button parentKey="CloseButton" inherits="UIPanelCloseButton">
+			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="TOPRIGHT">
-						<Offset>
-							<AbsDimension x="-3" y="-3" />
-						</Offset>
-					</Anchor>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
 				</Anchors>
+				<Scripts>
+					<OnClick function="HideParentPanel"/>
+				</Scripts>
 			</Button>
 			<EditBox parentKey="CopyText">
 				<Anchors>


### PR DESCRIPTION
This updates the maximize, minimize, and resize buttons on the main frame to use newer art assets in retail clients. The button positioning has been slightly altered to no longer bleed outside the frame.

![image](https://github.com/Total-RP/Total-RP-3/assets/287102/6653e3ea-e27c-4280-a964-2afbac983efe)

On classic clients the old assets are used, as the newer art doesn't exist there.

![image](https://github.com/Total-RP/Total-RP-3/assets/287102/4444bdf7-7540-4f3a-926f-50f7db39222d)

For the resize button this doesn't update the styling of the TRP3_ResizeButton template itself. The new templates use a different frame size and I didn't want to spend any time going through and correcting every single usage of the resize button template.