### PR TITLE
Update DisableAddOn usage for 10.2

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -74,7 +74,7 @@ function TRP3_KuiNamePlates:OnModuleInitialize()
 	-- users that they can disable it.
 
 	if TRP3_API.utils.IsAddOnEnabled("totalRP3_KuiNameplates") then
-		DisableAddOn("totalRP3_KuiNameplates", true);
+		DisableAddOn("totalRP3_KuiNameplates");
 		TRP3_API.popup.showAlertPopup(L.KUI_NAMEPLATES_WARN_OUTDATED_MODULE);
 	end
 end


### PR DESCRIPTION
The old global DisableAddOn function was documented as accepting a second `true` parameter for disabling addons on all characters. The new replacement doesn't seem to do this - it strictly expects a string or nil, so we shouldn't pass an explicit true here.