### PR TITLE
Misc Info Icon button - Remove OnClick script

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -69,11 +69,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<Anchors>
 					<Anchor point="LEFT" x="30" y="0"/>
 				</Anchors>
-				<Scripts>
-					<OnClick>
-						TRP3_UI_CharacteristicsMiscIconButton(self);
-					</OnClick>
-				</Scripts>
 			</Button>
 			<EditBox name="$parentNameField" inherits="TRP3_TitledHelpEditBox">
 				<Size x="100" y="18"/>


### PR DESCRIPTION
This was consistently trying to call a global nil value of `TRP3_UI_CharacteristicsMiscIconButton`.

Error fired every time you clicked on an "Additional Information" (misc info) icon to open the icon browser.