### PR TITLE
zhTW locale fixes

### DIFF
--- a/totalRP3/Locales/zhTW.lua
+++ b/totalRP3/Locales/zhTW.lua
@@ -155,7 +155,7 @@ L = {
 	["CO_GENERAL_BROADCAST"] = "使用廣播頻道",
 	["CO_GENERAL_BROADCAST_C"] = "廣播頻道名稱",
 	["CO_GENERAL_BROADCAST_TT"] = "廣播頻道和許多功能連結。禁用廣播功能將連帶禁用所有功能，例如顯示玩家在地圖上的位置、播放範圍音效、藏物處等…",
-	["CO_GENERAL_CHANGELOCALE_ALERT"] = [=[立即重新登入介面來切換為 %S 語言選項嗎？
+	["CO_GENERAL_CHANGELOCALE_ALERT"] = [=[立即重新登入介面來切換為 %s 語言選項嗎？
 
 如果不要，語言選項將會在下次登入時變更。]=],
 	["CO_GENERAL_COM"] = "訊息",
@@ -307,7 +307,6 @@ L = {
 	["DB_STATUS_CURRENTLY_COMMON"] = "這些狀態也會顯示在你的角色卡欄位，Keep it clear and brief as |cffff9900by default TRP3 players will only see the first 140 characters of them!",
 	["DB_STATUS_CURRENTLY_OOC"] = "其他資訊（OOC）",
 	["DB_STATUS_CURRENTLY_OOC_TT"] = "這裡可以輸入任何對角色還是玩家來說重要的資訊。",
-	["DB_STATUS_CURRENTLY_TT"] = "此欄位搭配「TRP3 Currently frame」使用可以達到不必開啟視窗，即時於畫面上變更的效果。",
 	["DB_STATUS_RP"] = "角色狀態",
 	["DB_STATUS_RP_IC"] = "進入角色（IC）",
 	["DB_STATUS_RP_IC_TT"] = "這表示你正在扮演你的角色，所有你的行動都不再依據你本人的好惡抉擇，而是衷於你所設定的角色性格來起心動念。",


### PR DESCRIPTION
CO_GENERAL_CHANGELOCALE_ALERT was fixed to have the proper formatting token and not error out when trying to change from zhTW locale.

DB_STATUS_CURRENTLY_TT was removed because it doesn't seem to match the original text at all.