### PR TITLE
Add companion custom name and color to Tooltips

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -765,9 +765,6 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 		local name = UnitName(targetType .. "target");
 		local targetTargetID = getUnitID(targetType .. "target");
 		if targetTargetID then
-			---@type Player
-			local targetTarget = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetTargetID)
-			local _, targetEnglishClass = UnitClass(targetType .. "target");
 			local unitType = TRP3_API.ui.misc.getTargetType(targetType .. "target");
 
 			local targetClassColor;
@@ -791,6 +788,9 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 					name = profile.data.NA;
 				end
 			else
+				---@type Player
+				local targetTarget = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetTargetID)
+				local _, targetEnglishClass = UnitClass(targetType .. "target");
 				local targetInfo = getCharacterInfoTab(targetTargetID);
 				targetClassColor = targetEnglishClass and TRP3_API.GetClassDisplayColor(targetEnglishClass) or TRP3_API.Colors.White;
 

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -768,14 +768,38 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			---@type Player
 			local targetTarget = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetTargetID)
 			local _, targetEnglishClass = UnitClass(targetType .. "target");
-			local targetInfo = getCharacterInfoTab(targetTargetID);
-			local targetClassColor = targetEnglishClass and TRP3_API.GetClassDisplayColor(targetEnglishClass) or TRP3_API.CreateColor(1, 1, 1, 1);
+			local unitType = TRP3_API.ui.misc.getTargetType("target");
 
-			if getConfigValue(ConfigKeys.CHARACT_COLOR) then
-				targetClassColor = targetTarget:GetCustomColorForDisplay() or targetClassColor;
+			local targetClassColor;
+			if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.BATTLE_PET or unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then
+				local owner, companionID = TRP3_API.utils.str.companionIDToInfo(targetTargetID);
+				targetClassColor = TRP3_API.Colors.White;
+
+				local profile;
+				if owner == TRP3_API.globals.player_id then
+					profile = TRP3_API.companions.player.getCompanionProfile(companionID);
+				else
+					profile = TRP3_API.companions.register.getCompanionProfile(targetTargetID);
+				end
+
+				if profile and profile.data then
+					if getConfigValue(ConfigKeys.CHARACT_COLOR) then
+						targetClassColor = profile.data.NH and TRP3_API.CreateColorFromHexString(profile.data.NH) or targetClassColor;
+						targetClassColor = TRP3_API.GenerateReadableColor(targetClassColor, TRP3_ReadabilityOptions.TextOnBlackBackground);
+					end
+
+					name = profile.data.NA;
+				end
+			else
+				local targetInfo = getCharacterInfoTab(targetTargetID);
+				targetClassColor = targetEnglishClass and TRP3_API.GetClassDisplayColor(targetEnglishClass) or TRP3_API.Colors.White;
+
+				if getConfigValue(ConfigKeys.CHARACT_COLOR) then
+					targetClassColor = targetTarget:GetCustomColorForDisplay() or targetClassColor;
+				end
+
+				name = getCompleteName(targetInfo.characteristics or {}, name, true);
 			end
-
-			name = getCompleteName(targetInfo.characteristics or {}, name, true);
 
 			if getConfigValue(ConfigKeys.CROP_TEXT) then
 				name = crop(name, FIELDS_TO_CROP.NAME);

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -768,7 +768,7 @@ local function writeTooltipForCharacter(targetID, _, targetType)
 			---@type Player
 			local targetTarget = AddOn_TotalRP3.Player.static.CreateFromCharacterID(targetTargetID)
 			local _, targetEnglishClass = UnitClass(targetType .. "target");
-			local unitType = TRP3_API.ui.misc.getTargetType("target");
+			local unitType = TRP3_API.ui.misc.getTargetType(targetType .. "target");
 
 			local targetClassColor;
 			if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.BATTLE_PET or unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then


### PR DESCRIPTION
This adds support for tooltips to show companions their custom names and colors.

Take a companion like this:
![Wow_GROaAraMLl](https://github.com/Total-RP/Total-RP-3/assets/172234435/17d52f61-80ac-446d-81f3-6e77c7f05270)

**Before this change,** tooltip with someone targetting that companion had this:
![Wow_DPUkRN9svD](https://github.com/Total-RP/Total-RP-3/assets/172234435/63e15eb9-b97f-4ea9-b4ec-4a22e69c705d)
Basically OOC name always and the WARRIOR color.

**After this change,** it now properly gets the RP name and color set:
![Wow_vA8Fo1kdrO](https://github.com/Total-RP/Total-RP-3/assets/172234435/a150278e-2392-4a39-808b-2ca261a236a2)
Look how pretty.


_Don't decimate me too hard, Meow._