### PR TITLE
Don't send MSP requests for pets on mouseover

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -518,7 +518,9 @@ local function onStart()
 			end
 		end
 	end);
-	TRP3_API.RegisterCallback(TRP3_Addon, Events.MOUSE_OVER_CHANGED, function(_, unitID) TRP3_API.r.sendMSPQuery(unitID); end);
+	TRP3_API.RegisterCallback(TRP3_Addon, Events.MOUSE_OVER_CHANGED, function(_, unitID, targetMode)
+		TRP3_API.r.sendMSPQuery(unitID, targetMode);
+	end);
 end
 
 function TRP3_API.r.sendMSPQuery(name, targetMode)


### PR DESCRIPTION
Whenever the player mouses over a companion pet, we seem to be sending an MSP request using the companion ID. Oddly enough, MSP requests sent to players with names like "Xxillidanxx-MoonGuard_Wiggles" always fail, so we've wasted a bit of comms bandwidth having ever queued such a request and are generating unnecessary CHAT_MSG_SYSTEM events when the server replies to us saying such a player doesn't exist.

As the MSP request function already has a targetMode parameter that's completely unused by all call sites and the 'MOUSE_OVER_CHANGED' event tells us the mode, we can just err... pass it in and completely avoid sending such unnecessary requests.