### PR TITLE
Currently deserves to be framed.

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -1089,6 +1089,14 @@ Putting your companion name in [brackets] will allow color and icon customizatio
 	NPC_TALK_BUTTON_TT = "Open the NPC speeches frame allowing you to do NPC speeches or emotes.",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+	-- Currently
+	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+
+	CURRENTLY_TITLE = "Currently",
+	CURRENTLY_COMMAND_HELP = "Open the Currently frame.",
+	CURRENTLY_BUTTON_TT = "Open the Currently frame allowing you to change your currently status.",
+
+	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- ANALYTICS
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -19,15 +19,14 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 	-- Prepares to show frame, gets player's "currently" and writes it to the scrollbox.
 	local function showCurrentlyFrame()
-		frame.currentlyText.scroll.text:SetText(AddOn_TotalRP3.Player.GetCurrentUser():GetCurrentlyText());
+		frame.CurrentlyText.scroll.text:SetText(AddOn_TotalRP3.Player.GetCurrentUser():GetCurrentlyText());
 
 		frame:Show();
 	end
 	TRP3_API.r.showCurrentlyFrame = showCurrentlyFrame;
 
-	frame.title:SetText(loc.CURRENTLY_TITLE);
-
-	frame.currentlyText.scroll.text:HookScript("OnTextChanged", onCurrentlyChanged);
+	frame.Title:SetText(loc.CURRENTLY_TITLE);
+	frame.CurrentlyText.scroll.text:HookScript("OnTextChanged", onCurrentlyChanged);
 
 	setupMovableFrame(frame);
 

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -5,7 +5,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	local loc = TRP3_API.loc;
 	local setupMovableFrame = TRP3_API.ui.frame.setupMove;
 
-	local frame = TRP3_CURRENTLY;
+	local frame = TRP3_CurrentlyFrame;
 
 	-- Called whenever the OnTextChanged event fires for the currentlyText scrollbox,
 	-- which checks if it was triggered by userInput before changing the "Currently" text.

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -1,0 +1,59 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()
+	local loc = TRP3_API.loc;
+	local setupMovableFrame = TRP3_API.ui.frame.setupMove;
+
+	local frame = TRP3_CURRENTLY;
+
+	-- Called whenever the OnTextChanged event fires for the currentlyText scrollbox,
+	-- which checks if it was triggered by userInput before changing the "Currently" text.
+	local function onCurrentlyChanged(editBox, userInput)
+		if not userInput then
+			return;
+		end
+
+		AddOn_TotalRP3.Player.GetCurrentUser():SetCurrentlyText(editBox:GetText());
+	end
+
+	-- Prepares to show frame, gets player's "currently" and writes it to the scrollbox.
+	local function showCurrentlyFrame()
+		frame.currentlyText.scroll.text:SetText(AddOn_TotalRP3.Player.GetCurrentUser():GetCurrentlyText());
+
+		frame:Show();
+	end
+	TRP3_API.r.showCurrentlyFrame = showCurrentlyFrame;
+
+	frame.title:SetText(loc.CURRENTLY_TITLE);
+
+	frame.currentlyText.scroll.text:HookScript("OnTextChanged", onCurrentlyChanged);
+
+	setupMovableFrame(frame);
+
+	if TRP3_API.toolbar then
+		-- Create a toolbar button to show/hide the Currently frame.
+		TRP3_API.toolbar.toolbarAddButton({
+			id = "bb_trp3_currently",
+			icon = TRP3_InterfaceIcons.ToolbarCurrently,
+			configText = loc.CURRENTLY_TITLE,
+			tooltip = loc.CURRENTLY_TITLE,
+			tooltipSub = loc.CURRENTLY_BUTTON_TT,
+			onClick = function()
+				if frame:IsShown() then
+					frame:Hide();
+				else
+					showCurrentlyFrame();
+				end
+			end,
+		});
+	end
+
+	-- Register a slash command, so if people disable the toolbar button
+	-- or toolbar module the frame can still be called.
+	TRP3_API.slash.registerCommand({
+		id = "currently",
+		helpLine = " " .. loc.CURRENTLY_COMMAND_HELP,
+		handler = showCurrentlyFrame
+	});
+end);

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -18,12 +18,17 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	end
 
 	-- Prepares to show frame, gets player's "currently" and writes it to the scrollbox.
-	local function showCurrentlyFrame()
+	local function toggleCurrentlyFrame()
+		if frame:IsShown() then
+			frame:Hide();
+			return;
+		end
+
 		frame.CurrentlyText.scroll.text:SetText(AddOn_TotalRP3.Player.GetCurrentUser():GetCurrentlyText());
 
 		frame:Show();
 	end
-	TRP3_API.r.showCurrentlyFrame = showCurrentlyFrame;
+	TRP3_API.r.toggleCurrentlyFrame = toggleCurrentlyFrame;
 
 	frame.Title:SetText(loc.CURRENTLY_TITLE);
 	frame.CurrentlyText.scroll.text:HookScript("OnTextChanged", onCurrentlyChanged);
@@ -39,11 +44,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			tooltip = loc.CURRENTLY_TITLE,
 			tooltipSub = loc.CURRENTLY_BUTTON_TT,
 			onClick = function()
-				if frame:IsShown() then
-					frame:Hide();
-				else
-					showCurrentlyFrame();
-				end
+				toggleCurrentlyFrame();
 			end,
 		});
 	end
@@ -53,6 +54,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	TRP3_API.slash.registerCommand({
 		id = "currently",
 		helpLine = " " .. loc.CURRENTLY_COMMAND_HELP,
-		handler = showCurrentlyFrame
+		handler = toggleCurrentlyFrame
 	});
 end);

--- a/totalRP3/Modules/Dashboard/Currently.xml
+++ b/totalRP3/Modules/Dashboard/Currently.xml
@@ -7,7 +7,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Include file="Currently.lua"/>
 
-	<Frame name="TRP3_CURRENTLY" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG">
+	<Frame name="TRP3_CurrentlyFrame" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG">
 		<Size x="350" y="215"/>
 		<Anchors>
 			<Anchor point="CENTER"/>

--- a/totalRP3/Modules/Dashboard/Currently.xml
+++ b/totalRP3/Modules/Dashboard/Currently.xml
@@ -19,14 +19,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Scripts>
 		<Layers>
 			<Layer level="OVERLAY">
-				<FontString parentKey="title" inherits="GameFontNormalLarge" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
+				<FontString parentKey="Title" inherits="GameFontHighlightLarge" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
 					<Size x="0" y="30"/>
 					<Anchors>
 						<Anchor point="TOP" x="0" y="-10"/>
 						<Anchor point="RIGHT" x="-10" y="0"/>
 						<Anchor point="LEFT" x="10" y="0"/>
 					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
 				</FontString>
 			</Layer>
 		</Layers>
@@ -43,10 +42,10 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<OnClick function="HideParentPanel"/>
 				</Scripts>
 			</Button>
-			<Frame parentKey="currentlyText" inherits="TRP3_TextArea">
+			<Frame parentKey="CurrentlyText" inherits="TRP3_TextArea">
 				<Size y="144"/>
 				<Anchors>
-					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.title" x="11" y="6"/>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.Title" x="11" y="6"/>
 					<Anchor point="RIGHT" x="-20" />
 				</Anchors>
 			</Frame>

--- a/totalRP3/Modules/Dashboard/Currently.xml
+++ b/totalRP3/Modules/Dashboard/Currently.xml
@@ -1,0 +1,55 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+
+	<Include file="Currently.lua"/>
+
+	<Frame name="TRP3_CURRENTLY" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG">
+		<Size x="350" y="215"/>
+		<Anchors>
+			<Anchor point="CENTER"/>
+		</Anchors>
+		<Scripts>
+			<OnLoad inherit="prepend">
+				tinsert(UISpecialFrames, self:GetName());
+			</OnLoad>
+		</Scripts>
+		<Layers>
+			<Layer level="OVERLAY">
+				<FontString parentKey="title" inherits="GameFontNormalLarge" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
+					<Size x="0" y="30"/>
+					<Anchors>
+						<Anchor point="TOP" x="0" y="-10"/>
+						<Anchor point="RIGHT" x="-10" y="0"/>
+						<Anchor point="LEFT" x="10" y="0"/>
+					</Anchors>
+					<Color r="0.95" g="0.95" b="0.95"/>
+				</FontString>
+			</Layer>
+		</Layers>
+		<Frames>
+			<Button parentKey="Close" inherits="TRP3_StyledButtonTemplate">
+				<Size x="24" y="24"/>
+				<KeyValues>
+					<KeyValue key="styleName" value="CloseButton" type="string"/>
+				</KeyValues>
+				<Anchors>
+					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
+				</Anchors>
+				<Scripts>
+					<OnClick function="HideParentPanel"/>
+				</Scripts>
+			</Button>
+			<Frame parentKey="currentlyText" inherits="TRP3_TextArea">
+				<Size y="144"/>
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.title" x="11" y="6"/>
+					<Anchor point="RIGHT" x="-20" />
+				</Anchors>
+			</Frame>
+		</Frames>
+	</Frame>
+</Ui>

--- a/totalRP3/Modules/Dashboard/Dashboard.xml
+++ b/totalRP3/Modules/Dashboard/Dashboard.xml
@@ -15,7 +15,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="HTMLContent.xml"/>
 	<Include file="TabFrame.xml"/>
 	<Include file="StatusPanel.xml"/>
-	<Include file="Currently.xml" />
+	<Include file="Currently.xml"/>
 
 	<Frame name="TRP3_PartyTime" virtual="true">
 		<Size x="75" y="75"/>

--- a/totalRP3/Modules/Dashboard/Dashboard.xml
+++ b/totalRP3/Modules/Dashboard/Dashboard.xml
@@ -15,6 +15,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="HTMLContent.xml"/>
 	<Include file="TabFrame.xml"/>
 	<Include file="StatusPanel.xml"/>
+	<Include file="Currently.xml" />
 
 	<Frame name="TRP3_PartyTime" virtual="true">
 		<Size x="75" y="75"/>

--- a/totalRP3/Resources/InterfaceIcons.lua
+++ b/totalRP3/Resources/InterfaceIcons.lua
@@ -55,6 +55,7 @@ TRP3_InterfaceIcons = {
 	ToolbarHelmetOn  = { "inv_helmet_13" },
 	ToolbarHelmetOff = { "spell_nature_invisibilty" },
 	ToolbarLanguage  = { "spell_holy_silence" },
+	ToolbarCurrently = { "ui_chat" },
 
 	--
 	-- Player Mode Icons


### PR DESCRIPTION
Basically this is based on the "NPC Speech" frame idea.

There's a new toolbar button using the "ui_chat" interface icon, which can be toggled in "Frames settings".
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/2459d5f3-dd97-46a2-a04b-65ae351cb243)
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/bab78bb2-a21b-43e2-bb63-e0a135998c79)

Clicking on it will reveal the Currently frame. Which features a single scrollbox that feeds directly into "CU" (like the profile currently box). Input is sanitzed and version incremented like normal.
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/e00965c2-65e4-4ee1-9765-dcb8e7956604)

There's also a chat command "/trp3 currently" which opens the same chat frame. In case the toolbar is not used or you want to hide the button.
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/b829e06e-9d46-4370-aab5-bd22c53499a1)


There are three new strings that will require localization.