### PR TITLE
Loosen localization script version specifiers

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,2 @@
-luaparser==3.1.1
-requests==2.31.0
+luaparser~=3.1
+requests~=2.31


### PR DESCRIPTION
Allow newer versions of dependencies to be used if they're within the same major version and the minor version is at least what we've listed.