### PR TITLE
Center Status panel on dashboard

### DIFF
--- a/totalRP3/Modules/Dashboard/StatusPanel.xml
+++ b/totalRP3/Modules/Dashboard/StatusPanel.xml
@@ -13,7 +13,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<FontString parentKey="RPStatusLabel" inherits="GameFontNormal" justifyH="LEFT">
 					<Size x="200" y="18"/>
 					<Anchors>
-						<Anchor point="TOPLEFT" x="30" y="-18"/>
+						<Anchor point="TOPRIGHT" relativePoint="TOP" x="-15" y="-18"/>
 					</Anchors>
 					<Color b="1.0" r="1.0" g="1.0"/>
 				</FontString>


### PR DESCRIPTION
Similar to the changes made for RP style options; make sure the contents of the Status panel are centered on window resize.

![image](https://github.com/Total-RP/Total-RP-3/assets/287102/c421540d-5746-43b1-9bfa-4658ce5f0473)
