### PR TITLE
Fix batch uploading of locales

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,1 @@
-luaparser~=3.1
 requests~=2.31

--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -22,12 +22,12 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Upload CurseForge Translations
-        run: make translations/upload
+        run: make push-locales
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
 
       - name: Download CurseForge Translations
-        run: make translations/download
+        run: make pull-locales
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
 

--- a/.github/workflows/upload_all_translations.yml
+++ b/.github/workflows/upload_all_translations.yml
@@ -17,7 +17,7 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Upload CurseForge Translations
-        run: make translations/upload-all
+        run: make push-all-locales
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
 

--- a/Makefile
+++ b/Makefile
@@ -2,40 +2,61 @@
 # SPDX-License-Identifier: Apache-2.0
 
 PYTHON ?= python3
-LIBDIR := totalRP3/libs
-PACKAGER_URL := https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh
+LIBDIR := totalRP3/Libs
+PACKAGER_URL := https://raw.githubusercontent.com/BigWigsMods/packager/eca4e176cd6ae5404c66bef5c11c08200a458400/release.sh
 SCHEMA_URL := https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd
 
 CF_PROJECT_ID := 75973
-LOCALE_DIR := totalRP3/Locales
 
-.PHONY: check dist libs translations translations/download translations/upload
+LOCALES := enUS deDE esES esMX frFR itIT koKR ptBR ruRU zhCN zhTW
+LOCALES_DIR := totalRP3/Locales
+LOCALE_PUSH_TARGETS := $(addprefix push-locales-,$(LOCALES))
+LOCALE_PULL_TARGETS := $(addprefix pull-locales-,$(LOCALES))
+PUSH_LOCALES := enUS
+PULL_LOCALES := $(filter-out enUS,$(LOCALES))
+
 .DEFAULT: all
 .DELETE_ON_ERROR:
 .FORCE:
 
+.PHONY: all
 all: dist
 
+.PHONY: check
 check: .github/scripts/ui.xsd
 	pre-commit run --all-files
 
+.PHONY: dist
 dist:
-	@curl -s $(PACKAGER_URL) | bash -s -- -d -S
+	curl -s $(PACKAGER_URL) | bash -s -- -dS
 
+.PHONY: libs
 libs:
-	@curl -s $(PACKAGER_URL) | bash -s -- -c -d -z
-	@cp -a .release/$(LIBDIR)/* $(LIBDIR)/
+	curl -s $(PACKAGER_URL) | bash -s -- -cdlz
+	cp -aTv .release/$(LIBDIR) $(LIBDIR)
 
-translations: translations/upload translations/download
+.PHONY: locales
+locales: push-locales pull-locales
 
-translations/download:
-	$(PYTHON) .github/scripts/localization.py --project-id=$(CF_PROJECT_ID) --locale-dir=$(LOCALE_DIR) download
+.PHONY: push-all-locales
+push-all-locales: $(addprefix push-locales-,$(LOCALES))
 
-translations/upload:
-	$(PYTHON) .github/scripts/localization.py --project-id=$(CF_PROJECT_ID) --locale-dir=$(LOCALE_DIR) upload
+.PHONY: push-locales
+push-locales: $(addprefix push-locales-,$(PUSH_LOCALES))
 
-translations/upload-all:
-	$(PYTHON) .github/scripts/localization.py --project-id=$(CF_PROJECT_ID) --locale-dir=$(LOCALE_DIR) upload -l "*"
+.PHONY: $(LOCALE_PUSH_TARGETS)
+$(LOCALE_PUSH_TARGETS): push-locales-%:
+	$(PYTHON) .github/scripts/localization.py upload --locale $* --project-id $(CF_PROJECT_ID) <$(LOCALES_DIR)/$*.lua
+
+.PHONY: pull-all-locales
+pull-all-locales: $(addprefix pull-locales-,$(LOCALES))
+
+.PHONY: pull-locales
+pull-locales: $(addprefix pull-locales-,$(PULL_LOCALES))
+
+.PHONY: $(LOCALE_PULL_TARGETS)
+$(LOCALE_PULL_TARGETS): pull-locales-%:
+	$(PYTHON) .github/scripts/localization.py download --locale $* --project-id $(CF_PROJECT_ID) >$(LOCALES_DIR)/$*.lua
 
 .github/scripts/ui.xsd: .FORCE
 	curl -s $(SCHEMA_URL) -o $@


### PR DESCRIPTION
Take a chainsaw to the existing localization script and Makefile a bit. No longer have a dependency on the luaparser library, we'll just yolo it with line-based matching instead.

The script also no longer directly handles file reads/writes, instead deferring to just reading from stdin and writing to stdout. The Makefile routes everything appropriately.