### PR TITLE
Misc preset renaming issues

### DIFF
--- a/totalRP3/Core/ProfileUtil.lua
+++ b/totalRP3/Core/ProfileUtil.lua
@@ -130,9 +130,6 @@ function TRP3_API.GetMiscFields(miscInfo)
 end
 
 function TRP3_API.GetMiscInfoTypeByName(miscName)
-	-- This is a legacy function that will be removed one day.
-	-- Callers should use the GetMiscInfoTypeFromData function instead.
-
 	if miscName == "House name" or miscName == L.REG_PLAYER_MSP_HOUSE then
 		return TRP3_API.MiscInfoType.House;
 	elseif miscName == "Nickname" or miscName == L.REG_PLAYER_MSP_NICK then

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -600,15 +600,9 @@ function TRP3_API.profile.init()
 					-- Misc info ID conversion
 					if data.player and data.player.characteristics and data.player.characteristics.MI then
 						for _, miscData in ipairs(data.player.characteristics.MI) do
-							if not miscData.ID then
-								-- No ID = retrieve ID from name
+							if not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom then
+								-- Adding ID from name if ID missing, or setting a preset to custom if renamed
 								miscData.ID = TRP3_API.GetMiscInfoTypeFromData(miscData);
-							elseif miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-								-- Existing non-custom ID = check name matches ID, convert to custom otherwise
-								local miscInfoData = TRP3_API.GetMiscTypeInfo(miscData.ID)
-								if miscData.NA ~= miscInfoData.localizedName and miscData.NA ~= miscInfoData.englishName then
-									miscData.ID = TRP3_API.MiscInfoType.Custom;
-								end
 							end
 						end
 					end

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -602,7 +602,7 @@ function TRP3_API.profile.init()
 						for _, miscData in ipairs(data.player.characteristics.MI) do
 							if not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom then
 								-- Adding ID from name if ID missing, or setting a preset to custom if renamed
-								miscData.ID = TRP3_API.GetMiscInfoTypeFromData(miscData);
+								miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
 							end
 						end
 					end

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -596,6 +596,22 @@ function TRP3_API.profile.init()
 					if data.player and data.player.about and data.player.about.MU and type(data.player.about.MU) == "string" then
 						profiles[profileID].player.about.MU = Utils.music.convertPathToID(data.player.about.MU);
 					end
+
+					-- Misc info ID conversion
+					if data.player and data.player.characteristics and data.player.characteristics.MI then
+						for _, miscData in ipairs(data.player.characteristics.MI) do
+							if not miscData.ID then
+								-- No ID = retrieve ID from name
+								miscData.ID = TRP3_API.GetMiscInfoTypeFromData(miscData);
+							elseif miscData.ID ~= TRP3_API.MiscInfoType.Custom then
+								-- Existing non-custom ID = check name matches ID, convert to custom otherwise
+								local miscInfoData = TRP3_API.GetMiscTypeInfo(miscData.ID)
+								if miscData.NA ~= miscInfoData.localizedName and miscData.NA ~= miscInfoData.englishName then
+									miscData.ID = TRP3_API.MiscInfoType.Custom;
+								end
+							end
+						end
+					end
 				end
 
 				TRP3_ProfileImport:Hide();

--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -5,7 +5,7 @@ TRP3_API.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 16;
+local SCHEMA_VERSION = 17;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -263,3 +263,27 @@ TRP3_API.flyway.patches["16"] = function()
 	TRP3_Configuration["NamePlates_HideOutOfCharacterUnits"] = nil;
 	TRP3_Configuration["NamePlates_CustomizeFirstName"] = nil;
 end
+
+TRP3_API.flyway.patches["17"] = function()
+	-- Check all non-custom Misc. Info fields
+	-- Names not matching localized or non-localized preset name are turned into custom fields
+
+	if not TRP3_Profiles then
+		return;
+	end
+
+	for _, profile in pairs(TRP3_Profiles) do
+		local miscInfo = SafeGet(profile, "player", "characteristics", "MI");
+
+		if miscInfo then
+			for _, miscData in ipairs(miscInfo) do
+				if miscData.ID ~= TRP3_API.MiscInfoType.Custom then
+					local miscInfo = TRP3_API.GetMiscTypeInfo(miscData.ID)
+					if miscData.NA ~= miscInfo.localizedName and miscData.NA ~= miscInfo.englishName then
+						miscData.ID = TRP3_API.MiscInfoType.Custom;
+					end
+				end
+			end
+		end
+	end
+end

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -278,7 +278,7 @@ TRP3_API.flyway.patches["17"] = function()
 		if miscInfo then
 			for _, miscData in ipairs(miscInfo) do
 				if miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-					miscData.ID = TRP3_API.GetMiscInfoTypeFromData(miscData);
+					miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
 				end
 			end
 		end

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -278,10 +278,7 @@ TRP3_API.flyway.patches["17"] = function()
 		if miscInfo then
 			for _, miscData in ipairs(miscInfo) do
 				if miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-					local miscInfoData = TRP3_API.GetMiscTypeInfo(miscData.ID)
-					if miscData.NA ~= miscInfoData.localizedName and miscData.NA ~= miscInfoData.englishName then
-						miscData.ID = TRP3_API.MiscInfoType.Custom;
-					end
+					miscData.ID = TRP3_API.GetMiscInfoTypeFromData(miscData);
 				end
 			end
 		end

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -278,8 +278,8 @@ TRP3_API.flyway.patches["17"] = function()
 		if miscInfo then
 			for _, miscData in ipairs(miscInfo) do
 				if miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-					local miscInfo = TRP3_API.GetMiscTypeInfo(miscData.ID)
-					if miscData.NA ~= miscInfo.localizedName and miscData.NA ~= miscInfo.englishName then
+					local miscInfoData = TRP3_API.GetMiscTypeInfo(miscData.ID)
+					if miscData.NA ~= miscInfoData.localizedName and miscData.NA ~= miscInfoData.englishName then
 						miscData.ID = TRP3_API.MiscInfoType.Custom;
 					end
 				end

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -1119,14 +1119,14 @@ function setEditDisplay()
 		frame.miscIndex = frameIndex;
 		_G[frame:GetName() .. "Icon"].IC = miscStructure.IC or TRP3_InterfaceIcons.Default;
 		_G[frame:GetName() .. "NameField"]:SetText(miscStructure.NA or loc.CM_NAME);
-		-- Disabling name edition on presets
+		-- Disable name editing on presets
 		if miscStructure.ID == TRP3_API.MiscInfoType.Custom then
 			_G[frame:GetName() .. "NameField"]:Show();
-			_G[frame:GetName() .. "PresetNameText"]:Hide();
+			frame.PresetName:Hide();
 		else
 			_G[frame:GetName() .. "NameField"]:Hide();
-			_G[frame:GetName() .. "PresetNameText"]:Show();
-			_G[frame:GetName() .. "PresetNameText"]:SetText(miscStructure.NA or loc.CM_NAME);
+			frame.PresetName:Show();
+			frame.PresetName:SetText(miscStructure.NA or loc.CM_NAME);
 		end
 		_G[frame:GetName() .. "ValueField"]:SetText(miscStructure.VA or loc.CM_VALUE);
 		refreshEditIcon(_G[frame:GetName() .. "Icon"]);

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -1119,6 +1119,15 @@ function setEditDisplay()
 		frame.miscIndex = frameIndex;
 		_G[frame:GetName() .. "Icon"].IC = miscStructure.IC or TRP3_InterfaceIcons.Default;
 		_G[frame:GetName() .. "NameField"]:SetText(miscStructure.NA or loc.CM_NAME);
+		-- Disabling name edition on presets
+		if miscStructure.ID == TRP3_API.MiscInfoType.Custom then
+			_G[frame:GetName() .. "NameField"]:Show();
+			_G[frame:GetName() .. "PresetNameText"]:Hide();
+		else
+			_G[frame:GetName() .. "NameField"]:Hide();
+			_G[frame:GetName() .. "PresetNameText"]:Show();
+			_G[frame:GetName() .. "PresetNameText"]:SetText(miscStructure.NA or loc.CM_NAME);
+		end
 		_G[frame:GetName() .. "ValueField"]:SetText(miscStructure.VA or loc.CM_VALUE);
 		refreshEditIcon(_G[frame:GetName() .. "Icon"]);
 		frame:ClearAllPoints();

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -55,12 +55,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 		<Layers>
 			<Layer level="OVERLAY">
-				<FontString name="$parentPresetNameText" parentKey="PresetName" text="[preset]" inherits="GameFontNormal" justifyH="LEFT">
+				<FontString parentKey="PresetName" text="[preset]" inherits="GameFontHighlight" justifyH="LEFT">
 					<Size x="100" y="18"/>
 					<Anchors>
 						<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="$parentIcon"/>
 					</Anchors>
-					<Color r="1.0" g="1.0" b="1.0"/>
 				</FontString>
 			</Layer>
 		</Layers>

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -53,6 +53,17 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 			</Button>
 		</Frames>
+		<Layers>
+			<Layer level="OVERLAY">
+				<FontString name="$parentPresetNameText" parentKey="PresetName" text="[preset]" inherits="GameFontNormal" justifyH="LEFT">
+					<Size x="100" y="18"/>
+					<Anchors>
+						<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="$parentIcon"/>
+					</Anchors>
+					<Color r="1.0" g="1.0" b="1.0"/>
+				</FontString>
+			</Layer>
+		</Layers>
 	</Frame>
 
 	<!-- Register characteristics psycho line jauge -->


### PR DESCRIPTION
Fixes #834.

Preset misc info names can no longer be edited, and a flyway patch will convert preset fields to custom fields if they have been renamed.

Imported profiles from before the ID conversion were also not given the new ID, this is now fixed, along with the same custom field conversion if there is an ID not matching the name.