### PR TITLE
Editing RP styles should send `REGISTER_DATA_UPDATED`.

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -110,6 +110,7 @@ local function onEditStyle(choice, frame)
 			-- version increment
 			assert(type(dataTab.v) == "number", "Error: No version in draftData or not a number.");
 			dataTab.v = Utils.math.incrementNumber(dataTab.v, 2);
+			TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, getPlayerCurrentProfileID(), "misc");
 		end
 	end
 end


### PR DESCRIPTION
Editing roleplay styles did not actually trigger `REGISTER_DATA_UPDATED`, thus not informing the UI that there was an update.

Apparently that's an oversight (or so Meow says). I tried to fix this, and this is the result.