### PR TITLE
Avoid potential asserts in GetRoleplayExperience

### DIFF
--- a/totalRP3/Core/Player.lua
+++ b/totalRP3/Core/Player.lua
@@ -204,7 +204,12 @@ end
 
 function Player:GetRoleplayExperience()
 	-- Note that this will return nil for profiles belonging to this player.
-	local characterInfo = TRP3_API.register.getUnitIDCharacter(self:GetCharacterID());
+	local characterInfo;
+
+	if TRP3_API.register.isUnitIDKnown(self:GetCharacterID()) then
+		characterInfo = TRP3_API.register.getUnitIDCharacter(self:GetCharacterID());
+	end
+
 	return characterInfo and characterInfo.roleplayExperience;
 end
 


### PR DESCRIPTION
Not sure on the cause, don't care. This logic was the same as GetAccountType so presumably that could error too, but as it's not been seen I suspect there's just some exigent circumstance that this specific field meeds that the other does not.