### PR TITLE
Clear additional fields on characteristics update

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -119,6 +119,9 @@ local function onStart()
 		msp.my['NH'] = nil;
 		msp.my['NI'] = nil;
 		msp.my['PN'] = nil;
+		msp.my['PG'] = nil;
+		msp.my['PR'] = nil;
+		msp.my['PV'] = nil;
 		if dataTab.MI then
 			for _, miscData in pairs(dataTab.MI) do
 				local miscType = TRP3_API.GetMiscInfoTypeFromData(miscData);


### PR DESCRIPTION
These fields were added to the MSP protocol a while back for custom guild names, ranks, and voice reference support, however we've not been clearing them to nil prior to looping over the profile's misc info fields which leads to a case where if a player removes one of these fields from their profile we'll incorrectly still send the old data for that field out via MSP.