### PR TITLE
Add soft target support for tooltips

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -366,6 +366,7 @@ stds.wow = {
 		C_TooltipInfo = {
 			fields = {
 				"GetUnit",
+				"GetWorldCursor",
 			},
 		},
 
@@ -380,6 +381,12 @@ stds.wow = {
 				TooltipDataLineType = {
 					fields = {
 						"UnitOwner",
+					},
+				},
+
+				TooltipDataType = {
+					fields = {
+						"Unit",
 					},
 				},
 
@@ -591,6 +598,7 @@ stds.wow = {
 		"UnitPVPName",
 		"UnitRace",
 		"UnitSex",
+		"UnitTokenFromGUID",
 		"Wrap",
 		"WrapTextInColorCode",
 

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1396,7 +1396,9 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 	-- Listen to the mouse over event
 	TRP3_API.RegisterCallback(TRP3_API.GameEvents, "UPDATE_MOUSEOVER_UNIT", NotifyTooltipUnitChanged);
 	hooksecurefunc(GameTooltip, "SetUnit", NotifyTooltipUnitChanged);
-	hooksecurefunc(GameTooltip, "SetWorldCursor", NotifyTooltipUnitChanged);
+	if GameTooltip.SetWorldCursor then
+		hooksecurefunc(GameTooltip, "SetWorldCursor", NotifyTooltipUnitChanged);
+	end
 	GameTooltip:HookScript("OnShow", function()
 		if not GameTooltip:GetUnit() then
 			ui_CharacterTT:Hide();


### PR DESCRIPTION
This implements the necessary changes to detach our tooltips from strictly looking at the "mouseover" unit and to instead use whatever unit is currently considered active per the world cursor.

The effect of this is that we now properly customize tooltips when a user has the SoftTargetFriend and SoftTargetTooltipFriend CVars enabled. Previously, if these were enabled then the tooltip that appears when looking at a friendly player would be the standard game one and wouldn't be customized with RP info.

One other side effect of this support is that the UPDATE_MOUSE_OVER event can now fire for non-"mouseover" units, which means that we'll also fire off profile requests if the appropriate soft target CVars are enabled and the user is looking at another friendly player.