### PR TITLE
Use displayed map ID for culling

### DIFF
--- a/totalRP3/Modules/Map/Map.lua
+++ b/totalRP3/Modules/Map/Map.lua
@@ -34,13 +34,13 @@ end
 ---@param target string @ A valid unit token
 ---@param targetHasWarModeEnabled bool|nil @ Indicate if the target has War Mode enabled or not. If nil, the check for War Mode will be ignored.
 ---@return boolean canSeeTarget @ Return true if the player can see the target, or false if something like phases prevent them from seeing each other.
-function Map.playerCanSeeTarget(target, targetHasWarModeEnabled)
+function Map.playerCanSeeTarget(target, targetHasWarModeEnabled, targetMapID)
 	-- Players should not see themselves (answer their own requests), except if in DEBUG_MODE, for testing
 	if target == TRP3_API.globals.player_id and not TRP3_API.globals.DEBUG_MODE then
 		return false;
 	end
 	local currentMapID = Map.getPlayerMapID();
-	if tContains(PERSONAL_PHASED_ZONES, currentMapID) then
+	if tContains(PERSONAL_PHASED_ZONES, targetMapID or currentMapID) then
 		-- If the player is in a personal phased zone, the target has to be in their group to be seen
 		return UnitInParty(Ambiguate(target, "none"));
 	end

--- a/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
@@ -203,13 +203,13 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					local hasWarModeActive = (not TRP3_ClientFeatures.WarMode) or C_PvP.IsWarModeActive();
 					local roleplayStatus = AddOn_TotalRP3.Player.GetCurrentUser():GetRoleplayStatus();
 
-					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, hasWarModeActive, roleplayStatus);
+					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, hasWarModeActive, roleplayStatus, playerMapID);
 				end
 			end
 		end
 	end)
 
-	broadcast.registerP2PCommand(SCAN_COMMAND, function(sender, x, y, hasWarModeActive, roleplayStatus)
+	broadcast.registerP2PCommand(SCAN_COMMAND, function(sender, x, y, hasWarModeActive, roleplayStatus, senderMapID)
 		-- Parameters received from commands are strings, need to cast to appropriate types
 		hasWarModeActive = (hasWarModeActive == "true");
 		roleplayStatus = tonumber(roleplayStatus);
@@ -225,7 +225,12 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			roleplayStatus = AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.IN_CHARACTER;
 		end
 
-		if Map.playerCanSeeTarget(sender, checkWarMode) and ShouldShowRoleplayStatus(roleplayStatus) and lastScannerUsed then
+		if not senderMapID then
+			-- Compatibility for versions older than 2.8.1; hope they can swim.
+			senderMapID = 1156;
+		end
+
+		if Map.playerCanSeeTarget(sender, checkWarMode, senderMapID) and ShouldShowRoleplayStatus(roleplayStatus) and lastScannerUsed then
 			lastScannerUsed:OnScanDataReceived(sender, x, y, {
 				hasWarModeActive = hasWarModeActive,
 				roleplayStatus = roleplayStatus,

--- a/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
@@ -226,7 +226,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		end
 
 		if not senderMapID then
-			-- Compatibility for versions older than 2.8.1; hope they can swim.
+			-- Compatibility for versions older than 2.8.2; hope they can swim.
 			senderMapID = 1156;
 		end
 

--- a/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
+++ b/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapScanner.lua
@@ -203,13 +203,13 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					local hasWarModeActive = (not TRP3_ClientFeatures.WarMode) or C_PvP.IsWarModeActive();
 					local roleplayStatus = AddOn_TotalRP3.Player.GetCurrentUser():GetRoleplayStatus();
 
-					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, hasWarModeActive, roleplayStatus, playerMapID);
+					broadcast.sendP2PMessage(sender, SCAN_COMMAND, x, y, hasWarModeActive, roleplayStatus);
 				end
 			end
 		end
 	end)
 
-	broadcast.registerP2PCommand(SCAN_COMMAND, function(sender, x, y, hasWarModeActive, roleplayStatus, senderMapID)
+	broadcast.registerP2PCommand(SCAN_COMMAND, function(sender, x, y, hasWarModeActive, roleplayStatus)
 		-- Parameters received from commands are strings, need to cast to appropriate types
 		hasWarModeActive = (hasWarModeActive == "true");
 		roleplayStatus = tonumber(roleplayStatus);
@@ -225,12 +225,8 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			roleplayStatus = AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.IN_CHARACTER;
 		end
 
-		if not senderMapID then
-			-- Compatibility for versions older than 2.8.2; hope they can swim.
-			senderMapID = 1156;
-		end
-
-		if Map.playerCanSeeTarget(sender, checkWarMode, senderMapID) and ShouldShowRoleplayStatus(roleplayStatus) and lastScannerUsed then
+		local scannedMapID = Map.getDisplayedMapID()
+		if Map.playerCanSeeTarget(sender, checkWarMode, scannedMapID) and ShouldShowRoleplayStatus(roleplayStatus) and lastScannerUsed then
 			lastScannerUsed:OnScanDataReceived(sender, x, y, {
 				hasWarModeActive = hasWarModeActive,
 				roleplayStatus = roleplayStatus,


### PR DESCRIPTION
Currently when a map scan response is received from another player, we attempt to cull responses if they're sitting in a phased zone while not part of our group.

The issue is that we're performing this culling based off *our* zone, not theirs, so scanning a phased map like a garrison has different results based upon whether or not you are actually in the same map.

We now test against the currently displayed map ID, rather than the one the player is actually sitting in.