### PR TITLE
Make NPCTalk and Currently frames toplevel

### DIFF
--- a/totalRP3/Modules/Dashboard/Currently.xml
+++ b/totalRP3/Modules/Dashboard/Currently.xml
@@ -7,7 +7,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Include file="Currently.lua"/>
 
-	<Frame name="TRP3_CurrentlyFrame" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG">
+	<Frame name="TRP3_CurrentlyFrame" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG" toplevel="true">
 		<Size x="350" y="215"/>
 		<Anchors>
 			<Anchor point="CENTER"/>

--- a/totalRP3/Modules/Dashboard/Dashboard.xml
+++ b/totalRP3/Modules/Dashboard/Dashboard.xml
@@ -141,7 +141,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_NPCTalk" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG">
+	<Frame name="TRP3_NPCTalk" inherits="TRP3_AltHoveredFrame" enableMouse="true" hidden="true" movable="true" clampedToScreen="true" parent="UIParent" frameStrata="DIALOG" toplevel="true">
 		<Size x="350" y="215"/>
 		<Anchors>
 			<Anchor point="CENTER"/>


### PR DESCRIPTION
These are interactive dialog frames which can be moved around. Adding the toplevel attribute ensures they're raised upon mouse interactions, and prevents issues when the frames overlap and try to have weird babies.

![image](https://github.com/Total-RP/Total-RP-3/assets/287102/59159562-8e4a-4c45-b8bc-55728a8ebf54)
