### PR TITLE
Characterictics UI tweaks

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -351,7 +351,7 @@ local function setConsultDisplay(context)
 	if #shownCharacteristics > 0 then
 		hasCharac = true;
 		TRP3_RegisterCharact_CharactPanel_Container.RegisterTitle:Show();
-		margin = 0;
+		margin = -5;
 	else
 		margin = 50;
 	end
@@ -431,7 +431,11 @@ local function setConsultDisplay(context)
 				tinsert(miscCharFrame, frame);
 			end
 			frame:ClearAllPoints();
-			frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 0);
+			if frameIndex == 1 then
+				frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, -5);
+			else
+				frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 0);
+			end
 			frame:SetPoint("RIGHT", 0, 0);
 			frame.Icon:SetIconTexture(field.icon);
 			frame.Name:SetText(field.localizedName or "");

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -357,10 +357,10 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<!-- Register characteristics register line -->
 	<Frame name="TRP3_RegisterCharact_RegisterInfoLine" virtual="true">
-		<Size y="26"/>
+		<Size y="32"/>
 		<Frames>
 			<Frame parentKey="Icon" inherits="TRP3_BorderedIconTemplate" useParentLevel="true">
-				<Size x="26" y="26"/>
+				<Size x="32" y="32"/>
 				<Anchors>
 					<Anchor point="LEFT" x="15"/>
 				</Anchors>

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -276,7 +276,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 			<Button name="$parentLeftIcon" parentKey="CustomLeftIcon" inherits="TRP3_IconButton">
 				<Anchors>
-					<Anchor point="RIGHT" relativeKey="$parent.LeftIcon" x="-2" />
+					<Anchor point="RIGHT" relativeKey="$parent.LeftIcon" x="-6" />
 				</Anchors>
 				<Layers>
 					<Layer level="OVERLAY">
@@ -293,7 +293,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Button>
 			<Button name="$parentRightIcon" parentKey="CustomRightIcon" inherits="TRP3_IconButton">
 				<Anchors>
-					<Anchor point="LEFT" relativeKey="$parent.RightIcon" x="2" />
+					<Anchor point="LEFT" relativeKey="$parent.RightIcon" x="6" />
 				</Anchors>
 				<Layers>
 					<Layer level="OVERLAY">

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -638,7 +638,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</EditBox>
 									<Button name="TRP3_RegisterCharact_Edit_ClassButton" inherits="TRP3_ColorPickerButton">
 										<Anchors>
-											<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_ClassField"/>
+											<Anchor point="LEFT" x="10" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_ClassField"/>
 										</Anchors>
 									</Button>
 									<EditBox name="TRP3_RegisterCharact_Edit_AgeField" inherits="TRP3_TitledHelpEditBox">
@@ -657,7 +657,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</EditBox>
 									<Button name="TRP3_RegisterCharact_Edit_EyeButton" inherits="TRP3_ColorPickerButton">
 										<Anchors>
-											<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_EyeField"/>
+											<Anchor point="LEFT" x="10" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_EyeField"/>
 										</Anchors>
 									</Button>
 									<EditBox name="TRP3_RegisterCharact_Edit_HeightField" inherits="TRP3_TitledHelpEditBox">
@@ -670,7 +670,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									<Frame name="TRP3_RegisterCharact_Dropdown_RelationshipField" inherits="TRP3_TitledDropdown">
 										<Anchors>
 											<Anchor point="TOPLEFT" x="-5" y="-10" relativePoint="BOTTOMLEFT" relativeTo="TRP3_RegisterCharact_Edit_HeightField"/>
-											<Anchor point="RIGHT" x="5" y="0" relativePoint="LEFT" relativeTo="TRP3_RegisterCharact_CharactPanel_Edit_RegisterPoint"/>
+											<Anchor point="RIGHT" relativePoint="LEFT" relativeTo="TRP3_RegisterCharact_CharactPanel_Edit_RegisterPoint"/>
 										</Anchors>
 									</Frame>
 									<EditBox name="TRP3_RegisterCharact_Edit_ResidenceField" inherits="TRP3_TitledHelpEditBox">
@@ -682,7 +682,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</EditBox>
 									<Button name="TRP3_RegisterCharact_Edit_ResidenceButton" inherits="TRP3_MapHereButton">
 										<Anchors>
-											<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_ResidenceField"/>
+											<Anchor point="LEFT" x="10" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_ResidenceField"/>
 										</Anchors>
 									</Button>
 									<EditBox name="TRP3_RegisterCharact_Edit_BirthplaceField" inherits="TRP3_TitledHelpEditBox">
@@ -694,7 +694,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									</EditBox>
 									<Button name="TRP3_RegisterCharact_Edit_BirthplaceButton" inherits="TRP3_MapHereButton">
 										<Anchors>
-											<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_BirthplaceField"/>
+											<Anchor point="LEFT" x="10" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterCharact_Edit_BirthplaceField"/>
 										</Anchors>
 									</Button>
 									<EditBox name="TRP3_RegisterCharact_Edit_WeightField" inherits="TRP3_TitledHelpEditBox">

--- a/totalRP3/Modules/Register/Main/RegisterTemplates.xml
+++ b/totalRP3/Modules/Register/Main/RegisterTemplates.xml
@@ -10,7 +10,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Frame name="TRP3_RegisterSectionHeaderTemplate" mixin="TRP3_RegisterSectionHeaderMixin" virtual="true">
 		<Frames>
 			<Frame parentKey="Icon" inherits="TRP3_BorderedIconTemplate" useParentLevel="true">
-				<Size x="36" y="36"/>
+				<Size x="44" y="44"/>
 				<Anchors>
 					<Anchor point="LEFT" x="5"/>
 				</Anchors>


### PR DESCRIPTION
Some small tweaks
- The color buttons have been moved to align better with the editboxes around. Residence buttons have been moved with them.
- The dropdown anchor has been moved slightly to better align with the editboxes above
- The additional info icon height has been slightly increased to be more readable
- The custom icon buttons for personality trait edition have been moved slightly for better alignment with presets. (Would have used the same bordered icon template for customs, but will have to wait until we have a proper button version)
- Category icons have been made bigger as they went smaller than the personality traits at some point. There was also some margin added between the titles and some categories where it felt really clumped.

![image](https://github.com/user-attachments/assets/f87d0556-86a7-4618-8020-0ee25b69206d)
![image](https://github.com/user-attachments/assets/6566f8e6-2fd2-4c89-bf47-d34ef5562c92)
