### PR TITLE
Fix glance editor overlap issues

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
@@ -229,7 +229,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_AtFirstGlanceEditor" inherits="TRP3_HoveredFrame" parent="UIParent" hidden="true">
+	<Frame name="TRP3_AtFirstGlanceEditor" inherits="TRP3_HoveredFrame" parent="UIParent" hidden="true" toplevel="true" enableMouse="true">
 		<Size x="300" y="175"/>
 		<Layers>
 			<Layer level="OVERLAY">

--- a/totalRP3/Modules/Register/Main/RegisterUIGlance.xml
+++ b/totalRP3/Modules/Register/Main/RegisterUIGlance.xml
@@ -31,7 +31,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Scripts>
 	</Button>
 
-	<Frame name="TRP3_GlanceBarTemplate" hidden="true" frameStrata="MEDIUM" toplevel="true" enableMouse="true" virtual="true" inherits="BackdropTemplate">
+	<Frame name="TRP3_GlanceBarTemplate" hidden="true" frameStrata="MEDIUM" enableMouse="true" virtual="true" inherits="BackdropTemplate">
 		<KeyValues>
 			<KeyValue key="backdropInfo" value="TRP3_BACKDROP_MIXED_TUTORIAL_TOOLTIP_418_16_3353" type="global"/>
 		</KeyValues>


### PR DESCRIPTION
Editing glances would cause a bit of overlap like here:
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/4bda89bd-acd3-46b3-bd96-c32ac7169fcf)

After these changes, it's fixed and like so:
![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/531839b7-523c-47e6-b3e5-7eb45212dd1f)

Also I totally did this all on my own _(thanks Meorawr for some insight in this issue)_!