### PR TITLE
Fix default color picker usage for 10.2.5

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -557,6 +557,7 @@ stds.wow = {
 			fields = {
 				"GetColorRGB",
 				"SetColorRGB",
+				"SetupColorPickerAndShow",
 			},
 		},
 

--- a/totalRP3/Core/Core.xml
+++ b/totalRP3/Core/Core.xml
@@ -19,6 +19,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="Events.lua"/>
 	<Include file="Color.lua"/>
 	<Include file="ColorData.lua"/>
+	<Include file="FunctionUtil.lua"/>
 	<Include file="StringUtil.lua"/>
 	<Include file="BindingUtil.lua"/>
 

--- a/totalRP3/Core/FunctionUtil.lua
+++ b/totalRP3/Core/FunctionUtil.lua
@@ -1,0 +1,52 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_FunctionUtil = {};
+
+--- Returns a closure that when first invoked will start a timer of duration
+--- `timeout`. When this timer has elapsed, the supplied callback will be
+--- invoked.
+---
+--- Repeated calls to the closure will reset the timeout back to zero, in
+--- effect delaying execution of the callback.
+---
+--- @param timeout number
+--- @param callback function
+function TRP3_FunctionUtil.Debounce(timeout, callback)
+	local calls = 0;
+
+	local function Decrement()
+		calls = calls - 1;
+
+		if calls == 0 then
+			callback();
+		end
+	end
+
+	return function()
+		C_Timer.After(timeout, Decrement);
+		calls = calls + 1;
+	end
+end
+
+--- Returns a closure that when first invoked will immediately execute the
+--- supplied callback, and starts a timer of duration `timeout`. Until the
+--- timer has elapsed, future invocations will do nothing.
+---
+--- @param timeout number
+--- @param callback function
+function TRP3_FunctionUtil.Throttle(timeout, callback)
+	local callable = true;
+
+	local function Reset()
+		callable = true;
+	end
+
+	return function()
+		if callable then
+			C_Timer.After(timeout, Reset);
+			callable = false;
+			callback();
+		end
+	end
+end

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -1016,25 +1016,41 @@ end
 function TRP3_API.popup.showDefaultColorPicker(popupArgs)
 	local setColor, r, g, b = unpack(popupArgs);
 
-	ColorPickerFrame:SetColorRGB((r or 255) / 255, (g or 255) / 255, (b or 255) / 255);
-	ColorPickerFrame.hasOpacity = false;
-	ColorPickerFrame.opacity = 1;
-
-	-- func is called every time the color is changed, whereas opacityFunc is only called when changing opacity or pressing OKAY
-	-- Since we don't have opacity, I put the callback on opacityFunc to have the same behaviour as TRP3 color picker.
-	ColorPickerFrame.func = function()
-	end
-
-	ColorPickerFrame.opacityFunc = function()
+	local function OnColorChanged()
 		local newR, newG, newB = ColorPickerFrame:GetColorRGB();
 		setColor(newR * 255, newG * 255, newB * 255);
 	end
 
-	ColorPickerFrame.cancelFunc = function()
+	local function OnCancel()
 		setColor(r, g, b);
 	end
 
-	ShowUIPanel(ColorPickerFrame);
+	-- For the swatchFunc and opacityFunc callbacks we debounce changes; these
+	-- fire rapidly so long as the user has the mouse held over the color
+	-- wheel or opacity slider. Debouncing means that we won't apply the color
+	-- change until the user stops changing things for 0.1s.
+
+	local options = {
+		swatchFunc = TRP3_FunctionUtil.Debounce(0.1, OnColorChanged),
+		opacityFunc = TRP3_FunctionUtil.Debounce(0.1, OnColorChanged),
+		cancelFunc = OnCancel,
+		hasOpacity = false,
+		r = (r or 255) / 255,
+		g = (g or 255) / 255,
+		b = (b or 255) / 255,
+	};
+
+	if ColorPickerFrame.SetupColorPickerAndShow then
+		ColorPickerFrame:SetupColorPickerAndShow(options);
+	else
+		ColorPickerFrame.func = options.swatchFunc;
+		ColorPickerFrame.hasOpacity = options.hasOpacity;
+		ColorPickerFrame.opacity = options.opacity;
+		ColorPickerFrame.opacityFunc = options.opacityFunc;
+		ColorPickerFrame.cancelFunc = options.cancelFunc;
+		ColorPickerFrame:SetColorRGB(options.r, options.g, options.b);
+		ShowUIPanel(ColorPickerFrame);
+	end
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*


### PR DESCRIPTION
Blizzard reworked the default color picker frame in 10.2.5 and our usage of it now breaks with a few errors. This commit uses the new SetupColorPickerAndShow method to err.. set up the color picker and show it, with a fallback for current clients that don't have that method.

This change includes a copy of FunctionUtil.lua from the icon browser tweaks branch to avoid some issues - the callbacks for changing color and opacity fire every tick so long as a button is held over those, so we debounce the input by a very small delay (0.1s) to in effect throttle the setColor calls until the user releases their mouse - this avoids the flash spark animation on our color swatch playing rapidly.