### PR TITLE
Make icons larger again

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -443,7 +443,7 @@ local function openGlanceEditor(slot, slotData, callback, external, arg1, arg2)
 	TRP3_AtFirstGlanceEditorIcon:SetScript("OnClick", function(self)
 		TRP3_API.popup.hideIconBrowser();
 		if self.isExternal then
-			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = TRP3_AtFirstGlanceEditor, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected, nil, 0.75, TRP3_AtFirstGlanceEditorIcon.icon});
+			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, {parent = TRP3_AtFirstGlanceEditor, point = "RIGHT", parentPoint = "LEFT"}, {onIconSelected, nil, nil, TRP3_AtFirstGlanceEditorIcon.icon});
 		else
 			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, nil, {onIconSelected, nil, nil, TRP3_AtFirstGlanceEditorIcon.icon});
 		end

--- a/totalRP3/UI/Browsers/IconBrowser.lua
+++ b/totalRP3/UI/Browsers/IconBrowser.lua
@@ -534,12 +534,12 @@ function TRP3_IconBrowserMixin:OnLoad()
 	local GRID_PADDING = 4;
 
 	local scrollBoxAnchorsWithBar = {
-		AnchorUtil.CreateAnchor("TOPLEFT", self.Content, "TOPLEFT", 8, -4),
+		AnchorUtil.CreateAnchor("TOPLEFT", self.Content, "TOPLEFT", 12, -4),
 		AnchorUtil.CreateAnchor("BOTTOMRIGHT", self.Content, "BOTTOMRIGHT", -10, 4),
 	};
 
 	local scrollBoxAnchorsWithoutBar = {
-		AnchorUtil.CreateAnchor("TOPLEFT", self.Content, "TOPLEFT", 16, -4),
+		AnchorUtil.CreateAnchor("TOPLEFT", self.Content, "TOPLEFT", 20, -4),
 		AnchorUtil.CreateAnchor("BOTTOMRIGHT", self.Content, "BOTTOMRIGHT", -17, -4),
 	};
 

--- a/totalRP3/UI/Browsers/IconBrowser.lua
+++ b/totalRP3/UI/Browsers/IconBrowser.lua
@@ -530,7 +530,7 @@ function TRP3_IconBrowserMixin:OnLoad()
 	self.selectionModel = CreateIconBrowserSelectionModel(self.baseModel);
 	self.filterModel = CreateIconBrowserFilterModel(self.selectionModel);
 
-	local GRID_STRIDE = 10;
+	local GRID_STRIDE = 8;
 	local GRID_PADDING = 4;
 
 	local scrollBoxAnchorsWithBar = {

--- a/totalRP3/UI/Browsers/IconBrowser.xml
+++ b/totalRP3/UI/Browsers/IconBrowser.xml
@@ -15,7 +15,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	</AnimationGroup>
 
 	<CheckButton name="TRP3_IconBrowserButtonTemplate" mixin="TRP3_IconBrowserButtonMixin" virtual="true">
-		<Size x="36" y="36"/>
+		<Size x="44" y="44"/>
 		<HitRectInsets left="2" right="2" top="2" bottom="2"/>
 		<Layers>
 			<Layer level="BACKGROUND">


### PR DESCRIPTION
This increases the size of the icons by 8x8 in both dimensions so that we're now only 2x2 smaller in each compared to before the rework. Additionally the downscaling of the icon browser has been disabled for the glance popout editor.