### PR TITLE
Export localization strings globally

### DIFF
--- a/totalRP3/Libs/Ellyb/Tools/Locale.lua
+++ b/totalRP3/Libs/Ellyb/Tools/Locale.lua
@@ -80,3 +80,7 @@ end
 function Locale:LocalizationKeyExists(localizationKey)
 	return self:GetText(localizationKey) ~= nil;
 end
+
+function Locale:EnumerateTexts()
+	return pairs(private[self].content);
+end

--- a/totalRP3/Libs/Ellyb/Tools/Localization.lua
+++ b/totalRP3/Libs/Ellyb/Tools/Localization.lua
@@ -144,3 +144,7 @@ function Localization:GetText(localizationKey)
 		self:GetDefaultLocale():GetText(localizationKey) or -- Look in the default locale
 		localizationKey; -- As a last resort, to avoid nil strings, return the key itself
 end
+
+function Localization:EnumerateTexts()
+	return self:GetActiveLocale():EnumerateTexts();
+end

--- a/totalRP3/Locales/Locale.lua
+++ b/totalRP3/Locales/Locale.lua
@@ -14,6 +14,14 @@ function Locale.init()
 	BINDING_NAME_TRP3_TOOLBAR_TOGGLE = TRP3_API.loc.BINDING_NAME_TRP3_TOOLBAR_TOGGLE;
 	BINDING_NAME_TRP3_OPEN_TARGET_PROFILE = TRP3_API.loc.BINDING_NAME_TRP3_OPEN_TARGET_PROFILE;
 	BINDING_NAME_TRP3_TOGGLE_CHARACTER_STATUS = TRP3_API.loc.BINDING_NAME_TRP3_TOGGLE_CHARACTER_STATUS;
+
+	-- Localization strings are exported globally for use from XML which
+	-- is incapable of performing nested lookups. Longer-term, we may want
+	-- to use global strings everywhere for consistency.
+
+	for key, value in TRP3_API.loc:EnumerateTexts() do
+		_G["TRP3_L_" .. key] = value;
+	end
 end
 
 -- Shortcut formatting


### PR DESCRIPTION
Currently using localization strings in XML is a massive pain in the rear with our approach being rather inconsistent. We've got a mixture of code that either sets strings in OnLoad or OnShow handlers, and some code using the "LocalizeTextOnAddOnLoad" genericism added with the icon browser rework.

There's two reasons that we've got such varied approaches;

  1. Translation strings aren't available until ADDON_LOADED thanks to our addon locale setting, that I've railed against as the worst idea since time immemorial.

  2. The various methods for accessing text strings in XML (typically via the `text=""` attribute) don't support nested lookups, only globals.

The first problem can be mitigated somewhat by moving all of our UI creation tasks until the point that they're needed - which is something that's *very slowly* happening in the background anyway.

The second problem isn't likely to be solved by Blizzard for us any time soon, so would be entirely on us to resolve.

As such, this commit puts forth the idea of just spilling our guts out all over \_G and exporting all of our translation strings with a "TRP3_L_" prefix. These can be referenced directly in text attributes in XML for all templates and frames that are known to be loaded after we've figured out which locale needs using.

Longer-term, we may want to consider killing the `loc` table and using the globals consistently everywhere - but stopping short of that now as that would be a cataclysmic change. Would rather evaluate how usable this global approach ends up being first.