### PR TITLE
Add resize cursor while resizing the main window

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1065,6 +1065,14 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	TRP3_API.ui.tooltip.setTooltipAll(resizeButton, "BOTTOMLEFT", 0, 0, loc.CM_RESIZE, loc.CM_RESIZE_TT);
 	local parentFrame = resizeButton.resizableFrame;
 	resizeButton:RegisterForDrag("LeftButton");
+	resizeButton:SetScript("OnMouseDown", function(self)
+		self.CursorFrame:Show();
+		SetCursor("Interface\\CURSOR\\UI-Cursor-Size");
+	end);
+	resizeButton:SetScript("OnMouseUp", function(self)
+		self.CursorFrame:Hide();
+		ResetCursor();
+	end);
 	resizeButton:SetScript("OnDragStart", function(self)
 		if not self.onResizeStart or not self.onResizeStart() then
 			resizeShadowFrame.minWidth = self.minWidth;
@@ -1080,6 +1088,8 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	end);
 	resizeButton:SetScript("OnDragStop", function(self)
 		if parentFrame.isSizing then
+			self.CursorFrame:Hide();
+			ResetCursor();
 			resizeShadowFrame:StopMovingOrSizing();
 			parentFrame.isSizing = false;
 			local height, width = resizeShadowFrame:GetHeight(), resizeShadowFrame:GetWidth()

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -193,6 +193,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" x="-1" y="1"/>
 				</Anchors>
+				<Frames>
+					<Frame parentKey="CursorFrame" hidden="true" enableMouse="true">
+						<Size x="50" y="50"/>
+						<Anchors>
+							<Anchor point="CENTER" relativePoint="BOTTOMRIGHT" />
+						</Anchors>
+					</Frame>
+				</Frames>
 			</Button>
 		</Frames>
 	</Frame>


### PR DESCRIPTION
This is very hacky so please sit down before reviewing.

Added a SetCursor call to the main window resizing. However, because the cursor gets reset when we get out of frames capturing the mouse inputs, moving the cursor to make the frame bigger does not keep the cursor.
To that effect (and this is the hack), I added a mouse-capturing frame to show only when we click on the button and hide when releasing or drag stop. This now lets us keep the resize cursor even when moving out of the frame. 

If this is too much of a hack, down to discard it, but hey at least it works.