### PR TITLE
Own companion target frame now has a NPC speech button

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -340,6 +340,8 @@ The |cnGREEN_FONT_COLOR:note only filter|r will filter the character profile lis
 	REG_COMPANION_PROFILES = "Companions profiles",
 	REG_COMPANION_TF_PROFILE = "Companion profile",
 	REG_COMPANION_TF_PROFILE_MOUNT = "Mount profile",
+	REG_COMPANION_TF_PROFILE_SPEECH = "Companion speech",
+	REG_COMPANION_TF_PROFILE_SPEECH_TT = "Open the NPC speech frame with your companion's name filled in.",
 	REG_COMPANION_TF_NO = "No profile",
 	REG_COMPANION_TF_CREATE = "Create new profile",
 	REG_COMPANION_TF_UNBOUND = "Unlink from profile",

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -27,6 +27,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		frame.CurrentlyText.scroll.text:SetText(AddOn_TotalRP3.Player.GetCurrentUser():GetCurrentlyText());
 
 		frame:Show();
+		frame.CurrentlyText.scroll.text:SetFocus();
 	end
 	TRP3_API.r.toggleCurrentlyFrame = toggleCurrentlyFrame;
 

--- a/totalRP3/Modules/Dashboard/NPCTalk.lua
+++ b/totalRP3/Modules/Dashboard/NPCTalk.lua
@@ -122,15 +122,29 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 	---
 	-- Display the frame and do everything that needs to be done at show time
-	local function toggleNPCTalkFrame()
+	---@param name string Given NPC name that will be used for the speech.
+	local function toggleNPCTalkFrame(name)
 		if frame:IsShown() then
 			frame:Hide();
 			return;
 		end
 
+		-- Make sure name starts as empty.
+		frame.Name:SetText("");
+		-- If name is given (companion npc speech button), fill it in.
+		if name then
+			frame.Name:SetText("[" .. name .. "]");
+		end
+
 		-- We always rebuild the dropdown on show as some of the colors can change during the session
 		buildChannelDropdown();
 		frame:Show();
+
+		if name then
+			frame.MessageText.scroll.text:SetFocus();
+		else
+			frame.Name:SetFocus();
+		end
 	end
 	TRP3_API.r.toggleNPCTalkFrame = toggleNPCTalkFrame;
 

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -601,6 +601,31 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			end,
 		});
 
+		TRP3_API.target.registerButton({
+			id = "bb_companion_profile_speech",
+			configText = loc.REG_COMPANION_TF_PROFILE_SPEECH,
+			icon = TRP3_InterfaceIcons.ToolbarNPCTalk;
+			condition = function(targetType, unitID)
+				if isTargetTypeACompanion(targetType) then
+					local ownerID, companionID = companionIDToInfo(unitID);
+					return ownerID == Globals.player_id and getCompanionInfo(ownerID, companionID, unitID);
+				end
+			end,
+			tooltip = loc.REG_COMPANION_TF_PROFILE_SPEECH,
+			tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.REG_COMPANION_TF_PROFILE_SPEECH_TT),
+			onClick = function(unitID)
+				local ownerID, companionID = companionIDToInfo(unitID);
+				local profile = getCompanionInfo(ownerID, companionID, unitID);
+
+				-- Check if the pet has a profile first (always true here).
+				if profile then
+					-- Retrieve profile name.
+					local name = profile.data.NA;
+					TRP3_API.r.toggleNPCTalkFrame(name);
+				end
+			end,
+		});
+
 		-- Target bar button for mounts
 		TRP3_API.target.registerButton({
 			id = "bb_companion_profile_mount",

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -618,7 +618,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				local profile = getCompanionInfo(ownerID, companionID, unitID);
 
 				-- Check if the pet has a profile first (always true here).
-				if profile then
+				if profile and profile.data then
 					-- Retrieve profile name.
 					local name = profile.data.NA;
 					TRP3_API.r.toggleNPCTalkFrame(name);


### PR DESCRIPTION
Resolves #266.

| Target Frame | NPC Speech Frame |
|  ----    |  ----   |
| ![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/ff5c8e67-004a-4fa1-b1ba-3286629f86a7) | ![image](https://github.com/Total-RP/Total-RP-3/assets/172234435/ada7bbc4-ff16-4f01-a130-8dfd133f5990) |

> [!NOTE]
> NPC speeches is renamed to NPC speech in #973, hence the image above is still showing the old variant.

This automatically opens the NPC speech frame with the companion's name filled in within [brackets], this only works if you own the companion AND it has a profile attached.

Another addition is auto-focusing on Currently and NPC speech (name or text if name is already filled in) frames.

There are two new LOCs added:
- `REG_COMPANION_TF_PROFILE_SPEECH`
- `REG_COMPANION_TF_PROFILE_SPEECH_TT`