### PR TITLE
Center RP style options on large window sizes

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -140,12 +140,10 @@ local function displayRPStyle(context)
 			-- Position
 			frame:ClearAllPoints();
 			if previous == nil then
-				frame:SetPoint("TOPLEFT", TRP3_RegisterMiscViewRPStyle, "TOPLEFT", 25, -12);
+				frame:SetPoint("TOP", TRP3_RegisterMiscViewRPStyle, "TOP", 0, -12);
 			else
-				frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 0);
+				frame:SetPoint("TOP", previous, "BOTTOM", 0, 0);
 			end
-			frame:SetPoint("LEFT", 0, 0);
-			frame:SetPoint("RIGHT", 0, 0);
 
 			-- Value
 			_G[frame:GetName().."FieldName"]:SetText(fieldData.name);

--- a/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
@@ -6,7 +6,7 @@
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Frame name="TRP3_RegisterRPStyleMain_Edit_Line" virtual="true">
-		<Size x="0" y="30"/>
+		<Size x="465" y="30"/>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString name="$parentFieldName" inherits="GameFontNormal" justifyH="LEFT" text="[Field]">


### PR DESCRIPTION
Currently the RP style options in the misc. tab all end up awkwardly hugging the left side of the window when the frame is resized. Rather than do anything crazy, let's center it to be consistent with other stuff on the same tab like the glance list.