### PR TITLE
Hide the spinner on companion tooltips

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1082,6 +1082,7 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 	-- Build tooltip
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
+	SetProgressSpinnerShown(ui_CharacterTT, false);
 	tooltipBuilder:Build();
 end
 


### PR DESCRIPTION
"So we're going to have two tooltips - one for characters and one for companions."

"The companion tooltip is for pets and mounts, right?"

":|"

"Right?"