### PR TITLE
Improve import and export of translation strings

### DIFF
--- a/.github/workflows/export-all-translations.yml
+++ b/.github/workflows/export-all-translations.yml
@@ -1,5 +1,5 @@
 ---
-name: Upload All Translations
+name: Export All Translations
 on:
   workflow_dispatch: {}
 
@@ -16,8 +16,8 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r .github/scripts/requirements.txt
 
-      - name: Upload CurseForge Translations
-        run: make push-all-locales
+      - name: Export All Translations
+        run: make translations-export-all
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
 

--- a/.github/workflows/export-translations.yml
+++ b/.github/workflows/export-translations.yml
@@ -1,11 +1,9 @@
 ---
-name: Process CurseForge Translations
+name: Export Translations
 on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 18 * * *'
   workflow_dispatch: {}
 
 jobs:
@@ -21,26 +19,10 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r .github/scripts/requirements.txt
 
-      - name: Upload CurseForge Translations
-        run: make push-locales
+      - name: Export Translations
+        run: make translations-export
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
-
-      - name: Download CurseForge Translations
-        run: make pull-locales
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: Import CurseForge Localization
-          branch: actions/import-cf-localization
-          delete-branch: true
-          title: Import CurseForge Localization
-          body: Automated import of CurseForge localization.
-          author: GitHub <noreply@github.com>
-          reviewers: Meorawr, Solanya
 
       - name: Send Webhook Notification
         if: failure()

--- a/.github/workflows/import-translations.yml
+++ b/.github/workflows/import-translations.yml
@@ -1,0 +1,46 @@
+---
+name: Import External Translations
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Import External Translations
+        run: make translations-import
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Import External Translations
+          branch: actions/import-external-translations
+          delete-branch: true
+          title: Import External Translations
+          body: Automated import of external translation strings.
+          author: GitHub <noreply@github.com>
+          reviewers: Meorawr, Solanya
+
+      - name: Send Webhook Notification
+        if: failure()
+        run: |
+          git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+          bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+        env:
+          JOB_STATUS: ${{ job.status }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}


### PR DESCRIPTION
Following on from the lessons previously learned in #946 and #948, we'll set the delete-missing-phrases flag _only_ on enUS uploads going forward as that appears to work fine. All other translation uploads will not set the flag.

This means that going forward the minimum required process to delete a translation string should just be to remove it from the 'enUS.lua' file; a subsequent import of translation strings would then remove it from all other files automatically. It is, however, totally permissible to remove the string from all files if that would make things clearer.

Additionally I've made some of the terminology around the place a bit more consistent for this whole process, eg. preferring to use "translations" instead of "locales" for target names and workflows. For the possibility of using non-CF sources (#949) I've also removed "CurseForge" from the workflow strings.

Finally - one functional change; we no longer import translations on commits to main. We continue to export new strings from the enUS file, but that's all. The importing of non-enUS translations continues to happen on the same timer it always has, as well as being manually runnable.