### PR TITLE
Handling of default profile in customizations and directory

### DIFF
--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -180,6 +180,7 @@ local function updateDefaultProfile()
 end
 
 function TRP3_API.profile.isDefaultProfile(profileID)
+	if not profileID then return false end
 	return string.sub(profileID, -1) == "*";
 end
 

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -683,21 +683,18 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	---@type Player
 	local player = AddOn_TotalRP3.Player.static.CreateFromNameAndRealm(character, realm);
 
-	-- Default profile, don't customize
-	if TRP3_API.profile.isDefaultProfile(player:GetProfileID()) then
-		return fallback(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12);
-	end
-
 	-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 	if realm == Globals.player_realm_id or getConfigValue(CONFIG_REMOVE_REALM) then
 		characterName = character;
 	end
 
-	-- Retrieve the character full RP name
-	local customizedName = getFullnameForUnitUsingChatMethod(unitID);
+	-- Retrieve the character full RP name (if not default profile)
+	if player:GetProfileID() and TRP3_API.profile.isDefaultProfile(player:GetProfileID()) == false then
+		local customizedName = getFullnameForUnitUsingChatMethod(unitID);
 
-	if customizedName then
-		characterName = customizedName;
+		if customizedName then
+			characterName = customizedName;
+		end
 	end
 
 	if GetCVar("chatClassColorOverride") ~= "1" then

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -664,7 +664,7 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 
 	-- We don't have a unit ID for this message (WTF? Some other add-on must be doing some weird shit again…)
 	-- Bail out, let the fallback function handle that shit.
-	if not unitID then return fallback(event, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12) end ;
+	if not unitID then return fallback(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12) end ;
 
 	-- Check if this message ID was flagged as containing NPC chat
 	-- If it does we use the NPC name that was saved before.
@@ -676,12 +676,17 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	local character, realm = unitIDToInfo(unitID);
 	if not realm then
 		-- if realm is nil (i.e. globals haven't been set yet) just run the vanilla version of the code to prevent errors.
-		return fallback(event, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12);
+		return fallback(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12);
 	end
 	-- Make sure we have a unitID formatted as "Player-Realm"
 	unitID = unitInfoToID(character, realm);
 	---@type Player
 	local player = AddOn_TotalRP3.Player.static.CreateFromNameAndRealm(character, realm);
+
+	-- Default profile, don't customize
+	if TRP3_API.profile.isDefaultProfile(player:GetProfileID()) then
+		return fallback(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, channelNumber, arg9, arg10, arg11, arg12);
+	end
 
 	-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 	if realm == Globals.player_realm_id or getConfigValue(CONFIG_REMOVE_REALM) then

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -689,7 +689,8 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 	end
 
 	-- Retrieve the character full RP name (if not default profile)
-	if player:GetProfileID() and TRP3_API.profile.isDefaultProfile(player:GetProfileID()) == false then
+	local hasNonDefaultProfile = player:GetProfileID() and TRP3_API.profile.isDefaultProfile(player:GetProfileID()) == false;
+	if hasNonDefaultProfile then
 		local customizedName = getFullnameForUnitUsingChatMethod(unitID);
 
 		if customizedName then
@@ -721,7 +722,7 @@ function Utils.customGetColoredNameWithCustomFallbackFunction(fallback, event, a
 		characterName = TimerunningUtil.AddSmallIcon(characterName);
 	end
 
-	if getConfigValue(CONFIG_SHOW_ICON) then
+	if hasNonDefaultProfile and getConfigValue(CONFIG_SHOW_ICON) then
 		local info = getCharacterInfoTab(unitID);
 		if info and info.characteristics and info.characteristics.IC then
 			characterName = Utils.str.icon(info.characteristics.IC, 15) .. " " .. characterName;

--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -5,7 +5,7 @@ TRP3_API.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 17;
+local SCHEMA_VERSION = 18;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -284,3 +284,23 @@ TRP3_API.flyway.patches["17"] = function()
 		end
 	end
 end
+
+TRP3_API.flyway.patches["18"] = function()
+	-- Modify default profile ID to include an identifier
+
+	if not TRP3_Profiles or not TRP3_Configuration then
+		return;
+	end
+
+	if TRP3_Configuration["default_profile_id"] then
+		local oldDefaultProfileID = TRP3_Configuration["default_profile_id"];
+		local newDefaultProfileID = string.sub(oldDefaultProfileID, 1, -2) .. "*";
+
+		-- Replacing the config key
+		TRP3_Configuration["default_profile_id"] = newDefaultProfileID;
+
+		-- Replacing the profile entry
+		TRP3_Profiles[newDefaultProfileID] = TRP3_Profiles[oldDefaultProfileID];
+		TRP3_Profiles[oldDefaultProfileID] = nil;
+	end
+end

--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -163,6 +163,11 @@ local function GetCharacterUnitDisplayInfo(unitToken, characterID)
 		local player = GetOrCreatePlayerFromCharacterID(characterID);
 		local classToken = UnitClassBase(unitToken);
 
+		-- Don't customize default profile nameplates
+		if TRP3_API.profile.isDefaultProfile(player:GetProfileID()) then
+			return displayInfo;
+		end
+
 		displayInfo.isRoleplayUnit = true;
 
 		do  -- Names/Titles

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -355,7 +355,7 @@ local function getCharacterLines()
 		local nameIsConform, guildIsConform, realmIsConform, notesIsConform = false, false, false, false;
 
 		-- Don't add default profiles to the directory
-		if not TRP3_API.profile.isDefaultProfile(Player:GetProfileID()) and profile.characteristics and next(profile.characteristics) ~= nil then
+		if not TRP3_API.profile.isDefaultProfile(profileID) and profile.characteristics and next(profile.characteristics) ~= nil then
 
 			-- Defines if at least one character is conform to the search criteria
 			for unitID, _ in pairs(profile.link or Globals.empty) do

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -354,7 +354,8 @@ local function getCharacterLines()
 	for profileID, profile in pairs(profileList) do
 		local nameIsConform, guildIsConform, realmIsConform, notesIsConform = false, false, false, false;
 
-		if profile.characteristics and next(profile.characteristics) ~= nil then
+		-- Don't add default profiles to the directory
+		if not TRP3_API.profile.isDefaultProfile(Player:GetProfileID()) and profile.characteristics and next(profile.characteristics) ~= nil then
 
 			-- Defines if at least one character is conform to the search criteria
 			for unitID, _ in pairs(profile.link or Globals.empty) do


### PR DESCRIPTION
The way the default profile works leads to weird displays when it comes to customization. To be able to quickly identify whether a profile ID belongs to a regular profile or the default one, the last character is now a special one (I chose an asterisk but I'm not picky, we can pick something else).

(Old default profile IDs get replaced by the flyway, and the old links will automatically reselect the new profile ID when the old one can't be found)

This way, I can remove customization from chat and nameplates, and hide profiles from the directory if they're default. There might be other places where this should be done, I'll look around, but wanted to get the first draft out in case there's major things to do better.

(Oh yeah, also fixed a bug where the fallback function for GetColoredName was called with the wrong arguments when the unitID or realm were missing, leading to chat messages having incorrect displays)