### PR TITLE
Regroup TRP3_MainFrame OnLoad scripts

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -582,6 +582,7 @@ stds.wow = {
 		"TargetFrame",
 		"UIErrorsFrame",
 		"UIParent",
+		"UISpecialFrames",
 		"WorldFrame",
 		"WorldMapFrame",
 

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -9,6 +9,7 @@ local WindowState = {
 TRP3_MainFrameMixin = {};
 
 function TRP3_MainFrameMixin:OnLoad()
+	tinsert(UISpecialFrames, self:GetName());
 	self.windowState = WindowState.Normal;
 	TRP3_Addon.RegisterCallback(self, "CONFIGURATION_CHANGED", "OnConfigurationChanged");
 	TRP3_API.ui.frame.initResize(self.Resize);

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -253,11 +253,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
-		<Scripts>
-			<OnLoad inherit="prepend">
-				tinsert(UISpecialFrames, self:GetName());
-			</OnLoad>
-		</Scripts>
 		<Layers>
 			<Layer level="BACKGROUND">
 				<!--Interface\BlackMarket\BlackMarketBackground-Tile-->


### PR DESCRIPTION
While investigating the Extended resizing issue, I found out there were two Scripts sections in TRP3_MainFrame. As both TRP3 and Extended have to include themselves in the UISpecialFrames, I thought it made sense to just auto-include that line in the mixin to remove that extra section.