### PR TITLE
Make default RP status OOC

### DIFF
--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -34,7 +34,7 @@ local get, getDefaultProfile = TRP3_API.profile.getData, TRP3_API.profile.getDef
 
 getDefaultProfile().player.character = {
 	v = 1,
-	RP = TRP3_Enums.ROLEPLAY_STATUS.IN_CHARACTER,
+	RP = TRP3_Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER,
 	XP = TRP3_Enums.ROLEPLAY_EXPERIENCE.EXPERIENCED,
 }
 

--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -3,7 +3,7 @@
 
 TRP3_API.flyway = {};
 
-local SCHEMA_VERSION = 18;
+local SCHEMA_VERSION = 19;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -319,6 +319,7 @@ TRP3_API.flyway.patches["19"] = function()
 
 		if character then
 			character.RP = AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER;
+			character.v = TRP3_API.utils.math.incrementNumber(character.v or 1, 2);
 		end
 	end
 end

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -304,3 +304,21 @@ TRP3_API.flyway.patches["18"] = function()
 		TRP3_Profiles[oldDefaultProfileID] = nil;
 	end
 end
+
+
+TRP3_API.flyway.patches["19"] = function()
+	-- Modify default profile ID to be OOC.
+
+	if not TRP3_Profiles or not TRP3_Configuration then
+		return;
+	end
+
+	if TRP3_Configuration["default_profile_id"] then
+		local profile = TRP3_Profiles[TRP3_Configuration["default_profile_id"]];
+		local character = SafeGet(profile, "player", "character");
+
+		if character then
+			character.RP = AddOn_TotalRP3.Enums.ROLEPLAY_STATUS.OUT_OF_CHARACTER;
+		end
+	end
+end


### PR DESCRIPTION
Fixes #179. The default profile is now created for new users with the RP status field set to OOC, and a flyway has been added to additionally migrate existing default profiles to OOC.

The rationale for the flyway is just to ensure consistency; it'll be confusing for all parties involved if we have to explain that for some users the default state will vary based upon when they first used the addon, and the only way for users who would want it to default to OOC would be through manual modification.

The #179 ticket additionally suggests additional tutorials, but it's unlikely such tutorials would ever be read.