### PR TITLE
Avoid rare errors in tooltip SetPoint calls

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1264,13 +1264,15 @@ local function show(targetType, targetID, targetMode)
 				elseif getAnchoredPosition() == "ANCHOR_CURSOR" then
 					GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);
 					placeTooltipOnCursor(ui_CharacterTT);
-				else
-					if getAnchoredFrame() == GameTooltip and getConfigValue(ConfigKeys.CHARACT_HIDE_ORIGINAL) then
+				elseif getAnchoredFrame() == GameTooltip and getConfigValue(ConfigKeys.CHARACT_HIDE_ORIGINAL) then
+					if GameTooltip:GetNumPoints() > 0 then
 						ui_CharacterTT:SetOwner(UIParent, "ANCHOR_NONE");
 						ui_CharacterTT:SetPoint(GameTooltip:GetPoint(1));
 					else
-						ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
+						GameTooltip_SetDefaultAnchor(ui_CharacterTT, UIParent);
 					end
+				else
+					ui_CharacterTT:SetOwner(getAnchoredFrame(), getAnchoredPosition());
 				end
 
 				ui_CharacterTT:SetBorderColor(1, 1, 1);


### PR DESCRIPTION
The ui_CharacterTT:SetPoint call can fail in rare circumstances where the normal tooltip frame has no anchor points, and the addon is configured to replace the original tooltip.

I believe this is related to the changes to add soft target support; presumably what happens is that there's extremely rare scenarios where GameTooltip:SetWorldCursor is called by the client for an object that has no tooltip data (or at least, nothing cached). In such a case the tooltip probably never shows, has no anchor points, and our hook then attempts to set up an RP profile tooltip and ends up choking on the nil return from GetPoint being passed into SetPoint.

Hypothetically this problem could also exist for normal GameTooltip:SetUnit calls, we've probably just been lucky enough to not see it there so far.

As such - if the original tooltip has no anchors, we'll fall back and use the default anchor point that the original tooltip would normally have. Odds are we don't even _have_ a valid unit in this case anyway, so we'll probably display nothing - but at least this way we avoid the error and - if there is something - we'll at least show it somewhere sensible.