### PR TITLE
Check launcher action validity for tooltip instructions

### DIFF
--- a/totalRP3/Modules/Launcher/Launcher.lua
+++ b/totalRP3/Modules/Launcher/Launcher.lua
@@ -95,9 +95,10 @@ function TRP3_Launcher:OnTooltipShow(tooltip)
 	for _, binding in ipairs(bindings) do
 		local actionID = self.bindings[binding];
 		local action = self.actions[actionID];
-		local instruction = TRP3_API.FormatShortcutWithInstruction(binding, action.name);
-
-		tooltip:AddLine(instruction);
+		if action then
+			local instruction = TRP3_API.FormatShortcutWithInstruction(binding, action.name);
+			tooltip:AddLine(instruction);
+		end
 	end
 
 	local owner = tooltip:GetOwner();


### PR DESCRIPTION
When writing the launcher tooltip instructions, we parse each action's name to add it at the bottom. However, if an action was bound to a module (say, Extended) that is subsequently disabled, the action doesn't exist anymore, causing the tooltip to error out.

This change just checks whether the action is valid before trying to add it at the bottom of the tooltip, so the instruction just gets skipped otherwise.