### PR TITLE
Restore the Timerunner icon on customized chat names

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -220,6 +220,7 @@ stds.wow = {
 		C_ChatInfo = {
 			fields = {
 				"GetChannelShortcut",
+				"IsTimerunningPlayer",
 				"RegisterAddonMessagePrefix",
 				"SwapChatChannelsByChannelIndex",
 			},
@@ -410,6 +411,12 @@ stds.wow = {
 				"InitScrollBoxListWithScrollBar",
 				"RegisterScrollBoxWithScrollBar",
 			},
+		},
+
+		TimerunningUtil = {
+		    fields = {
+                "AddSmallIcon",
+            },
 		},
 
 		"AbbreviateLargeNumbers",

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -715,6 +715,10 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 		characterName = OOC_INDICATOR_TEXT .. characterName;
 	end
 
+	if C_ChatInfo.IsTimerunningPlayer and C_ChatInfo.IsTimerunningPlayer(GUID) then
+		characterName = TimerunningUtil.AddSmallIcon(characterName);
+	end
+
 	if getConfigValue(CONFIG_SHOW_ICON) then
 		local info = getCharacterInfoTab(unitID);
 		if info and info.characteristics and info.characteristics.IC then
@@ -732,10 +736,6 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	-- We remove the space so the comma is placed right after the name
 	if emoteStartingWithACommaID == messageID then
 		characterName = characterName .. ",";
-	end
-
-	if C_ChatInfo.IsTimerunningPlayer and C_ChatInfo.IsTimerunningPlayer(GUID) then
-		characterName = TimerunningUtil.AddSmallIcon(characterName);
 	end
 
 	return characterName;

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -734,6 +734,10 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 		characterName = characterName .. ",";
 	end
 
+	if C_ChatInfo.IsTimerunningPlayer(GUID) then
+		characterName = TimerunningUtil.AddSmallIcon(characterName);
+	end
+
 	return characterName;
 end
 

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -734,7 +734,7 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 		characterName = characterName .. ",";
 	end
 
-	if C_ChatInfo.IsTimerunningPlayer(GUID) then
+	if C_ChatInfo.IsTimerunningPlayer and C_ChatInfo.IsTimerunningPlayer(GUID) then
 		characterName = TimerunningUtil.AddSmallIcon(characterName);
 	end
 


### PR DESCRIPTION
Because the timerunner icon is added directly in the GetColoredName function, we're eating it when applying the chat name customization, since we replace the entire function. This should restore the hourglass in front of everything else so you still know who's a timerunner.

Note: When the setting to show the icon on chat names is enabled, it'll take priority over the hourglass. Seems like a Blizzard bug that we can't have two textures in there.