### PR TITLE
Guard against attempts to animate the void

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1067,7 +1067,10 @@ function TRP3_API.ui.frame.configureHoverFrame(frame, hoveredFrame, arrowPositio
 	end
 
 	frame:Show();
-	playAnimation(frame[animation]);
+
+	if frame[animation] then
+		playAnimation(frame[animation]);
+	end
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*


### PR DESCRIPTION
The configureHoverFrame utility unilaterally assumes the supplied frames has associated animations. With the removal of the checks in playAnimation, this is now lethal.