### PR TITLE
Support 10.2 changes to `GetAddOnEnableState`

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -193,8 +193,8 @@ stds.wow = {
 
 		C_AddOns = {
 			fields = {
-				"GetAddOnMetadata",
 				"GetAddOnEnableState",
+				"GetAddOnMetadata",
 			},
 		},
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -194,6 +194,7 @@ stds.wow = {
 		C_AddOns = {
 			fields = {
 				"GetAddOnMetadata",
+				"GetAddOnEnableState",
 			},
 		},
 

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -1106,3 +1106,16 @@ function Utils.GenerateFormattedDateString(time)
 
 	return result;
 end
+
+function Utils.IsAddOnEnabled(addonName)
+	local characterName = UnitNameUnmodified("player");
+	local enableState;
+
+	if C_AddOns and C_AddOns.GetAddOnEnableState then
+		enableState = C_AddOns.GetAddOnEnableState(addonName, characterName);
+	else
+		enableState = GetAddOnEnableState(characterName, addonName);
+	end
+
+	return enableState > 0;
+end

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -1117,5 +1117,5 @@ function Utils.IsAddOnEnabled(addonName)
 		enableState = GetAddOnEnableState(characterName, addonName);
 	end
 
-	return enableState > 0;
+	return enableState == 2;
 end

--- a/totalRP3/Modules/ModuleManagement.lua
+++ b/totalRP3/Modules/ModuleManagement.lua
@@ -15,7 +15,6 @@ local setTooltipForSameFrame, setTooltipAll = TRP3_API.ui.tooltip.setTooltipForS
 local registerMenu = TRP3_API.navigation.menu.registerMenu;
 local registerPage, setPage = TRP3_API.navigation.page.registerPage, TRP3_API.navigation.page.setPage;
 local CreateFrame = CreateFrame;
-local GetAddOnEnableState = C_AddOns and C_AddOns.GetAddOnEnableState or GetAddOnEnableState;
 local initModule;
 local startModule;
 local onModuleStarted;
@@ -113,7 +112,7 @@ local function checkModuleDependency(_, dependency)
 		return MODULE_REGISTRATION[dependency_id] and MODULE_REGISTRATION[dependency_id].version >= dependency_version and
 			MODULE_ACTIVATION[dependency_id] ~= false;
 	else
-		return GetAddOnEnableState(dependency_id, UnitName("player")) == 2;
+		return TRP3_API.utils.IsAddOnEnabled(dependency_id);
 	end
 end
 

--- a/totalRP3/Modules/ModuleManagement.lua
+++ b/totalRP3/Modules/ModuleManagement.lua
@@ -15,6 +15,7 @@ local setTooltipForSameFrame, setTooltipAll = TRP3_API.ui.tooltip.setTooltipForS
 local registerMenu = TRP3_API.navigation.menu.registerMenu;
 local registerPage, setPage = TRP3_API.navigation.page.registerPage, TRP3_API.navigation.page.setPage;
 local CreateFrame = CreateFrame;
+local GetAddOnEnableState = C_AddOns and C_AddOns.GetAddOnEnableState or GetAddOnEnableState;
 local initModule;
 local startModule;
 local onModuleStarted;
@@ -112,7 +113,7 @@ local function checkModuleDependency(_, dependency)
 		return MODULE_REGISTRATION[dependency_id] and MODULE_REGISTRATION[dependency_id].version >= dependency_version and
 			MODULE_ACTIVATION[dependency_id] ~= false;
 	else
-		return GetAddOnEnableState(nil, dependency_id) == 2;
+		return GetAddOnEnableState(dependency_id, UnitName("player")) == 2;
 	end
 end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -100,7 +100,7 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 	};
 
 	for _, addon in ipairs(addons) do
-		if GetAddOnEnableState(nil, addon) == 2 then
+		if GetAddOnEnableState(addon, UnitName("player")) == 2 then
 			return false, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
 		end
 	end

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -100,7 +100,7 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 	};
 
 	for _, addon in ipairs(addons) do
-		if GetAddOnEnableState(addon, UnitName("player")) == 2 then
+		if TRP3_API.utils.IsAddOnEnabled(addon) then
 			return false, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
 		end
 	end

--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -73,7 +73,7 @@ function TRP3_KuiNamePlates:OnModuleInitialize()
 	-- Disable our (old) Kui nameplate module explicitly, we'll also tell
 	-- users that they can disable it.
 
-	if GetAddOnEnableState("totalRP3_KuiNameplates", UnitName("player")) ~= 0 then
+	if TRP3_API.utils.IsAddOnEnabled("totalRP3_KuiNameplates") then
 		DisableAddOn("totalRP3_KuiNameplates", true);
 		TRP3_API.popup.showAlertPopup(L.KUI_NAMEPLATES_WARN_OUTDATED_MODULE);
 	end

--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -73,7 +73,7 @@ function TRP3_KuiNamePlates:OnModuleInitialize()
 	-- Disable our (old) Kui nameplate module explicitly, we'll also tell
 	-- users that they can disable it.
 
-	if GetAddOnEnableState(nil, "totalRP3_KuiNameplates") ~= 0 then
+	if GetAddOnEnableState("totalRP3_KuiNameplates", UnitName("player")) ~= 0 then
 		DisableAddOn("totalRP3_KuiNameplates", true);
 		TRP3_API.popup.showAlertPopup(L.KUI_NAMEPLATES_WARN_OUTDATED_MODULE);
 	end

--- a/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
@@ -144,7 +144,7 @@ function TRP3_PlaterNamePlates:OnNamePlateDataUpdated(_, nameplate, unitToken, d
 end
 
 function TRP3_PlaterNamePlates:OnModuleInitialize()
-	if GetAddOnEnableState(nil, PlaterAddonName) ~= 2 then
+	if GetAddOnEnableState(PlaterAddonName, UnitName("player")) ~= 2 then
 		return false, L.NAMEPLATES_MODULE_DISABLED_BY_DEPENDENCY;
 	end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
@@ -144,7 +144,7 @@ function TRP3_PlaterNamePlates:OnNamePlateDataUpdated(_, nameplate, unitToken, d
 end
 
 function TRP3_PlaterNamePlates:OnModuleInitialize()
-	if GetAddOnEnableState(PlaterAddonName, UnitName("player")) ~= 2 then
+	if not TRP3_API.utils.IsAddOnEnabled(PlaterAddonName) then
 		return false, L.NAMEPLATES_MODULE_DISABLED_BY_DEPENDENCY;
 	end
 


### PR DESCRIPTION
Technically, I think the old syntax still works through the Blizzard_Deprecated addon, but the return values we were checking for were based on old behavior - instead of changing the number we check for, feels more sensible to instead update the argument order to reflect changes made in 10.2.