### PR TITLE
Fix numeric sequencing of chat links

### DIFF
--- a/totalRP3/Modules/ChatLinks/ChatLinksManager.lua
+++ b/totalRP3/Modules/ChatLinks/ChatLinksManager.lua
@@ -12,11 +12,16 @@ local sentChatLinks, openedChatLinks = {}, {};
 ---@param chatLink ChatLink
 function ChatLinksManager:StoreSentLink(chatLink)
 	local tries = 1;
-	while sentChatLinks[chatLink:GetIdentifier()] do
-		chatLink:SetIdentifier(chatLink:GetIdentifier() .. tries);
+	local stem = chatLink:GetIdentifier();
+	local identifier = stem;
+
+	while sentChatLinks[identifier] do
 		tries = tries + 1;
+		identifier = strjoin(" ", stem, tries);
 	end
-	sentChatLinks[chatLink:GetIdentifier()] = chatLink;
+
+	chatLink:SetIdentifier(identifier);
+	sentChatLinks[identifier] = chatLink;
 end
 
 ---@return ChatLink


### PR DESCRIPTION
When generating a chat link that conflicted with a pre-existing identifier, we'd attempt to uniquify it by appending an incrementing number.

The problem however is that if the identifier collided two or more times, we'd continue appending to the already-appended identifier, resulting in strings like "My Profile12" if two links for that profile had previously been generated.

This commit fixes that so that we now suffix links in incrementing order properly, eg. "My Profile", "My Profile 1", "My Profile 2", and so on.