### PR TITLE
Fix sorting down arrows on directory

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -197,24 +197,23 @@ local function getCurrentComparator()
 	return comparators[sortingType];
 end
 
-local ARROW_DOWN = "Interface\\Buttons\\Arrow-Down-Up";
-local ARROW_UP = "Interface\\Buttons\\Arrow-Up-Up";
-local ARROW_SIZE = 15;
+local ARROW_DOWN = "|TInterface\\Buttons\\Arrow-Down-Up:15:15:0:-6|t";
+local ARROW_UP = "|TInterface\\Buttons\\Arrow-Up-Up:15|t";
 
 local function getComparatorArrows()
 	local nameArrow, relationArrow, timeArrow = "", "", "";
 	if sortingType == 1 then
-		nameArrow = " |T" .. ARROW_DOWN .. ":" .. ARROW_SIZE .. "|t";
+		nameArrow = " " .. ARROW_DOWN;
 	elseif sortingType == 2 then
-		nameArrow = " |T" .. ARROW_UP .. ":" .. ARROW_SIZE .. "|t";
+		nameArrow = " " .. ARROW_UP;
 	elseif sortingType == 3 then
-		relationArrow = " |T" .. ARROW_DOWN .. ":" .. ARROW_SIZE .. "|t";
+		relationArrow = " " .. ARROW_DOWN;
 	elseif sortingType == 4 then
-		relationArrow = " |T" .. ARROW_UP .. ":" .. ARROW_SIZE .. "|t";
+		relationArrow = " " .. ARROW_UP;
 	elseif sortingType == 5 then
-		timeArrow = " |T" .. ARROW_DOWN .. ":" .. ARROW_SIZE .. "|t";
+		timeArrow = " " .. ARROW_DOWN;
 	elseif sortingType == 6 then
-		timeArrow = " |T" .. ARROW_UP .. ":" .. ARROW_SIZE .. "|t";
+		timeArrow = " " .. ARROW_UP;
 	end
 	return nameArrow, relationArrow, timeArrow;
 end


### PR DESCRIPTION
The down arrow when filtering a category in the directory list was placed on the upper part of the line, unlike the up arrow. Just added a small offset to it so it would look properly aligned.

![image](https://github.com/user-attachments/assets/cb3ab3ab-b51d-4fad-a2f1-a97a4282ebcc)
