### PR TITLE
Added unread icon on About tab

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -722,10 +722,10 @@ local function tabBar_onSelect(tabGroup, index)
 	for i=1, #tabGroup.tabs do
 		local widget = tabGroup.tabs[i];
 		if i == index then
-			widget:SetTabSelected(true);
+			widget:SetTabState("SELECTED");
 			tabGroup.current = index;
 		else
-			widget:SetTabSelected(false);
+			widget:SetTabState("NORMAL");
 		end
 	end
 end

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -459,7 +459,7 @@ local function updateAboutTabIcon(context)
 	if not context.isPlayer and context.profile.about and not context.profile.about.read then
 		aboutUnread = true;
 	end
-	tabGroup.tabs[2].Unread:SetShown(aboutUnread);
+	tabGroup.tabs[2]:SetIcon(aboutUnread and "QuestNormal" or nil);
 end
 
 local function onInformationUpdated(profileID, infoType)
@@ -537,14 +537,6 @@ local function createTabBar()
 				callback();
 			end
 		end);
-
-	-- Adding unread flag
-	tabGroup.tabs[2].textMargin = 20;
-	local unreadFlag = tabGroup.tabs[2]:CreateTexture(nil, "ARTWORK");
-	unreadFlag:SetAtlas("QuestNormal");
-	unreadFlag:SetSize(15, 15);
-	unreadFlag:SetPoint("RIGHT", tabGroup.tabs[2].Text, "LEFT", 0, 0);
-	tabGroup.tabs[2].Unread = unreadFlag;
 
 	TRP3_API.register.player.tabGroup = tabGroup;
 end

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -454,6 +454,14 @@ local function onMouseOver()
 	end
 end
 
+local function updateAboutTabIcon(context)
+	local aboutUnread = false;
+	if not context.isPlayer and context.profile.about and not context.profile.about.read then
+		aboutUnread = true;
+	end
+	tabGroup.tabs[2].Unread:SetShown(aboutUnread);
+end
+
 local function onInformationUpdated(profileID, infoType)
 	if getCurrentPageID() == "player_main" then
 		local context = getCurrentContext();
@@ -461,6 +469,7 @@ local function onInformationUpdated(profileID, infoType)
 		if not context.isPlayer and profileID == context.profileID then
 			if infoType == registerInfoTypes.ABOUT and tabGroup.current == 2 then
 				showAboutTab();
+				updateAboutTabIcon(context);
 			elseif (infoType == registerInfoTypes.CHARACTERISTICS or infoType == registerInfoTypes.CHARACTER) and tabGroup.current == 1 then
 				showCharacteristicsTab();
 			elseif infoType == registerInfoTypes.MISC and tabGroup.current == 3 then
@@ -509,6 +518,7 @@ local function createTabBar()
 				showCharacteristicsTab();
 			elseif value == 2 then
 				showAboutTab();
+				updateAboutTabIcon(getCurrentContext());
 			elseif value == 3 then
 				showMiscTab();
 			elseif value == 4 then
@@ -527,6 +537,18 @@ local function createTabBar()
 				callback();
 			end
 		end);
+
+	-- Adding unread flag
+	tabGroup.tabs[2].textMargin = 20;
+	local unreadFlag = CreateFrame("Button", nil, tabGroup.tabs[2]);
+	unreadFlag:SetNormalAtlas("QuestNormal");
+	unreadFlag:SetHighlightAtlas("QuestNormal", "ADD");
+	unreadFlag:SetSize(15, 15);
+	unreadFlag:SetScript("OnEnter", function(self) TRP3_RefreshTooltipForFrame(self); end);
+	unreadFlag:SetScript("OnLeave", function() TRP3_MainTooltip:Hide(); end);
+	unreadFlag:SetPoint("RIGHT", tabGroup.tabs[2].Text, "LEFT", 0, 0);
+	tabGroup.tabs[2].Unread = unreadFlag;
+
 	TRP3_API.register.player.tabGroup = tabGroup;
 end
 
@@ -550,6 +572,7 @@ local function showTabs()
 	local context = getCurrentContext();
 	assert(context, "No context for page player_main !");
 	if not context.isPlayer or getPlayerCurrentProfileID() ~= getConfigValue("default_profile_id") then
+		updateAboutTabIcon(context);
 		tabGroup:SetAllTabsVisible(true);
 		tabGroup:SelectTab(1);
 	else

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -540,12 +540,9 @@ local function createTabBar()
 
 	-- Adding unread flag
 	tabGroup.tabs[2].textMargin = 20;
-	local unreadFlag = CreateFrame("Button", nil, tabGroup.tabs[2]);
-	unreadFlag:SetNormalAtlas("QuestNormal");
-	unreadFlag:SetHighlightAtlas("QuestNormal", "ADD");
+	local unreadFlag = tabGroup.tabs[2]:CreateTexture(nil, "ARTWORK");
+	unreadFlag:SetAtlas("QuestNormal");
 	unreadFlag:SetSize(15, 15);
-	unreadFlag:SetScript("OnEnter", function(self) TRP3_RefreshTooltipForFrame(self); end);
-	unreadFlag:SetScript("OnLeave", function() TRP3_MainTooltip:Hide(); end);
 	unreadFlag:SetPoint("RIGHT", tabGroup.tabs[2].Text, "LEFT", 0, 0);
 	tabGroup.tabs[2].Unread = unreadFlag;
 

--- a/totalRP3/UI/TabSystem.lua
+++ b/totalRP3/UI/TabSystem.lua
@@ -53,6 +53,6 @@ function TRP3_TabButtonMixin:Update()
 	self.LeftActive:SetShown(selected);
 	self.MiddleActive:SetShown(selected);
 	self.RightActive:SetShown(selected);
-	self.Text:SetPoint("LEFT", 10, selected and -3 or -6);
-	self.Text:SetPoint("RIGHT", -10, selected and -3 or -6);
+	self.Text:SetPoint("LEFT", self.textMargin, selected and -3 or -6);
+	self.Text:SetPoint("RIGHT", -self.textMargin, selected and -3 or -6);
 end

--- a/totalRP3/UI/TabSystem.lua
+++ b/totalRP3/UI/TabSystem.lua
@@ -4,14 +4,7 @@
 TRP3_TabButtonMixin = {};
 
 function TRP3_TabButtonMixin:OnLoad()
-end
-
-function TRP3_TabButtonMixin:OnShow()
-	self:MarkDirty();
-end
-
-function TRP3_TabButtonMixin:OnHide()
-	self:MarkClean();
+	-- No-op; reserved for any future nonsense.
 end
 
 function TRP3_TabButtonMixin:OnEnter()
@@ -26,33 +19,49 @@ function TRP3_TabButtonMixin:OnLeave()
 	TRP3_TooltipUtil.HideTooltip(self);
 end
 
-function TRP3_TabButtonMixin:IsTabSelected()
-	return GetValueOrCallFunction(self, "selected");
+function TRP3_TabButtonMixin:SetIcon(icon)
+	local textOffsetTop = select(5, self.Text:GetPointByName("LEFT"));
+
+	if icon ~= nil then
+		if C_Texture.GetAtlasInfo(icon) then
+			local useAtlasSize = false;
+			self.Icon:SetAtlas(icon, useAtlasSize);
+		else
+			self.Icon:SetTexture(icon);
+		end
+
+		self.Text:SetPoint("LEFT", 26, textOffsetTop);
+		self.Icon:Show();
+	else
+		self.Text:SetPoint("LEFT", 10, textOffsetTop);
+		self.Icon:SetTexture(nil);
+		self.Icon:Hide();
+	end
 end
 
-function TRP3_TabButtonMixin:SetTabSelected(selected)
-	self.selected = selected;
-	self:MarkDirty();
-end
+function TRP3_TabButtonMixin:SetTabState(state)
+	self:EnableMouse(state == "NORMAL");
+	self:SetEnabled(state ~= "DISABLED");
+	self.Left:SetShown(state ~= "SELECTED");
+	self.Middle:SetShown(state ~= "SELECTED");
+	self.Right:SetShown(state ~= "SELECTED");
+	self.LeftActive:SetShown(state == "SELECTED");
+	self.MiddleActive:SetShown(state == "SELECTED");
+	self.RightActive:SetShown(state == "SELECTED");
 
-function TRP3_TabButtonMixin:MarkDirty()
-	self:SetScript("OnUpdate", self.Update);
-end
+	local iconOffsetLeft = select(4, self.Icon:GetPointByName("LEFT"));
+	local textOffsetLeft = select(4, self.Text:GetPointByName("LEFT"));
+	local textOffsetRight = select(4, self.Text:GetPointByName("RIGHT"));
 
-function TRP3_TabButtonMixin:MarkClean()
-	self:SetScript("OnUpdate", nil);
-end
-
-function TRP3_TabButtonMixin:Update()
-	local selected = self:IsTabSelected();
-
-	self:SetEnabled(not selected);
-	self.Left:SetShown(not selected);
-	self.Middle:SetShown(not selected);
-	self.Right:SetShown(not selected);
-	self.LeftActive:SetShown(selected);
-	self.MiddleActive:SetShown(selected);
-	self.RightActive:SetShown(selected);
-	self.Text:SetPoint("LEFT", self.textMargin, selected and -3 or -6);
-	self.Text:SetPoint("RIGHT", -self.textMargin, selected and -3 or -6);
+	if state == "SELECTED" then
+		self:SetNormalFontObject(self.selectedFontObject);
+		self.Icon:SetPoint("LEFT", iconOffsetLeft, -3);
+		self.Text:SetPoint("LEFT", textOffsetLeft, -3);
+		self.Text:SetPoint("RIGHT", textOffsetRight, -3);
+	else
+		self:SetNormalFontObject(self.unselectedFontObject);
+		self.Icon:SetPoint("LEFT", iconOffsetLeft, -6);
+		self.Text:SetPoint("LEFT", textOffsetLeft, -6);
+		self.Text:SetPoint("RIGHT", textOffsetRight, -6);
+	end
 end

--- a/totalRP3/UI/TabSystem.xml
+++ b/totalRP3/UI/TabSystem.xml
@@ -9,6 +9,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Button name="TRP3_TabButtonTemplate" mixin="TRP3_TabButtonMixin" motionScriptsWhileDisabled="true" virtual="true">
 		<KeyValues>
 			<KeyValue key="selected" value="false" type="boolean"/>
+			<KeyValue key="textMargin" value="10" type="number"/>
 			<KeyValue key="selectedFontObject" value="GameFontHighlightSmall" type="global"/>
 			<KeyValue key="unselectedFontObject" value="GameFontNormalSmall" type="global"/>
 		</KeyValues>

--- a/totalRP3/UI/TabSystem.xml
+++ b/totalRP3/UI/TabSystem.xml
@@ -8,8 +8,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Button name="TRP3_TabButtonTemplate" mixin="TRP3_TabButtonMixin" motionScriptsWhileDisabled="true" virtual="true">
 		<KeyValues>
-			<KeyValue key="selected" value="false" type="boolean"/>
-			<KeyValue key="textMargin" value="10" type="number"/>
 			<KeyValue key="selectedFontObject" value="GameFontHighlightSmall" type="global"/>
 			<KeyValue key="unselectedFontObject" value="GameFontNormalSmall" type="global"/>
 		</KeyValues>
@@ -55,6 +53,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</Anchors>
 				</Texture>
 			</Layer>
+			<Layer level="ARTWORK">
+				<Texture parentKey="Icon" hidden="true">
+					<Size x="16" y="16"/>
+					<Anchors>
+						<Anchor point="LEFT" x="10" y="-6"/>
+					</Anchors>
+				</Texture>
+			</Layer>
 			<Layer level="HIGHLIGHT">
 				<Texture parentKey="LeftHighlight" atlas="uiframe-tab-left" useAtlasSize="false" alphaMode="ADD" alpha="0.4" rotation="180" texelSnappingBias="0.0" snapToPixelGrid="false">
 					<Size x="27" y="28"/>
@@ -85,11 +91,9 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</ButtonText>
 		<NormalFont style="GameFontNormalSmall"/>
 		<HighlightFont style="GameFontHighlightSmall"/>
-		<DisabledFont style="GameFontHighlightSmall"/>
+		<DisabledFont style="GameFontDisableSmall"/>
 		<Scripts>
 			<OnLoad method="OnLoad"/>
-			<OnShow method="OnShow"/>
-			<OnHide method="OnHide"/>
 			<OnEnter method="OnEnter"/>
 			<OnLeave method="OnLeave"/>
 		</Scripts>


### PR DESCRIPTION
When the About tab is unread, we add the unread icon to it so people get used to it by association.
This will have to be adjusted when we change the tooltip icons.

![image](https://github.com/user-attachments/assets/3de0968d-b0f1-4c0f-ad05-273a370229d4)

In order to avoid issues with languages that have very long "About" tab names, I added a parameter to change the margin on the text for them. I've been told it will conflict with half the tab changes. We'll just have to find out.

![image](https://github.com/user-attachments/assets/17d748dc-52c9-4484-baa5-cbb137eddba8)
