### PR TITLE
Add 'Open Profile' option to Battle.net friends

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -629,6 +629,7 @@ stds.wow = {
 		"AMMOSLOT",
 		"ARCANE_CHARGES",
 		"BATTLENET_FONT_COLOR",
+		"BNET_CLIENT_WOW",
 		"CANCEL",
 		"CHI",
 		"CLOSE",


### PR DESCRIPTION
Extend the unit popup module to also allow opening the profiles of Battle.net friends. Thank you Sol for staying logged in while I pulled your profile four times to test this.