### PR TITLE
Fix handling of unknown music names

### DIFF
--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -916,16 +916,19 @@ function Utils.music.playMusic(music, source)
 end
 
 function Utils.music.getTitle(musicURL)
-	if type(musicURL) == "number" then
-		musicURL = LibRPMedia:GetMusicNameByFile(musicURL);
-	end
-
+	local musicName;
 	local musicTitle;
-	if musicURL then
-		musicTitle = musicURL:match("[%/]?([^%/]+)$");
+
+	if type(musicURL) == "number" then
+		musicName = LibRPMedia:GetMusicNameByFile(musicURL);
 	end
 
-	return musicTitle or musicURL;
+	if not musicName then
+		musicName = format("<File: %s>", tostring(musicURL));
+	end
+
+	musicTitle = musicName:match("[%/]?([^%/]+)$");
+	return musicTitle or musicName;
 end
 
 function Utils.music.convertPathToID(musicURL)


### PR DESCRIPTION
If a profile is received from a player who has selected profile music from a newer version of LibRPMedia, then the GetMusicNameByFile API will return nil.

This results in a few errors with the target bar when the player is targeted (we attempt to format a nil value into a string), and in the About page we don't display any name at all for the music.

This adds a fallback to the Utils.music.getTitle function so that in cases where no name can be obtained, we'll instead use a temporary string that at least shows _something_ and prevents errors.