### PR TITLE
Persist window layout in configuration

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -34,6 +34,7 @@ externals:
   totalRP3/Libs/LibMSP: https://github.com/wow-rp-addons/LibMSP
   totalRP3/Libs/LibRPMedia: https://github.com/wow-rp-addons/LibRPMedia
   totalRP3/Libs/LibStub: https://repos.curseforge.com/wow/libstub/trunk
+  totalRP3/Libs/LibWindow-1.1: https://repos.curseforge.com/wow/libwindow-1-1/trunk
   totalRP3/Libs/UTF8: https://repos.curseforge.com/wow/utf8/trunk
 
 embedded-libraries:

--- a/totalRP3/Core/Configuration.lua
+++ b/totalRP3/Core/Configuration.lua
@@ -389,6 +389,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 	registerConfigKey("ui_animations", true);
 	registerConfigKey("disable_welcome_message", false);
 	registerConfigKey("hide_maximize_button", false);
+	registerConfigKey("window_layout", {});  -- Contents managed by TRP3_MainFrameMixin.
 	registerConfigKey("default_color_picker", false);
 	registerConfigKey("color_contrast_level", TRP3_API.ColorContrastOption.Default);
 	registerConfigKey("date_format", "");

--- a/totalRP3/Core/UIMain.lua
+++ b/totalRP3/Core/UIMain.lua
@@ -68,8 +68,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		TRP3_API.navigation.delayedRefresh();
 	end);
 
-	TRP3_API.ui.frame.setupMove(TRP3_MainFrame);
-
 	-- Update frame
 	TRP3_UpdateFrame.popup.title:SetText(L.NEW_VERSION_TITLE);
 end);

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -249,7 +249,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameMixin" hidden="true" movable="true">
+	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameMixin" hidden="true" movable="true" dontSavePosition="true">
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -36,6 +36,7 @@ Libs\LibDeflate\lib.xml
 Libs\LibDropDownExtension\LibDropDownExtension.lua
 Libs\LibMSP\LibMSP.xml
 Libs\LibRPMedia\lib.xml
+Libs\LibWindow-1.1\LibWindow-1.1.lua
 Libs\MSA-DropDownMenu-1.0\MSA-DropDownMenu-1.0.xml
 Libs\UTF8\lib.xml
 


### PR DESCRIPTION
This replaces the use of the game layout cache for storing the position of our main window to instead persist it within our own saved variables, using a combination of LibWindow for window positioning and our own management of window size.

The layout cache is known to have a few issues - it restores layout information at weird times in the load process, and it forgets frames if they're not loaded in a UI session.

Storing the layout in our saved variables resolves this; we get a fully controllable point in the load process from which we can restore the layout and reposition/resize the window, and we don't have to worry about the game forgetting our frame if the addon isn't loaded once.

Use of LibWindow for managing the window position is employed as it's the recommended practice; it has smart logic for anchoring to the nearest quadrant of the screen and handles scale changes. This can be quite important for the small subset of users who might be mirroring their SVs across devices with different screen resolutions.

One thing to note - as we're no longer using the layout cache I suspect everyone's stored window position will reset with this, but it should be a minor one-off inconvenience.