### PR TITLE
Add SetIconTextureTo* methods for bordered icons

### DIFF
--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -96,7 +96,7 @@ local function onStart()
 
 			if type(buttonStructure.icon) == "table" and buttonStructure.icon.Apply then
 				if buttonStructure.icon:GetFileID() == 516771 then
-					uiButton.Icon:SetTexture(buttonStructure.icon:GetFileID())
+					uiButton:SetIconTextureToFile(buttonStructure.icon:GetFileID())
 				else
 					uiButton:SetIconTexture(buttonStructure.icon:GetFileID())
 				end

--- a/totalRP3/UI/IconTemplates.lua
+++ b/totalRP3/UI/IconTemplates.lua
@@ -14,3 +14,11 @@ TRP3_BorderedIconMixin = {};
 function TRP3_BorderedIconMixin:SetIconTexture(icon)
 	self.Icon:SetIconTexture(icon);
 end
+
+function TRP3_BorderedIconMixin:SetIconTextureToFile(texture)
+	self.Icon:SetTexture(texture);
+end
+
+function TRP3_BorderedIconMixin:SetIconTextureToAtlas(atlas)
+	self.Icon:SetAtlas(atlas);
+end


### PR DESCRIPTION
Rather than have Sol reaching into the insides of things and touching them in weird ways, add a proper set of methods for assigning raw assets to the icon.