### PR TITLE
Fix unit frame 'open profile' button

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -602,8 +602,22 @@ function TRP3_API.register.inits.dataExchangeInit()
 	end);
 end
 
-local UNIT_TOKENS = { "target", "mouseover", "player", "focus" };
-UNIT_TOKENS = tInvert(UNIT_TOKENS);
+local function isUnitToken(token)
+	local tokens = tInvert({ "target", "mouseover", "player", "focus" });
+	local groupPatterns = { "^party%d+$", "^raid%d+$" };
+
+	if tokens[token] then
+		return true;
+	end
+
+	for _, pattern in ipairs(groupPatterns) do
+		if token:find(pattern) then
+			return true;
+		end
+	end
+
+	return false;
+end
 
 function TRP3_API.slash.openProfile(...)
 	local args = {...};
@@ -618,7 +632,7 @@ function TRP3_API.slash.openProfile(...)
 	elseif #args == 1 then
 		characterToOpen = table.concat(args, " ");
 
-		if UNIT_TOKENS[characterToOpen:lower()] then
+		if isUnitToken(characterToOpen:lower()) then
 			-- If we typed a unit token we resolve it
 			characterToOpen = Utils.str.getUnitID(characterToOpen:lower());
 		else

--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -602,23 +602,6 @@ function TRP3_API.register.inits.dataExchangeInit()
 	end);
 end
 
-local function isUnitToken(token)
-	local tokens = tInvert({ "target", "mouseover", "player", "focus" });
-	local groupPatterns = { "^party%d+$", "^raid%d+$" };
-
-	if tokens[token] then
-		return true;
-	end
-
-	for _, pattern in ipairs(groupPatterns) do
-		if token:find(pattern) then
-			return true;
-		end
-	end
-
-	return false;
-end
-
 function TRP3_API.slash.openProfile(...)
 	local args = {...};
 
@@ -632,7 +615,7 @@ function TRP3_API.slash.openProfile(...)
 	elseif #args == 1 then
 		characterToOpen = table.concat(args, " ");
 
-		if isUnitToken(characterToOpen:lower()) then
+		if UnitExists(characterToOpen:lower()) then
 			-- If we typed a unit token we resolve it
 			characterToOpen = Utils.str.getUnitID(characterToOpen:lower());
 		else


### PR DESCRIPTION
This button uses the `TRP3_API.slash.openProfile()` function - which only checks if the selected unit is your target, mouseover, current player, or focus target. This would cause it to not functions correctly on raid and party frames, since those supplied the unit tokens `raid%d` or `party%d` and since it wasn't any of the previously mentioned unit tokens, it treated it as a name, which then ended up requesting a profile from `raid16-MoonGuard` - who really can't come to the phone right now (or ever).

This fix seems efficient enough, as the feature really isn't used often at all in the circumstances in which it breaks, since it requires you to specifically request the profile from a raid or party member while NOT having them targeted.

It might be better to just throw in a `UnitExists(name)` instead though, depending on if we'd rather keep the list of potential unit tokens low, but it may behave weirdly, example: using `Utils.str.getUnitID` on a unit token that happens to be the same as a player's name will likely result in unexpected behavior, though that condition is probably very rare.

TLDR; additionally checks the name input for `raid%d` or `party%d` when deciding if the input is a name or unit token. May be better to just replace the whole thing with `UnitExists(name)`.