### PR TITLE
Make tooltip fonts alphabet-aware

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -580,6 +580,7 @@ stds.wow = {
 		"GameFontNormalHuge3",
 		"GameFontNormalLarge",
 		"GameTooltip",
+		"GameTooltipText",
 		"GridLayoutMixin",
 		"MapCanvasDataProviderMixin",
 		"NamePlateDriverFrame",

--- a/Types/Game.d.lua
+++ b/Types/Game.d.lua
@@ -37,3 +37,13 @@ function string.splittable(delimiter, str, pieces) end
 ---@param str string
 ---@return string str
 function string.trim(str) end
+
+---@class TooltipTextureInfo
+---@field width number? can be 0 to use actual texture width
+---@field height number? can be 0 to use actual texture width
+---@field anchor Enum.TooltipTextureAnchor?
+---@field region Enum.TooltipTextureRelativeRegion?
+---@field verticalOffset number?
+---@field margin { left: number?, right: number?, top: number?, bottom: number? }?
+---@field texCoords { left: number?, right: number?, top: number?, bottom: number? }?
+---@field vertexColor ColorMixin

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -11,14 +11,6 @@ local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local loc = TRP3_API.loc;
 
--- WOW imports
-local pcall, tostring, pairs, type, print, string, date, math, strconcat, wipe, tonumber = pcall, tostring, pairs, type, print, string, date, math, strconcat, wipe, tonumber;
-local strsplit, strtrim = strsplit, strtrim;
-local tinsert, assert, tremove, next = tinsert, assert, tremove, next;
-local UnitFullName = UnitFullName;
-local UNKNOWNOBJECT = UNKNOWNOBJECT;
-local getZoneText, getSubZoneText = GetZoneText, GetSubZoneText;
-
 function Utils.pcall(func, ...)
 	if func then
 		return {pcall(func, ...)};
@@ -110,25 +102,6 @@ function Utils.table.keys(table)
 		tinsert(keys, key);
 	end
 	return keys;
-end
-
--- Create a weak tables pool.
-local TABLE_POOL = setmetatable( {}, { __mode = "k" } );
-
--- Return an already created table, or a new one if the pool is empty
--- It ultra mega important to release the table once you finished using it !
-function Utils.table.getTempTable()
-	local t = next( TABLE_POOL );
-	if t then
-		TABLE_POOL[t] = nil;
-		return wipe(t);
-	end
-	return {};
-end
-
--- Release a temp table.
-function Utils.table.releaseTempTable(table)
-	TABLE_POOL[ table ] = true;
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -315,9 +288,9 @@ function Utils.str.nilToEmpty(text)
 end
 
 function Utils.str.buildZoneText()
-	local text = getZoneText() or ""; -- assuming that there is ALWAYS a zone text. Don't know if it's true.
-	if getSubZoneText():len() > 0 then
-		text = strconcat(text, " - ", getSubZoneText());
+	local text = GetZoneText() or ""; -- assuming that there is ALWAYS a zone text. Don't know if it's true.
+	if GetSubZoneText():len() > 0 then
+		text = strconcat(text, " - ", GetSubZoneText());
 	end
 	return text;
 end

--- a/totalRP3/UI/FontUtil.lua
+++ b/totalRP3/UI/FontUtil.lua
@@ -1,0 +1,97 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+--- Enumeration of valid font alphabets. These strings match the tokens used
+--- in XML FontFamily definitions.
+---@alias TRP3.FontAlphabet "roman" | "korean" | "simplifiedchinese" | "traditionalchinese" | "russian"
+
+---@type { [TRP3.FontAlphabet]: string }
+local AlphabetTexts = {
+	["roman"] = "T",
+	["korean"] = "더",
+	["simplifiedchinese"] = "這",
+	["traditionalchinese"] = "以",
+	["russian"] = "Э",
+};
+
+TRP3_FontUtil = {};
+
+local DummyFontString = UIParent:CreateFontString();
+
+--- Obtains the font face, height, and flags that would be selected from a
+--- font object based upon an alphabet.
+---
+---@param font FontObject The font family to query.
+---@param alphabet TRP3.FontAlphabet The alphabet to query.
+function TRP3_FontUtil.GetFontForAlphabet(font, alphabet)
+	DummyFontString:SetFontObject(font);
+	DummyFontString:SetText(AlphabetTexts[alphabet]);
+	return DummyFontString:GetFontObject():GetFont();
+end
+
+--- Obtains the font face, height, and flags that would be selected from a
+--- font object if the supplied text were used.
+---
+---@param font FontObject The font family to query.
+---@param text string The text to test.
+function TRP3_FontUtil.GetFontForText(font, text)
+	DummyFontString:SetFontObject(font);
+	DummyFontString:SetText(text);
+	return DummyFontString:GetFontObject():GetFont();
+end
+
+--- Replaces the font used by a specific alphabet within a font family.
+---
+--- If the height or flags parameters are nil, the existing values for the
+--- current font will be retained.
+---
+---@param font FontObject The font family to modify.
+---@param alphabet TRP3.FontAlphabet The alphabet to change the font of.
+---@param file string? The desired font face for this alphabet.
+---@param height number? The desired font height for this alphabet.
+---@param flags string? The desired font flags for this alphabet.
+function TRP3_FontUtil.SetFontForAlphabet(font, alphabet, file, height, flags)
+	DummyFontString:SetFontObject(font);
+	DummyFontString:SetText(AlphabetTexts[alphabet]);
+
+	local alphabetFont = DummyFontString:GetFontObject();
+	local alphabetFile, alphabetHeight, alphabetFlags = alphabetFont:GetFont();
+
+	alphabetFont:SetFont(file or alphabetFile, height or alphabetHeight, flags or alphabetFlags);
+end
+
+--- Changes the height and outlining options for all alphabet members of a
+--- supplied font family.
+---
+--- If the height or flags parameters are nil, the existing values for the
+--- current fonts will be retained.
+---
+---@param font FontObject The font family to modify.
+---@param height number? The desired height to apply to all family members.
+---@param flags string? The desired flags to apply to all family members.
+function TRP3_FontUtil.SetFontOptions(font, height, flags)
+	local file = nil;
+
+	TRP3_FontUtil.SetFontForAlphabet(font, "roman", file, height, flags);
+	TRP3_FontUtil.SetFontForAlphabet(font, "korean", file, height, flags);
+	TRP3_FontUtil.SetFontForAlphabet(font, "simplifiedchinese", file, height, flags);
+	TRP3_FontUtil.SetFontForAlphabet(font, "traditionalchinese", file, height, flags);
+	TRP3_FontUtil.SetFontForAlphabet(font, "russian", file, height, flags);
+end
+
+--- Changes the height and outlining options applied to a font string.
+---
+--- This function picks an appropriate font family from the supplied font
+--- object based upon the current text content of the string.
+---
+--- If the height or flags parameters are nil, the existing values for the
+--- selected font will be retained.
+---
+---@param fontString FontString The font string to change the font of.
+---@param font FontObject The font object to select a font face from.
+---@param height number? The desired height of the font.
+---@param flags string? The desired flags of the font.
+function TRP3_FontUtil.SetFontStringOptions(fontString, font, height, flags)
+	local alphabetFile, alphabetHeight, alphabetFlags = TRP3_FontUtil.GetFontForText(font, fontString:GetText());
+	fontString:SetFont(alphabetFile, height or alphabetHeight, flags or alphabetFlags);
+end

--- a/totalRP3/UI/TooltipUtil.lua
+++ b/totalRP3/UI/TooltipUtil.lua
@@ -1,0 +1,105 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+---@type { [GameTooltip]: { left: FontString?, right: FontString? }[] }
+local TooltipFontStrings = setmetatable({}, { __index = function(t, k) t[k] = {}; return t[k]; end });
+
+local function GetTooltipFontStrings(tooltip, numLines)
+	local fontstrings = TooltipFontStrings[tooltip];
+
+	for i = #fontstrings + 1, numLines do
+		local left  = tooltip["TextLeft" .. i]  or _G[tooltip:GetName() .. "TextLeft" .. i];
+		local right = tooltip["TextRight" .. i] or _G[tooltip:GetName() .. "TextRight" .. i];
+
+		if not left and not right then
+			break
+		end
+
+		fontstrings[i] = { left = left, right = right };
+	end
+
+	return fontstrings;
+end
+
+TRP3_TooltipUtil = {};
+
+--- Returns the left and right fontstrings of a tooltip line, if present.
+---@param tooltip GameTooltip The tooltip frame to query.
+---@param line integer? The line index to obtain fontstrings for.
+function TRP3_TooltipUtil.GetLineFontStrings(tooltip, line)
+	local fontstrings = GetTooltipFontStrings(tooltip, line)[line];
+
+	if fontstrings then
+		return fontstrings.left, fontstrings.right;
+	end
+end
+
+local function NextLineFontStrings(tooltip, line)
+	line = line + 1;
+	local left, right = TRP3_TooltipUtil.GetLineFontStrings(tooltip, line);
+
+	if left or right then
+		return line, left, right;
+	end
+end
+
+--- Obtains an iterator for enumerating over the fontstrings in a tooltip.
+---@param tooltip GameTooltip The tooltip frame to query.
+---@param line integer? The line index to begin enumerating from.
+function TRP3_TooltipUtil.EnumerateFontStrings(tooltip, line)
+	return NextLineFontStrings, tooltip, line or 0;
+end
+
+--- Adds a single line to the tooltip.
+---@param tooltip GameTooltip The tooltip frame to append to.
+---@param text string The text to display on the line.
+---@param options TRP3_TooltipUtil.LineOptions? Options for this line.
+function TRP3_TooltipUtil.AddLine(tooltip, text, options)
+	local wrap = options and options.wrap or false;
+	local color = options and options.color or NORMAL_FONT_COLOR;
+
+	local r, g, b = color:GetRGB();
+	tooltip:AddLine(text, r, g, b, wrap);
+end
+
+--- Adds a two-column line to the tooltip.
+---@param tooltip GameTooltip The tooltip frame to append to.
+---@param textLeft string The text to display on the left side of the line.
+---@param textRight string The text to display on the right side of the line.
+---@param options TRP3_TooltipUtil.DoubleLineOptions? Options for this line.
+function TRP3_TooltipUtil.AddDoubleLine(tooltip, textLeft, textRight, options)
+	local colorLeft = options and (options.colorLeft or options.color) or NORMAL_FONT_COLOR;
+	local colorRight = options and (options.colorRight or options.color) or NORMAL_FONT_COLOR;
+
+	local rL, gL, bL = colorLeft:GetRGB();
+	local rR, gR, bR = colorRight:GetRGB();
+
+	tooltip:AddDoubleLine(textLeft, textRight, rL, gL, bL, rR, gR, bR);
+end
+
+--- Adds a blank line to the tooltip.
+---@param tooltip GameTooltip The tooltip frame to append to.
+function TRP3_TooltipUtil.AddBlankLine(tooltip)
+	tooltip:AddLine(" ");
+end
+
+function TRP3_TooltipUtil.SetLineFontOptions(tooltip, line, height, flags)
+	local fontStringLeft, fontStringRight = TRP3_TooltipUtil.GetLineFontStrings(tooltip, line);
+
+	if fontStringLeft then
+		TRP3_FontUtil.SetFontStringOptions(fontStringLeft, GameTooltipText, height, flags);
+	end
+
+	if fontStringRight then
+		TRP3_FontUtil.SetFontStringOptions(fontStringRight, GameTooltipText, height, flags);
+	end
+end
+
+---@class TRP3_TooltipUtil.LineOptions
+---@field color ColorMixin? The color to apply to the line.
+---@field wrap boolean? If true, automatically wrap text on the line.
+
+---@class TRP3_TooltipUtil.DoubleLineOptions
+---@field color ColorMixin? The color to apply to both sides of the line.
+---@field colorLeft ColorMixin? The color to apply to the left side of the line.
+---@field colorRight ColorMixin? The color to apply to the right side of the line.

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -9,6 +9,8 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="ScrollingEditBox.xml"/>
 	<Include file="FocusRegion.xml"/>
 	<Include file="StyledButton.xml"/>
+	<Include file="FontUtil.lua"/>
+	<Include file="TooltipUtil.lua"/>
 	<Include file="UIButton.xml"/>
 	<Include file="Widgets.lua"/>
 


### PR DESCRIPTION
Currently, our tooltips don't behave all too well when dealing with mixed-languages due to API deficiencies around the SetFont API.

If we view a profile in a tooltip in one language - say English - then the tooltip becomes generally unable to view profiles written in other languages, as the SetFont call to customize line heights breaks the alphabet switching logic present in the original font objects used by each tooltip line.

This work resolves that issue, making it possible to use the correct font based upon the content of a line whilst still allowing us to change the height/flags of individual lines.

A few new utilities have been added to manipulate fontstrings and font objects in a way that's alphabet-aware, and a set of new tooltip utilities have been added which make use of this.

The existing tooltip builder logic has also been slightly refactored; it no longer buffers lines up internally and instead just writes directly to a tooltip - there's no real benefit from the existing buffer logic, aside from making it take twice as long to generate a tooltip as we effectively need to run over 2n lines. It remains API compatible with all existing usages.

The temporary table utilities have been blown from orbit as they're no longer used, and to appease the luacheck gods a small cleanup of a few wholly unnecessary upvalues has occurred.

---

Some screenshot examples;

1. The first screenshot below is from the current version; I opened another players tooltip first and then my own which has special characters - the end result is my own tooltip displays incorrectly.
2. The second screenshot is with these changes applied; the same process above correctly displays my tooltip.

![Example 1 - Broken](https://github.com/Total-RP/Total-RP-3/assets/287102/185ad778-8487-485a-b7b4-e426ee475a19)
![Example 1 - Fixed](https://github.com/Total-RP/Total-RP-3/assets/287102/8179fb18-1db9-4ed1-a631-ca78580e9c8d)

The below screenshots show the effect in reverse as well - on the current version, mousing over my tooltip first in a session with special characters in my title has the effect of breaking other players tooltips if they've got certain characters in their title.

![Example 2 - Broken](https://github.com/Total-RP/Total-RP-3/assets/287102/3f874415-47c2-444d-93de-ded1638642fa)
![Example 2 - Fixed](https://github.com/Total-RP/Total-RP-3/assets/287102/b996abe0-3bfa-403c-8463-91e5177e94d3)

