### PR TITLE
Customize own pet nameplate

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -253,7 +253,13 @@ end
 local function GetCompanionUnitDisplayInfo(unitToken, companionFullID)
 	local displayInfo = GetOrCreateDisplayInfo(unitToken);
 
-	local profile = TRP3_API.companions.register.getCompanionProfile(companionFullID);
+	local owner, companionID = TRP3_API.utils.str.companionIDToInfo(companionFullID);
+	local profile;
+	if owner == TRP3_API.globals.player_id then
+		profile = TRP3_API.companions.player.getCompanionProfile(companionID);
+	else
+		profile = TRP3_API.companions.register.getCompanionProfile(companionFullID);
+	end
 
 	if profile and profile.data then
 		displayInfo.isRoleplayUnit = true;


### PR DESCRIPTION
We looked up our own pet profile in the directory of others players' pet profiles, couldn't find it, so never customized the nameplate. I just check who the owner is before calling the appropriate function.