### PR TITLE
Migrate to C_Spell.GetSpellInfo for 11.0

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -333,6 +333,7 @@ stds.wow = {
 		C_Spell = {
 			fields = {
 				"DoesSpellExist",
+				"GetSpellInfo",
 				"RequestLoadSpellData",
 			},
 		},

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -35,9 +35,21 @@ end
 
 TRP3_API.navigation.menu.id.COMPANIONS_MAIN = "main_20_companions";
 
-function TRP3_API.companions.getCompanionNameFromSpellID(spellID)
-	local name = GetSpellInfo(tonumber(spellID));
-	return name or spellID;
+function TRP3_API.companions.getCompanionNameFromSpellID(spellIDString)
+	local name;
+	local spellID = tonumber(spellIDString);
+
+	-- C_Spell.GetSpellInfo will error if spellID is nil.
+	if spellID then
+		if C_Spell and C_Spell.GetSpellInfo then
+			local spellInfo = C_Spell.GetSpellInfo(spellID);
+			name = spellInfo and spellInfo.name;
+		else
+			name = GetSpellInfo(spellID);
+		end
+	end
+
+	return name or spellIDString;
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/Resources/CompanionData.lua
+++ b/totalRP3/Resources/CompanionData.lua
@@ -577,6 +577,9 @@ do
 
 		if LE_EXPANSION_LEVEL_CURRENT <= LE_EXPANSION_BURNING_CRUSADE then
 			name = C_Item.GetItemNameByID(petInfo.itemID);
+		elseif C_Spell and C_Spell.GetSpellInfo then
+			local spellInfo = C_Spell.GetSpellInfo(petInfo.spellID);
+			name = spellInfo and spellInfo.name;
 		else
 			name = GetSpellInfo(petInfo.spellID);
 		end
@@ -704,7 +707,15 @@ do
 			return;
 		end
 
-		local name = GetSpellInfo(mountInfo.spellID);
+		local name;
+
+		if C_Spell and C_Spell.GetSpellInfo then
+			local spellInfo = C_Spell.GetSpellInfo(mountInfo.spellID);
+			name = spellInfo and spellInfo.name;
+		else
+			name = GetSpellInfo(mountInfo.spellID);
+		end
+
 		local spellID = mountInfo.spellID;
 		local icon = GetSpellTexture(mountInfo.spellID);
 		local isActive = TRP3_API.utils.resources.GetSummonedMountID() == mountInfo.mountID;


### PR DESCRIPTION
The global GetSpellInfo API is deprecated in current clients and removed in 11.0. fixy fix.

One thing to note is that the new API doesn't accept nil values being supplied as a parameter - it'll error. This only seems to impact one of our call sites, but is a fun problem to deal with.