### PR TITLE
Make empty glance text be actually empty (and not "...") (fixes #682)

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -193,11 +193,7 @@ local function setupGlanceButton(button, active, icon, title, text, isMine)
 	button:SetNormalTexture("Interface\\ICONS\\" .. (icon or GLANCE_NOT_USED_ICON));
 	if active then
 		button:SetAlpha(1);
-		if not isMine then
-			setTooltipForSameFrame(button, "RIGHT", 0, 5, title or "...", text);
-		else
-			setTooltipForSameFrame(button, "RIGHT", 0, 5, title or "...", (text or "..."));
-		end
+		setTooltipForSameFrame(button, "RIGHT", 0, 5, title or "...", text or "");
 	else
 		button:SetAlpha(0.1);
 		if not isMine then

--- a/totalRP3/Modules/Register/Main/AtFirstGlanceChatLinksModule.lua
+++ b/totalRP3/Modules/Register/Main/AtFirstGlanceChatLinksModule.lua
@@ -42,7 +42,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		if glance.IC and glance.IC:len() > 0 then
 			icon = glance.IC;
 		end
-		local TTText = glance.TX or "...";
+		local TTText = glance.TX or "";
 		local glanceTitle = glance.TI or "...";
 		if shouldCropTexts() then
 			TTText = crop(TTText, GLANCE_TOOLTIP_CROP);

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -637,7 +637,7 @@ local function displayGlanceSlots()
 				if glance.IC and glance.IC:len() > 0 then
 					icon = glance.IC;
 				end
-				local TTText = glance.TX or "...";
+				local TTText = glance.TX or "";
 				local glanceTitle = glance.TI or "...";
 				if not isCurrentMine and shouldCropTexts() then
 					TTText = crop(TTText, GLANCE_TOOLTIP_CROP);


### PR DESCRIPTION
It was decided by the wisdom of the *lesser* ancients (Sol, Meorawr) that to be consistent a glance with empty text will just display nothing instead of "..." at times.

This should fix/resolve #682.