### PR TITLE
Defer fade rule registration until plugin enabled

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -85,7 +85,11 @@ function TRP3_KuiNamePlates:OnModuleEnable()
 	self.unitDisplayInfo = {};
 	self.initialized = {};
 
-	self.plugin = KuiNameplates:NewPlugin("TotalRP3", 250);
+	local maxMinor = nil;
+	local enableOnLoad = true;
+
+	self.plugin = KuiNameplates:NewPlugin("TotalRP3", 250, maxMinor, enableOnLoad);
+	self.plugin.OnEnable = function(_) self:OnPluginEnable() end;
 	self.plugin.Create = function(_, ...) return self:OnNamePlateCreate(...); end;
 	self.plugin.Show = function(_, nameplate) return self:OnNamePlateShow(nameplate); end;
 	self.plugin.HealthUpdate = function(_, nameplate) return self:UpdateNamePlate(nameplate); end;
@@ -106,13 +110,20 @@ function TRP3_KuiNamePlates:OnModuleEnable()
 	self.plugin:RegisterMessage("Combat");
 	self.plugin:RegisterMessage("Hide");
 
+
+	self.fading = KuiNameplates:GetPlugin("Fading");
+end
+
+function TRP3_KuiNamePlates:OnPluginEnable()
 	-- Nameplate visibility is handled through a fade rule. As we only ever
 	-- forcefully hide nameplates with this rule we give it a high priority.
+	--
+	-- This has to be deferred to the OnEnable of the *plugin* and not
+	-- our module due to timing issues with ADDON_LOADED/PLAYER_LOGIN.
 
 	local FADE_PRIORITY = 15;
 	local FADE_RULE_ID = "TRP3_KuiNamePlates";
 
-	self.fading = KuiNameplates:GetPlugin("Fading");
 	self.fading:AddFadeRule(GenerateClosure(self.EvaluateNamePlateVisibility, self), FADE_PRIORITY, FADE_RULE_ID);
 end
 


### PR DESCRIPTION
There's a race condition if AceAddon is loaded before KuiNamePlates where the event frame registered by the former may receive either ADDON_LOADED or PLAYER_LOGIN events before Kui does.

If this happens, we register our custom fade rule too early and when Kui runs its own PLAYER_LOGIN logic - it deletes it.

To avoid this we'll use an OnEnable hook on the Kui plugin itself, which should be guaranteed to be sequenced well after the fader plugin has itself been enabled and means we won't lose our custom rule.