### PR TITLE
Ensure ChatThrottleLib is packaged

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -24,6 +24,7 @@ externals:
   totalRP3/Libs/AceEvent-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceEvent-3.0
   totalRP3/Libs/AceSerializer-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceSerializer-3.0
   totalRP3/Libs/CallbackHandler-1.0: https://repos.curseforge.com/wow/callbackhandler/trunk/CallbackHandler-1.0
+  totalRP3/Libs/ChatThrottleLib: https://repos.curseforge.com/wow/chatthrottlelib/trunk
   totalRP3/Libs/Chomp: https://github.com/wow-rp-addons/Chomp
   totalRP3/Libs/LibChatAnims: https://repos.curseforge.com/wow/libchatanims/trunk/LibChatAnims
   totalRP3/Libs/LibCompress: https://repos.curseforge.com/wow/libcompress/trunk

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -19,6 +19,7 @@
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
+Libs\ChatThrottleLib\ChatThrottleLib.xml
 Libs\AceAddon-3.0\AceAddon-3.0.xml
 Libs\AceConsole-3.0\AceConsole-3.0.xml
 Libs\AceDB-3.0\AceDB-3.0.xml


### PR DESCRIPTION
It's marked as a dependency of Chomp in its own pkgmeta, but for some reason we neglected to actually ship it ourselves. Not a huge issue as Chomp has coped until now without it, but was still technically incorrect anyway - and now fatally so.