### PR TITLE
Add manual workflow for force-uploading translations

### DIFF
--- a/.github/workflows/upload_all_translations.yml
+++ b/.github/workflows/upload_all_translations.yml
@@ -1,0 +1,33 @@
+---
+name: Upload All Translations
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Upload CurseForge Translations
+        run: make translations/upload-all
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+
+      - name: Send Webhook Notification
+        if: failure()
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        env:
+          JOB_STATUS: ${{ job.status }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,8 @@ translations/download:
 translations/upload:
 	$(PYTHON) .github/scripts/localization.py --project-id=$(CF_PROJECT_ID) --locale-dir=$(LOCALE_DIR) upload
 
+translations/upload-all:
+	$(PYTHON) .github/scripts/localization.py --project-id=$(CF_PROJECT_ID) --locale-dir=$(LOCALE_DIR) upload -l "*"
+
 .github/scripts/ui.xsd: .FORCE
 	curl -s $(SCHEMA_URL) -o $@


### PR DESCRIPTION
In theory this PR adds the necessary crap to trigger a forced replacement of all locales on CF with the contents of the files in our repo.

The main use for this is for cases where we need to batch-edit a bunch of strings at once and don't want to suffer through the torturous hellscape that is CF's localization "UI".

No clue if this even works but it looked like it wasn't going to do anything _wrong_ at least. Blame Ghost if it's broken.