### PR TITLE
Wrap companion mount titles in tooltips

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -982,7 +982,7 @@ local function writeCompanionTooltip(companionFullID, _, targetType, targetMode)
 			if getConfigValue(CONFIG_CROP_TEXT) then
 				fullTitle = crop(fullTitle, FIELDS_TO_CROP.TITLE);
 			end
-			tooltipBuilder:AddLine(fullTitle, colors.TITLE, getSubLineFontSize());
+			tooltipBuilder:AddLine(fullTitle, colors.TITLE, getSubLineFontSize(), true);
 		end
 	end
 


### PR DESCRIPTION
Noticed this by chance as some wonderful user has a title on their companion tooltip that fills half the screen.