### PR TITLE
Update the target frame buttons

### DIFF
--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -95,11 +95,13 @@ local function onStart()
 			end
 
 			if type(buttonStructure.icon) == "table" and buttonStructure.icon.Apply then
-				uiButton:SetNormalTexture(buttonStructure.icon:GetFileID())
-				uiButton:SetPushedTexture(buttonStructure.icon:GetFileID());
+				if buttonStructure.icon:GetFileID() == 516771 then
+					uiButton.Icon:SetTexture(buttonStructure.icon:GetFileID())
+				else
+					uiButton:SetIconTexture(buttonStructure.icon:GetFileID())
+				end
 			else
-				uiButton:SetNormalTexture("Interface\\ICONS\\"..buttonStructure.icon);
-				uiButton:SetPushedTexture("Interface\\ICONS\\"..buttonStructure.icon);
+				uiButton:SetIconTexture(buttonStructure.icon);
 			end
 
 			if uiButton:GetPushedTexture() then

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -60,7 +60,7 @@ local function onStart()
 	end
 
 	local function displayButtonsPanel()
-		local buttonSize = getConfigValue(CONFIG_TARGET_ICON_SIZE);
+		local buttonSize = getConfigValue(CONFIG_TARGET_ICON_SIZE) + 8; -- Adding 8 to offset the borders making the icon look smaller
 
 		--Hide all
 		for _,uiButton in pairs(uiButtons) do
@@ -125,17 +125,17 @@ local function onStart()
 			uiAlert:Hide();
 			if buttonStructure.alert and buttonStructure.alertIcon then
 				uiAlert:Show();
-				uiAlert:SetWidth(buttonSize / 1.7);
-				uiAlert:SetHeight(buttonSize / 1.7);
+				uiAlert:SetWidth(buttonSize / 2);
+				uiAlert:SetHeight(buttonSize / 2);
 				uiAlert:SetTexture(buttonStructure.alertIcon);
 			end
 
 			index = index + 1;
-			x = x + buttonSize + 2;
+			x = x + buttonSize - 2;
 		end
 
 		local oldWidth = ui_TargetFrame:GetWidth();
-		ui_TargetFrame:SetWidth(math.max(30 + index * buttonSize, 200));
+		ui_TargetFrame:SetWidth(math.max(22 + index * (buttonSize - 2), 200));
 		-- Updating anchors so the toolbar expands from the center
 		local anchor, _, _, tfX, tfY = ui_TargetFrame:GetPoint(1);
 		if anchor == "LEFT" then

--- a/totalRP3/Modules/TargetFrame/TargetFrame.xml
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.xml
@@ -15,7 +15,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<Texture name="$parentAlert">
 					<Size x="15" y="15" />
 					<Anchors>
-						<Anchor point="BOTTOMLEFT" x="0" y="0" />
+						<Anchor point="BOTTOMLEFT" x="0" y="4" />
 					</Anchors>
 				</Texture>
 			</Layer>

--- a/totalRP3/Modules/TargetFrame/TargetFrame.xml
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.xml
@@ -5,10 +5,11 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<!-- Target frame button -->
-	<Button name="TRP3_TargetFrameButton" virtual="true">
-		<Size x="30" y="30" />
-		<NormalTexture name="$parentNormal" />
-		<HighlightTexture alphaMode="ADD" file="Interface/BUTTONS/ButtonHilight-Square"/>
+	<Button name="TRP3_TargetFrameButton" inherits="TRP3_BorderedIconTemplate" virtual="true">
+		<Size x="35" y="35" />
+		<HighlightTexture parentKey="HighlightBorder" file="Interface\AddOns\totalRP3\Resources\UI\ui-frame-slice-sm-glow" alphaMode="ADD">
+			<Color r="1" g="0.675" b="0.125"/>
+		</HighlightTexture>
 		<Layers>
 			<Layer level="OVERLAY">
 				<Texture name="$parentAlert">


### PR DESCRIPTION
This new bordered icon button is sick so we might as well abuse the hell out of it.

Of note, the size of the buttons in the target frame doesn't exactly match the size in the settings anymore. I thought it best to not mess with the setting value and just offset in the background to account for the border.

I've also done a very minor adjustment so the margins on each side are properly symmetrical.

![image](https://github.com/Total-RP/Total-RP-3/assets/17127080/8e564ef2-a9c8-4480-b3b8-6134152e2fef)
