### PR TITLE
Add character class ID to exchange

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -257,7 +257,7 @@ local function SanitizeRoleplayExperience(experience)
 end
 
 --- Raises error if unknown unitName
-function TRP3_API.register.saveClientInformation(unitID, client, clientVersion, msp, extended, trialAccount, extendedVersion, roleplayExperience)
+function TRP3_API.register.saveClientInformation(unitID, client, clientVersion, msp, extended, trialAccount, extendedVersion, roleplayExperience, classID)
 	local character = getUnitIDCharacter(unitID);
 	character.client = Utils.str.sanitize(client);
 	character.clientVersion = Utils.str.sanitizeVersion(clientVersion);
@@ -266,6 +266,7 @@ function TRP3_API.register.saveClientInformation(unitID, client, clientVersion, 
 	character.isTrial = trialAccount;
 	character.extendedVersion = Utils.str.sanitizeVersion(extendedVersion);
 	character.roleplayExperience = SanitizeRoleplayExperience(roleplayExperience);
+	character.classID = classID;
 end
 
 --- Raises error if unknown unitName

--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -144,6 +144,7 @@ local VERNUM_QUERY_INDEX_COMPANION_SECONDARY_PET = 20;
 local VERNUM_QUERY_INDEX_COMPANION_SECONDARY_PET_V1 = 21;
 local VERNUM_QUERY_INDEX_COMPANION_SECONDARY_PET_V2 = 22;
 local VERNUM_QUERY_INDEX_ROLEPLAY_EXPERIENCE = 23;
+local VERNUM_QUERY_INDEX_CHARACTER_CLASS = 24;
 
 local queryInformationType, createVernumQuery;
 
@@ -176,6 +177,7 @@ function createVernumQuery()
 	query[VERNUM_QUERY_INDEX_COMPANION_MOUNT_V1] = mountV1 or 0;
 	query[VERNUM_QUERY_INDEX_COMPANION_MOUNT_V2] = mountV2 or 0;
 	query[VERNUM_QUERY_INDEX_ROLEPLAY_EXPERIENCE] = AddOn_TotalRP3.Player.GetCurrentUser():GetRoleplayExperience();
+	query[VERNUM_QUERY_INDEX_CHARACTER_CLASS] = TRP3_API.globals.player_class_index;
 
 	-- Extended
 	if Globals.extended_version then
@@ -390,6 +392,7 @@ local function incomingVernumQuery(structure, senderID, sendBack)
 	local senderIsTrial = structure[VERNUM_QUERY_INDEX_TRIALS];
 	local senderExtendedVersionText = structure[VERNUM_QUERY_INDEX_EXTENDED_DISPLAY];
 	local roleplayExperience = structure[VERNUM_QUERY_INDEX_ROLEPLAY_EXPERIENCE];
+	local senderClassID = structure[VERNUM_QUERY_INDEX_CHARACTER_CLASS];
 
 	senderVersion = tonumber(senderVersion) or 0;
 	senderExtendedVersion = tonumber(senderExtendedVersion) or 0;
@@ -404,7 +407,7 @@ local function incomingVernumQuery(structure, senderID, sendBack)
 	if not isUnitIDKnown(senderID) then
 		addCharacter(senderID);
 	end
-	saveClientInformation(senderID, clientName, senderVersionText, false, senderExtendedVersion, senderIsTrial, senderExtendedVersionText, roleplayExperience);
+	saveClientInformation(senderID, clientName, senderVersionText, false, senderExtendedVersion, senderIsTrial, senderExtendedVersionText, roleplayExperience, senderClassID);
 	saveCurrentProfileID(senderID, senderProfileID);
 
 	-- Query specific data, depending on version number.


### PR DESCRIPTION
The class ID is useful to have in contexts where we want to apply class coloring but the user hasn't actually set a specific color up in their profile.