### PR TITLE
Use labelled binding categories instead of headers

### DIFF
--- a/totalRP3/Bindings.xml
+++ b/totalRP3/Bindings.xml
@@ -3,20 +3,20 @@
 	SPDX-License-Identifier: Apache-2.0
 -->
 <Bindings>
-	<Binding name="TRP3_TOGGLE" header="TRP3" category="ADDONS">
+	<Binding name="TRP3_TOGGLE" category="BINDING_HEADER_TRP3">
 		TRP3_API.navigation.switchMainFrame();
 	</Binding>
-	<Binding name="TRP3_TOOLBAR_TOGGLE" category="ADDONS">
+	<Binding name="TRP3_TOOLBAR_TOGGLE" category="BINDING_HEADER_TRP3">
 		if TRP3_API.toolbar then
 			TRP3_API.toolbar.switch();
 		end
 	</Binding>
-	<Binding name="TRP3_OPEN_TARGET_PROFILE" category="ADDONS">
+	<Binding name="TRP3_OPEN_TARGET_PROFILE" category="BINDING_HEADER_TRP3">
 		if UnitExists("target") then
 			TRP3_API.slash.openProfile("target");
 		end
 	</Binding>
-	<Binding name="TRP3_TOGGLE_CHARACTER_STATUS" category="ADDONS">
+	<Binding name="TRP3_TOGGLE_CHARACTER_STATUS" category="BINDING_HEADER_TRP3">
 		TRP3_API.dashboard.switchStatus();
 	</Binding>
 </Bindings>


### PR DESCRIPTION
With the settings panel rework the keybindings interface no longer shows text when using headers - it simply puts in a massive dividing space with no text at all.

As it's been about a year and this has now propagated to all client flavours and looks like it'll be unfixed, let's just bite the bullet and use categories which _do_ have nice text labels.