### PR TITLE
Defer Launcher event registrations to OnInitialize

### DIFF
--- a/totalRP3/Modules/Launcher/Launcher.lua
+++ b/totalRP3/Modules/Launcher/Launcher.lua
@@ -28,8 +28,6 @@ function TRP3_Launcher:OnLoad()
 	self.callbacks = TRP3_API.InitCallbackRegistry(self);
 
 	self.events = TRP3_API.CreateCallbackGroup();
-	self.events:AddCallback(TRP3_API.GameEvents, "ADDONS_UNLOADING", self.OnUninitialize, self);
-	self.events:AddCallback(TRP3_Addon, "CONFIGURATION_CHANGED", self.OnConfigurationChanged, self);
 
 	self:SetEnabledState(false);
 end
@@ -49,6 +47,9 @@ function TRP3_Launcher:OnInitialize()
 	LibDBCompartment:Register(self.objectName, self.object);
 
 	self:LoadBindings(TRP3_LauncherSettings.GetSavedBindings());
+
+	self.events:AddCallback(TRP3_API.GameEvents, "ADDONS_UNLOADING", self.OnUninitialize, self);
+	self.events:AddCallback(TRP3_Addon, "CONFIGURATION_CHANGED", self.OnConfigurationChanged, self);
 end
 
 function TRP3_Launcher:OnEnable()


### PR DESCRIPTION
This avoids risky scenarios where ADDONS_UNLOADING can fire in between script files being loaded and ADDON_LOADED firing for our saved variables.

Unsure if such a circumstance can actually occur, but I've been noticing a few weird scenarios as of late where my launcher settings (and nothing else) are getting reset and think they may be tied to a few client crashes I've been forcing.