### PR TITLE
Request PG, PR, and PV fields via MSP

### DIFF
--- a/totalRP3/Modules/Register/MSP/Fields.lua
+++ b/totalRP3/Modules/Register/MSP/Fields.lua
@@ -8,7 +8,7 @@ local Globals = TRP3_API.globals;
 local module = AddOn_TotalRP3.MSP or {};
 
 module.TOOLTIP_FIELDS = {"CO", "IC", "PX", "RC", "RS", "TR", "PN"};
-module.REQUEST_FIELDS = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "MU", "PE", "PS", "RS", "PN"};
+module.REQUEST_FIELDS = {"TT", "IC", "PG", "PR", "PN", "PV", "CO", "AE", "AG", "AH", "AW", "DE", "HB", "HH", "HI", "MO", "NH", "MU", "PE", "PS", "RS"};
 
 -- Registry of known serializers/deserializers by name.
 local serializers = {};


### PR DESCRIPTION
Kat's implementing these in MRP for 10.2.5, so we should begin requesting them via MSP now.

I've additionally re-organized the list to bring some of the tooltip-adjacent fields closer to the TT entry; an (undocumented) aspect of MSP is that it'll respond with fields in the order that you request them, and currently some of the fields like IC and PN are behind bulk data fields like DE meaning they take a lot longer to come through.