### PR TITLE
Re-add support for linking companions on Classic

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -306,6 +306,7 @@ stds.wow = {
 				"IsPetTypeChecked",
 				"SetAllPetSourcesChecked",
 				"SetAllPetTypesChecked",
+				"SetCustomName",
 				"SetFilterChecked",
 				"SetPetSortParameter",
 				"SetPetSourceChecked",

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -528,7 +528,6 @@ local function decorateCompanion(button, index)
 	local tooltipTitle = "|T" .. icon .. ":40|t " .. name;
 	local tooltipText = text;
 
-
 	-- For Retail clients we strongly recommend that battle pets be renamed
 	-- to be bound, but this is only possible there and not in Classic.
 

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -524,8 +524,22 @@ local function decorateCompanion(button, index)
 	if description and description:len() > 0 then
 		text = text .. "\n\"" .. description .. "\"";
 	end
-	setTooltipForFrame(button, TRP3_CompanionBrowser, "RIGHT", 0, -100,
-		"|T" .. icon .. ":40|t " .. name, text);
+
+	local tooltipTitle = "|T" .. icon .. ":40|t " .. name;
+	local tooltipText = text;
+
+
+	-- For Retail clients we strongly recommend that battle pets be renamed
+	-- to be bound, but this is only possible there and not in Classic.
+
+	if C_PetJournal and C_PetJournal.SetCustomName and (name == speciesName) then
+		button.RenameWarning:Show();
+		tooltipText = tooltipText .. "|n|n" .. TRP3_API.loc.UI_COMPANION_BROWSER_RENAME_WARNING;
+	else
+		button.RenameWarning:Hide();
+	end
+
+	setTooltipForFrame(button, TRP3_CompanionBrowser, "RIGHT", 0, -100, tooltipTitle, tooltipText);
 	button.index = index;
 end
 
@@ -617,13 +631,20 @@ local function SearchFilterPredicate(value, filter)
 end
 
 local function CollectBattlePets(filter)
+	local uniquePetNames = {};
+
 	local function CollectUnfilteredBattlePets()
 		local battlePets = {};
 
 		for i = 1, GetNumPets() do
-			local _, _, _, customName, _, _, _, speciesName, icon, _, _, _, description = GetPetInfoByIndex(i);
+			local _, _, owned, customName, _, _, _, speciesName, icon, _, _, _, description = GetPetInfoByIndex(i);
 
-			if SearchFilterPredicate(customName, filter) then
+			if not customName or customName == "" then
+				customName = speciesName
+			end
+
+			if owned and not uniquePetNames[customName] and SearchFilterPredicate(customName, filter) then
+				uniquePetNames[customName] = true;
 				table.insert(battlePets, { customName, icon, description, speciesName });
 			end
 		end
@@ -634,6 +655,19 @@ local function CollectBattlePets(filter)
 	return CallWithUnfilteredPetJournal(CollectUnfilteredBattlePets);
 end
 
+local function BattlePetNameComparator(a, b)
+	local customNameA = a[1]
+	local customNameB = b[1]
+	local isRenamedA = customNameA ~= a[4]
+	local isRenamedB = customNameB ~= b[4]
+
+	if isRenamedA ~= isRenamedB then
+		return isRenamedA;
+	else
+		return strcmputf8i(customNameA, customNameB) < 0;
+	end
+end
+
 local function getWoWCompanionFilteredList(filter)
 	local count = 0;
 	wipe(filteredCompanionList);
@@ -642,6 +676,7 @@ local function getWoWCompanionFilteredList(filter)
 		-- Battle pets
 		Mixin(filteredCompanionList, CollectBattlePets(filter));
 		count = #filteredCompanionList;
+		table.sort(filteredCompanionList, BattlePetNameComparator);
 	elseif currentCompanionType == TRP3_Enums.UNIT_TYPE.MOUNT then
 		-- Mounts
 		for _, id in pairs(GetMountIDs()) do
@@ -652,9 +687,9 @@ local function getWoWCompanionFilteredList(filter)
 				count = count + 1;
 			end
 		end
+		table.sort(filteredCompanionList, nameComparator);
 	end
 
-	table.sort(filteredCompanionList, nameComparator);
 
 	return count;
 end
@@ -690,7 +725,6 @@ local function initCompanionBrowser()
 
 	TRP3_CompanionBrowserFilterBox:SetScript("OnTextChanged", filteredCompanionBrowser);
 	TRP3_CompanionBrowserClose:SetScript("OnClick", onCompanionClose);
-	setTooltipForSameFrame(TRP3_CompanionBrowserFilterHelp, "TOPLEFT", 0, 0, loc.UI_COMPANION_BROWSER_HELP ,loc.UI_COMPANION_BROWSER_HELP_TT);
 
 	TRP3_CompanionBrowserFilterBoxText:SetText(loc.UI_FILTER);
 end
@@ -699,19 +733,8 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 	currentCompanionType = companionType or TRP3_Enums.UNIT_TYPE.BATTLE_PET;
 	if currentCompanionType == TRP3_Enums.UNIT_TYPE.BATTLE_PET then
 		TRP3_CompanionBrowserTitle:SetText(loc.REG_COMPANION_BROWSER_BATTLE);
-		TRP3_RefreshTooltipForFrame(TRP3_CompanionBrowserFilterHelp);
-
-		-- For Retail clients we have a restriction that battle pets
-		-- must be renamed to be bound, this is communicated in a help tooltip
-		-- but isn't relevant for Classic so it's hidden there.
-		if C_PetJournal then
-			TRP3_CompanionBrowserFilterHelp:Show();
-		else
-			TRP3_CompanionBrowserFilterHelp:Hide();
-		end
 	else
 		TRP3_CompanionBrowserTitle:SetText(loc.REG_COMPANION_BROWSER_MOUNT);
-		TRP3_CompanionBrowserFilterHelp:Hide();
 	end
 	ui_CompanionBrowserContent.onSelectCallback = onSelectCallback;
 	ui_CompanionBrowserContent.onCancelCallback = onCancelCallback;
@@ -719,10 +742,6 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 	filteredCompanionBrowser();
 	showPopup(TRP3_CompanionBrowser);
 	TRP3_CompanionBrowserFilterBox:SetFocus();
-
-	if currentCompanionType == TRP3_Enums.UNIT_TYPE.BATTLE_PET then
-		TRP3_RefreshTooltipForFrame(TRP3_CompanionBrowserFilterHelp);
-	end
 end
 
 function TRP3_API.popup.showPetBrowser(profileID, onSelectCallback, onCancelCallback)

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -713,7 +713,7 @@ Possible status:
 	PR_CO_PROFILE_HELP = [[A profile contains all information about a |cffffff00"pet"|r as a |cff00ff00roleplay character|r.
 
 A companion profile can be linked to:
-- A battle pet |cffff9900(only if it has been renamed)|r
+- A battle pet
 - A hunter pet
 - A warlock minion
 - A mage elemental
@@ -823,7 +823,7 @@ This will works:|cff00ff00
 - On any icon in the spellbook|r]],
 	UI_ICON_BROWSER_SEARCHING = "Searching...",
 	UI_COMPANION_BROWSER_HELP = "Select a battle pet",
-	UI_COMPANION_BROWSER_HELP_TT = "|cffffff00Warning:|r Only renamed battle pets can be linked to a profile.\n\n|cff00ff00This section lists these battle pets only.",
+	UI_COMPANION_BROWSER_RENAME_WARNING = "|cffff0000Warning:|r It is strongly recommended to only link companion profiles to renamed pets.",
 	UI_ICON_SELECT = "Select icon",
 	UI_MUSIC_BROWSER = "Music browser",
 	UI_MUSIC_SELECT = "Select music",

--- a/totalRP3/Resources/CompanionData.lua
+++ b/totalRP3/Resources/CompanionData.lua
@@ -33,7 +33,7 @@
 --    GROUP BY CritterSpeciesID, CritterCreatureID
 --    ORDER BY CritterSpeciesID ASC
 
-TRP3_CompanionPetData = C_PetJournal and {} or {
+TRP3_CompanionPetData = {
 	{ speciesID = 39, creatureID = 2671, spellID = 4055, itemID = 4401 },  -- Mechanical Squirrel
 	{ speciesID = 40, creatureID = 7385, spellID = 10673, itemID = 8485 },  -- Bombay Cat
 	{ speciesID = 41, creatureID = 7384, spellID = 10674, itemID = 8486 },  -- Cornish Rex Cat
@@ -235,7 +235,7 @@ TRP3_CompanionPetData = C_PetJournal and {} or {
 --         )
 --     ORDER BY MountID ASC
 
-TRP3_CompanionMountData = C_MountJournal and {} or {
+TRP3_CompanionMountData = {
 	{ mountID = 6, spellID = 458, factionGroup = nil },  -- Brown Horse
 	{ mountID = 7, spellID = 459, factionGroup = nil },  -- Gray Wolf
 	{ mountID = 8, spellID = 468, factionGroup = nil },  -- White Stallion
@@ -769,7 +769,7 @@ do
 		-- Finding the summoned mount is hard work on Classic so we only rescan
 		-- when unit auras change for the player.
 
-		if not C_PetJournal then
+		if not C_MountJournal then
 			TRP3_API.RegisterCallback(TRP3_API.GameEvents, "UNIT_AURA", function(_, unit)
 				local currentMountedStatus = IsMounted();
 				rescanSummonedMountID = rescanSummonedMountID or (unit == "player") and (previousMountedStatus ~= currentMountedStatus);

--- a/totalRP3/UI/Browsers/Companions.xml
+++ b/totalRP3/UI/Browsers/Companions.xml
@@ -7,6 +7,16 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Button name="TRP3_CompanionBrowserButtonTemplate" mixin="TRP3_CompanionBrowserButtonMixin" virtual="true">
 		<Size x="40" y="40"/>
+		<Layers>
+			<Layer level="OVERLAY">
+				<Texture parentKey="RenameWarning" atlas="services-icon-warning" useAtlasSize="false" hidden="true">
+					<Size x="20" y="20"/>
+					<Anchors>
+						<Anchor point="BOTTOMRIGHT" x="-2" y="2"/>
+					</Anchors>
+				</Texture>
+			</Layer>
+		</Layers>
 		<NormalTexture file="Interface\ICONS\INV_Misc_QuestionMark"/>
 		<PushedTexture file="Interface\ICONS\INV_Misc_QuestionMark"/>
 		<HighlightTexture alphaMode="ADD" file="Interface\Buttons\ButtonHilight-Square"/>
@@ -80,38 +90,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<Anchor point="BOTTOM" x="0" y="10"/>
 						</Anchors>
 					</EditBox>
-					<Button name="TRP3_CompanionBrowserFilterHelp" inherits="TRP3_HelpButton">
-						<Anchors>
-							<Anchor point="TOPRIGHT" x="-10" y="-10"/>
-						</Anchors>
-						<Layers>
-							<Layer level="OVERLAY">
-
-								<Texture file="Interface\Calendar\EventNotificationGlow" name="$parentBlink" alpha="0.0" alphaMode="ADD">
-									<Animations>
-										<AnimationGroup name="$parentAnimate" looping="REPEAT">
-											<Alpha duration="0.4" toAlpha="0.3" fromAlpha="0" smoothing="IN" order="1"/>
-											<Alpha duration="0.4" toAlpha="0" fromAlpha="0.3" smoothing="OUT" startDelay="0.4" order="1"/>
-										</AnimationGroup>
-									</Animations>
-									<Size x="25" y="25"/>
-									<Anchors>
-										<Anchor x="0" y="0" point="CENTER"/>
-									</Anchors>
-								</Texture>
-							</Layer>
-						</Layers>
-						<Scripts>
-							<OnEnter>
-								TRP3_CompanionBrowserFilterHelpBlinkAnimate:Stop();
-								self.animationShown = true;
-								TRP3_RefreshTooltipForFrame(self);
-							</OnEnter>
-							<OnLoad>
-								self.animationShown = false;
-							</OnLoad>
-						</Scripts>
-					</Button>
 				</Frames>
 			</Frame>
 		</Frames>


### PR DESCRIPTION
Fixes #812. This bonks the code over the head enough times to give it a severe enough concussion that linking companion pets should hopefully now work again on Classic.

As part of this, the need to rename a pet has been removed on all clients. Unrenamed pets in retail will show a warning in their tooltip however, and get sorted to the list as well as deduplicated.

Minimal testing - seems to work fine for my own player and pets at least, but haven't tested others.