### PR TITLE
Prefer securecall for non-fatal error dispatch

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -431,7 +431,6 @@ stds.wow = {
 		"BNGetGameAccountInfoByGUID",
 		"BNGetInfo",
 		"CalculateStringEditDistance",
-		"CallErrorHandler",
 		"Chat_GetChatFrame",
 		"ChatConfigChannelSettings_SwapChannelsByIndex",
 		"ChatEdit_FocusActiveWindow",

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -591,11 +591,11 @@ local function CallWithUnfilteredPetJournal(func, ...)
 	};
 
 	local function RestoreFiltersAndReturn(ok, ...)
-		xpcall(RestoreIndexedMutator, CallErrorHandler, C_PetJournal.SetFilterChecked, filters.options);
-		xpcall(RestoreIndexedMutator, CallErrorHandler, C_PetJournal.SetPetSourceChecked, filters.sources);
-		xpcall(RestoreIndexedMutator, CallErrorHandler, C_PetJournal.SetPetTypeFilter, filters.types);
-		xpcall(C_PetJournal.SetSearchFilter, CallErrorHandler, filters.search);
-		xpcall(C_PetJournal.SetPetSortParameter, CallErrorHandler, filters.sort);
+		securecallfunction(RestoreIndexedMutator, C_PetJournal.SetFilterChecked, filters.options);
+		securecallfunction(RestoreIndexedMutator, C_PetJournal.SetPetSourceChecked, filters.sources);
+		securecallfunction(RestoreIndexedMutator, C_PetJournal.SetPetTypeFilter, filters.types);
+		securecallfunction(C_PetJournal.SetSearchFilter, filters.search);
+		securecallfunction(C_PetJournal.SetPetSortParameter, filters.sort);
 
 		if not ok then
 			error((...), 3);

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1261,6 +1261,7 @@ Adds a simple button to the toolbar to toggle on and off the map scan location f
 {col:ffffff}Thanks to Horionne for sending us the magazine Gamer Culte Online #14 with an article about Total RP.{/col}]],
 
 	MO_ADDON_NOT_INSTALLED = "The %s add-on is not installed, custom Total RP 3 integration disabled.",
+	MO_SCRIPT_ERROR = "This module encountered a fatal script error.",
 	MO_TOOLTIP_CUSTOMIZATIONS_DESCRIPTION = "Add custom compatibility for the %s add-on, so that your tooltip preferences are applied to Total RP 3's tooltips.",
 	MO_CHAT_CUSTOMIZATIONS_DESCRIPTION = "Add custom compatibility for the %s add-on, so that chat messages and player names are modified by Total RP 3 in that add-on.",
 	CO_TOOLTIP_PREFERRED_OOC_INDICATOR = "Preferred OOC indicator",

--- a/totalRP3/Resources/InterfaceIcons.lua
+++ b/totalRP3/Resources/InterfaceIcons.lua
@@ -230,7 +230,7 @@ do
 		local name = GetFirstValidTexturePath(candidates, [[interface\icons\]]);
 
 		if not name and TRP3_API.globals.DEBUG_MODE then
-			CallErrorHandler(string.format("Invalid interface icon %q: No valid texture file found", id));
+			securecallfunction(error, string.format("Invalid interface icon %q: No valid texture file found", id));
 		end
 
 		TRP3_InterfaceIcons[id] = name or DEFAULT_ICON_NAME;

--- a/totalRP3/UI/Browsers/PetBrowser.lua
+++ b/totalRP3/UI/Browsers/PetBrowser.lua
@@ -288,7 +288,7 @@ function TRP3_PetBrowserMixin:TriggerDialogCallback(result, ...)
 	self.dialogCallback = nil;
 
 	if dialogCallback then
-		xpcall(dialogCallback, CallErrorHandler, result, ...);
+		securecallfunction(dialogCallback, result, ...);
 	end
 end
 


### PR DESCRIPTION
The securecall function implicitly routes all errors that occur in the invoked function to the global error handler. Previously this was preferable to xpcall as it would enable the error handler to display a locals dump, but as of recently this difference was removed.

However, currently in 11.0 there's a bug where xpcall with CallErrorHandler doesn't actually work sometimes. The default script errors window itself encounters an error when this combination of functions is used, resulting in the error being silently dropped on the floor with no indication whatsoever that something has gone wrong.

The securecall method however isn't impacted by this bug, and we've been making changes elsewhere to use securecall for this type of stuff anyway, so might as well just commit to the idea and blanket replace all usages of xpcall with securecall instead.

One thorny area is the module management interface. For that I've elected to remove its weird dual-handling of initialization errors (which differs between debug and release builds) and instead just allow errors to route to the default error handler.