### PR TITLE
ElvUI default tooltip anchoring

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -122,6 +122,10 @@ local function getSmallLineFontSize()
 end
 TRP3_API.ui.tooltip.getSmallLineFontSize = getSmallLineFontSize;
 
+function TRP3_API.ui.tooltip.setTooltipDefaultAnchor(tooltip, parent)
+	GameTooltip_SetDefaultAnchor(tooltip, parent);
+end
+
 function TRP3_API.ui.tooltip.shouldCropTexts()
 	if not registerTooltipModuleIsEnabled then
 		return true;
@@ -1452,7 +1456,10 @@ local function onModuleInit()
 		if TRP3_CharacterTooltip:IsShown() and ShouldDisplayUnmodifiedTooltip() then
 			local unitToken = TRP3_CharacterTooltip.targetType;
 			TRP3_CharacterTooltip:Hide();
-			GameTooltip_SetDefaultAnchor(GameTooltip, UIParent);
+
+			-- Need to use the global ref to this function since it may be overridden by another module
+			TRP3_API.ui.tooltip.setTooltipDefaultAnchor(GameTooltip, UIParent);
+
 			GameTooltip:SetUnit(unitToken);
 			GameTooltip:Show();
 		elseif GameTooltip:IsShown() then

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -130,6 +130,12 @@ TRP3_API.module.registerModule({
 				end
 			end
 
+			-- Override default tooltip anchoring behavior to use ElvUI anchors
+			local function setElvUITooltipDefaultAnchor(tooltip, parent)
+				TT:GameTooltip_SetDefaultAnchor(tooltip, parent);
+			end
+			TRP3_API.ui.tooltip.setTooltipDefaultAnchor = setElvUITooltipDefaultAnchor;
+
 			-- Apply the skinning if the settings are enabled
 			if TRP3_API.configuration.getValue(CONFIG.SKIN_TOOLTIPS) then
 				skinTooltips();


### PR DESCRIPTION
With the introduction of the whole 'hold modifier to see original tooltip' feature, it was found through extensive testing and hours of hard work that ElvUI tooltips don't use the existing `GameTooltip_SetDefaultAnchor` function and instead use the version inside the ElvUI tooltip module to set their anchor points.

With this PR, we're exporting `TRP3_API.ui.tooltip.setTooltipDefaultAnchor` as a global function, then allowing the ElvUI tooltip skinning module to override it if enabled, which then uses the correct ElvUI function to place the tooltip in the correct spot correctly.