### PR TITLE
Use MaskTextures instead of SetPortraitToTexture

### DIFF
--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -14,10 +14,9 @@ local loc = TRP3_API.loc;
 -- WOW imports
 local pcall, tostring, pairs, type, print, string, date, math, strconcat, wipe, tonumber = pcall, tostring, pairs, type, print, string, date, math, strconcat, wipe, tonumber;
 local strsplit, strtrim = strsplit, strtrim;
-local tinsert, assert, _G, tremove, next = tinsert, assert, _G, tremove, next;
+local tinsert, assert, tremove, next = tinsert, assert, tremove, next;
 local UnitFullName = UnitFullName;
 local UNKNOWNOBJECT = UNKNOWNOBJECT;
-local SetPortraitToTexture = SetPortraitToTexture;
 local getZoneText, getSubZoneText = GetZoneText, GetSubZoneText;
 
 function Utils.pcall(func, ...)
@@ -959,18 +958,6 @@ end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Textures
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-
-Utils.texture.applyRoundTexture = function(textureFrame, texturePath, failTexture)
-	local ok, errorMess = pcall(SetPortraitToTexture, textureFrame, texturePath);
-	if not ok then
-		TRP3_API.Log("Fail to round texture: " .. tostring(errorMess));
-		if failTexture then
-			SetPortraitToTexture(textureFrame, failTexture);
-		elseif _G[textureFrame] then
-			_G[textureFrame]:SetTexture(texturePath);
-		end
-	end
-end
 
 local function Rainbow(value, max)
 	local movedValue = value - 1;    -- screw Lua lmao

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -20,6 +20,23 @@ local TRP3_Enums = AddOn_TotalRP3.Enums;
 -- CONSTANTS
 local EMPTY = Globals.empty;
 
+TRP3_GlanceBarSlotMixin = {};
+
+function TRP3_GlanceBarSlotMixin:OnLoad()
+	-- This needs to be deferred to OnLoad as NormalTexture children aren't
+	-- created until after all Layer contents are processed.
+	self.Icon:AddMaskTexture(self.IconMask);
+end
+
+function TRP3_GlanceBarSlotMixin:OnEnter()
+	TRP3_RefreshTooltipForFrame(self);
+end
+
+function TRP3_GlanceBarSlotMixin:OnLeave()
+	TRP3_MainTooltip:Hide();
+end
+
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Glance utils
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -633,7 +650,7 @@ local function displayGlanceSlots()
 				setTooltipForSameFrame(button);
 			end
 
-			Utils.texture.applyRoundTexture("TRP3_GlanceBarSlot" .. i .. "Image", "Interface\\ICONS\\" .. icon);
+			button:SetNormalTexture("Interface\\ICONS\\" .. icon);
 			button.isCurrentMine = isCurrentMine;
 		end
 	end

--- a/totalRP3/Modules/Register/Main/RegisterUIGlance.xml
+++ b/totalRP3/Modules/Register/Main/RegisterUIGlance.xml
@@ -4,7 +4,7 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
-	<Button name="TRP3_GlanceBarSlotTemplate" virtual="true">
+	<Button name="TRP3_GlanceBarSlotTemplate" mixin="TRP3_GlanceBarSlotMixin" virtual="true">
 		<Size x="20" y="20" />
 		<Layers>
 			<Layer level="OVERLAY">
@@ -14,17 +14,20 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						<Anchor point="CENTER" x="8" y="-8" />
 					</Anchors>
 				</Texture>
+				<MaskTexture parentKey="IconMask" file="Interface\CharacterFrame\TempPortraitAlphaMask" hWrapMode="CLAMPTOBLACKADDITIVE" vWrapMode="CLAMPTOBLACKADDITIVE">
+					<Anchors>
+						<Anchor point="TOPLEFT" x="2" y="-2"/>
+						<Anchor point="BOTTOMRIGHT" x="-2" y="2"/>
+					</Anchors>
+				</MaskTexture>
 			</Layer>
 		</Layers>
-		<NormalTexture name="$parentImage" file="Interface\TargetingFrame\UI-TargetingFrame-Seal.blp" />
+		<NormalTexture name="$parentImage" parentKey="Icon" file="Interface\TargetingFrame\UI-TargetingFrame-Seal.blp"/>
 		<HighlightTexture file="Interface\Minimap\UI-Minimap-ZoomButton-Highlight" alphaMode="ADD" />
 		<Scripts>
-			<OnEnter>
-				TRP3_RefreshTooltipForFrame(self);
-			</OnEnter>
-			<OnLeave>
-				TRP3_MainTooltip:Hide();
-			</OnLeave>
+			<OnLoad method="OnLoad"/>
+			<OnEnter method="OnEnter"/>
+			<OnLeave method="OnLeave"/>
 		</Scripts>
 	</Button>
 


### PR DESCRIPTION
Fixes #827. The SetPortraitToTexture API only accepts textures whose size is 64x64 or smaller, whereas MaskTextures support any size.

Previously we guarded this with a pcall check to fall back and show a failure texture (or an unmasked one) if a texture was larger than 64x64 however a variant of WoWUIBugs#393 impacts this API - the pcall will return true implying no error occurred, but instead the error about the texture size will be deferred and raised upon the next call into any widget API - as seen in the ticket.

This also removes the applyRoundTexture utility in general - this requires some changes to Extended.