### PR TITLE
Update phased zone constants for garrisons

### DIFF
--- a/totalRP3/Modules/Map/Map.lua
+++ b/totalRP3/Modules/Map/Map.lua
@@ -11,8 +11,8 @@ local Map = {};
 -- These are the map IDs for zones that have a phase personal to the user (garrisons)
 -- TODO Update with BfA zones ID
 local PERSONAL_PHASED_ZONES = {
-	971, -- Alliance garrison
-	976  -- Horde garrison
+	582, -- Lunarfall (Alliance garrison)
+	590, -- Frostwall (Horde garrison)
 };
 
 ---@return number mapID @ The ID of the zone where the player currently is


### PR DESCRIPTION
The UiMap IDs we have embedded for garrison detection are completely out-of-touch with reality.

The IDs we presently have are for Telogrus Rift (971), and Tol Dagor (976). Consequently this means that one cannot launch a map scan while standing in any of those zones, as we're testing the wrong constants.

Additionally - this phase culling logic is using the players' own zone rather than the one they actually scanned, but that'll be fixed separately.