### PR TITLE
Don't probe LRPM with invalid icon names

### DIFF
--- a/totalRP3/UI/Browsers/IconBrowser.lua
+++ b/totalRP3/UI/Browsers/IconBrowser.lua
@@ -172,6 +172,10 @@ end
 ---@param name string
 ---@return integer? index
 function IconBrowserModel:GetIconIndex(name)
+	if not name or name == "" then
+		return nil;
+	end
+
 	return LibRPMedia:GetIconIndexByName(name);
 end
 


### PR DESCRIPTION
LRPM won't allow searching for nil icon names to begin with. Also handling empty strings and short-circuiting them into returning a nil index as these would never match anything anyway,