### PR TITLE
Rename Masters to Owners

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -731,7 +731,7 @@ Just like characters profiles, a |cff00ff00companion profile|r can be linked to 
 	PR_CO_PROFILE_HELP2 = [[Click here to create a new companion profile.
 
 |cff00ff00To link a profile to a pet (hunter pet, warlock minion...), just summon the pet, select it and use the target frame to link it to a existing profile (or create a new one).|r]],
-	PR_CO_MASTERS = "Masters",
+	PR_CO_MASTERS = "Owners",
 	PR_CO_EMPTY = "No companion profile",
 	PR_CO_NEW_PROFILE = "New companion profile",
 	PR_CO_COUNT = "%s pets/mounts linked to this profile.",


### PR DESCRIPTION
Most places in the addon refer to the person in charge of a pet as its owner, but this one dropdown in companion profiles.
Not sure it's worth resetting other languages just for that, but we can at least be consistent here.