### PR TITLE
Fix altform trigger on druid forms

### DIFF
--- a/totalRP3/Modules/Automation/Automation_Conditions.lua
+++ b/totalRP3/Modules/Automation/Automation_Conditions.lua
@@ -147,9 +147,9 @@ TRP3_AutomationUtil.RegisterCondition({
 	tokens = { "altform" },
 
 	Evaluate = function()
-		local inAlternateForm = false;
+		local inAlternateForm = true;
 
-		if C_PlayerInfo.GetAlternateFormInfo then
+		if C_PlayerInfo.GetAlternateFormInfo and GetShapeshiftForm() == 0 then
 			inAlternateForm = select(2, C_PlayerInfo.GetAlternateFormInfo());
 		end
 

--- a/totalRP3/Modules/Automation/Automation_Conditions.lua
+++ b/totalRP3/Modules/Automation/Automation_Conditions.lua
@@ -149,7 +149,7 @@ TRP3_AutomationUtil.RegisterCondition({
 	Evaluate = function()
 		local inAlternateForm = true;
 
-		if C_PlayerInfo.GetAlternateFormInfo and GetShapeshiftForm() == 0 then
+		if C_PlayerInfo.GetAlternateFormInfo and not (TRP3_API.utils.str.GetClass("player") == "DRUID" and GetShapeshiftForm() ~= 0) then
 			inAlternateForm = select(2, C_PlayerInfo.GetAlternateFormInfo());
 		end
 


### PR DESCRIPTION
# Preface
According to the [Macro Conditionals](https://github.com/Total-RP/Total-RP-3/wiki/Macro-conditionals) wiki page:
> `[altform]`: (Worgen/Evoker only) Checks if the character is in their human form (Example: `[altform] Human Profile; Worgen Profile`).

However, in its current form, `altform` will also trigger as a positive if you are in druid form as a Worgen. This is not desirable, as the macro conditional is only supposed to be true for their 'True Form' (Dracthyr / Worgen).

# Example to reproduce
Look at the following automation profile:
```
[altform] "Human"; "Worgen
```
This turns on the Worgen profile when in Worgen form as expected, but also turns it on when in Druid form.

# The problem explained
`C_PlayerInfo.GetAlternateFormInfo()` returns the following:
- Alternate form (Human / Visage): `true true`.
- True Form (Dracthyr / Worgen): `true false`.
- Druid forms (as Worgen): `true false`.

Since TRP relies on the second result being false to determine if you're in your True Form, it also triggers on druid forms for Worgens.

# The fix explained
We now always assume that `inAlternateForm` starts as true (true means we're in our true form as a dracthyr or Worgen).

Then, when an `altform` macro conditional is used, we check to see if `C_PlayerInfo.GetAlternateFormInfo` exists AND NOT a druid that is shapeshifted shapeshifted (`and not (TRP3_API.utils.str.GetClass("player") == "DRUID" and GetShapeshiftForm() ~= 0)`), because `true forms` are always considered by the game as not shapeshifted. The druid check is because other classes also have non-0 results for shapeshift forms like a rogue in stealth, or a warrior's specific stance.

This has the side effect that druid forms, if not handled by multiple macro conditionals (as they should be), will now trigger the alternate form (Human for Worgens). But this seems more desirable than before, as strictly speaking a druid form is still NOT your 'true form'. Druid forms should be handled by the `[form:x]` macro conditional as is.

# Regressions tested
I've re-tested the automation profiles to check for problems:
```
[altform] "Human"; "Worgen
```
Correctly switches to Worgen in Worgen form, and does not trigger the Worgen profile when the user is shapeshifted (and thus not in their 'true form').

Then again with multiple conditionals:
```
[form:3] "Travel"; [form:4] "Moonkin"; [altform] "Human"; "Worgen"
```
This works just fine before AND after my fix, because you made sure to handle the druid forms first.

This means there are no regressions and everything else continues to work as it should.