### PR TITLE
Fix profile errors while still receiving data

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -322,7 +322,7 @@ local function setConsultDisplay(context)
 	TRP3_RegisterCharact_CharactPanel_ResidenceButton:Hide();
 	TRP3_RegisterCharact_NamePanel_WalkupButton:Hide();
 
-	if context.profile.character.WU == AddOn_TotalRP3.Enums.WALKUP.YES then
+	if context.profile.character and context.profile.character.WU == AddOn_TotalRP3.Enums.WALKUP.YES then
 		TRP3_RegisterCharact_NamePanel_WalkupButton:Show();
 		setTooltipForSameFrame(TRP3_RegisterCharact_NamePanel_WalkupButton, "RIGHT", 0, 5, loc.DB_STATUS_WU, loc.REG_PLAYER_WALKUP_TT);
 	end

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -1062,7 +1062,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					profile = getUnitIDProfile(unitID);
 				end
 
-				local name = getCompleteName(profile.characteristics or {}, nil, true);
+				local name = getCompleteName(profile.characteristics or {}, "", true);
 				buttonStructure.tooltipSub = name .. "\n\n" ..  TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_CHARACTER);
 
 				if unitID ~= Globals.player_id and profile.about and not profile.about.read then


### PR DESCRIPTION
- When the tooltip for the target frame button to Open profile was modified to include the character name, the getCompleteName call was given a `nil` fallback name, which makes it error out when targeting someone for whom we haven't yet received the characteristics tab.
I've added the fallback string found in other places in the very file, knowing the target frame gets refreshed once we receive the characteristics data to display the proper name.

- In the same vein, opening a profile while receiving data could throw an error trying to access a character table that wasn't received yet. I just added a check to prevent it from errorring out.