### PR TITLE
Add TRP3 toggle window to toolbar

### DIFF
--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -171,6 +171,17 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 	if TRP3_API.toolbar then
 
+		local Button_TRP3_Open = {
+			id = "aa_trp3_a",
+			icon = TRP3_InterfaceIcons.DirectorySection,
+			configText = loc.LAUNCHER_ACTION_OPEN,
+			tooltip = TRP3_API.globals.addon_name,
+			tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.LAUNCHER_ACTION_OPEN),
+			onClick = function() TRP3_API.navigation.switchMainFrame(); end,
+			visible = 1
+		}
+		TRP3_API.toolbar.toolbarAddButton(Button_TRP3_Open);
+
 		local updateToolbarButton = TRP3_API.toolbar.updateToolbarButton;
 		-- away/dnd
 		local status1Text = color("w")..loc.TB_STATUS..": "..color("r")..loc.TB_DND_MODE;


### PR DESCRIPTION
Another certified Rae banger, adding a toolbar button to toggle the main frame.

Short of rewriting the toolbar system to be able to handle the custom file path to the minimap logo (and in turn needing to use the bordered icon template to account for the border inconsistency between regular icons and that one), it was preferred to use a book icon to convey the "main frame" idea. Open to using a different one though.

![image](https://github.com/Total-RP/Total-RP-3/assets/17127080/61b95a5d-80d1-453f-b6cf-68a17dbcac4d)
