### PR TITLE
Fix progress spinner wobble

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUIMain.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMain.xml
@@ -9,7 +9,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Size x="18" y="18"/>
 		<Layers>
 			<Layer level="OVERLAY">
-				<Texture parentKey="Icon" file="Interface\AddOns\totalRP3\Resources\UI\ui-refresh">
+				<Texture parentKey="Icon" file="Interface\AddOns\totalRP3\Resources\UI\ui-refresh" texelSnappingBias="0.0" snapToPixelGrid="false">
 					<Size x="16" y="16"/>
 					<Anchors>
 						<Anchor point="RIGHT"/>


### PR DESCRIPTION
The progress spinner on the tooltip has a bit of a visual wobble when animating, with the cause being that by default it has texel and grid snapping enabled for image sharpening.

Disabling this fixes the wobble and makes the animation much smoother.