### PR TITLE
Avoid customizing tooltips if GTT is unowned

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1377,6 +1377,10 @@ local function GetWorldCursorUnit()
 end
 
 local function GetCurrentTooltipUnit()
+	if not GameTooltip:GetOwner() then
+		return nil;
+	end
+
 	local unitToken;
 
 	if UnitExists("mouseover") then


### PR DESCRIPTION
In 11.0 there's a bug where we can customize tooltips when interacting with the new menus. The cause of this is that in some cases the "mouseover" unit can continue to exist when you go from hovering over a unit frame to any other frame that's not WorldFrame.

In this state, opening a menu that uses tooltips can cause us to sometimes show our tooltip close to the menu itself.

To avoid this - we now only consider there to be an active tooltip unit if GameTooltip is currently an owned frame. This seems to resolve the issue. Not too sure why, but whatevs.