### PR TITLE
Add companion icon to sidebar list entries

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -111,6 +111,7 @@ local function openCompanionPage(profileID)
 			onSelected = function() setPage(TRP3_API.navigation.page.id.COMPANIONS_PAGE, {profile = profile, profileID = profileID, isPlayer = false}) end,
 			isChildOf = REGISTER_PAGE,
 			closeable = true,
+			icon = [[interface\icons\]] .. TRP3_InterfaceIcons.CompanionMenuItem,
 		});
 		selectMenu(currentlyOpenedProfilePrefix .. profileID);
 	end


### PR DESCRIPTION
Could have sworn this was always here, and we have an interface icon entry for it, but seemingly we never used it? Did we remove it by accident? Did Rae eat it? idk.

![image](https://github.com/user-attachments/assets/84933fc8-b065-44c4-8db8-ccf26aa9a62e)
