### PR TITLE
Fix KuiNameplates error when customization module is disabled

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Kui.lua
@@ -393,7 +393,7 @@ end
 function TRP3_KuiNamePlates:CanCustomizeNamePlate(nameplate)
 	local nameplateKey = nameplate:GetName();
 
-	if not self.initialized[nameplateKey] then
+	if not self.initialized or not self.initialized[nameplateKey] then
 		return false;  -- Reject uninitialized nameplates.
 	elseif nameplate.state.personal or not nameplate.state.reaction then
 		return false;  -- Reject personal and invalid nameplates.


### PR DESCRIPTION
A long time ago (https://github.com/Total-RP/Total-RP-3/pull/884), changes were made to the KuiNameplates module to register some functions before the Kui initialization process.

Unfortunately, the function in charge of determining whether the nameplate should be customized tries to access a table that is not initialized if the module is disabled, causing it to completely break KuiNameplates as a result (on top of perma-erroring).

I've added a check on whether the table is nil. Alternative solution would be to create the table in OnLoad, not sure if that'd be a better solve. 🤷 