### PR TITLE
Fix positioning of regions on music player frame

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
@@ -528,13 +528,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 												<Anchor point="TOP" x="0" y="-8"/>
 											</Anchors>
 										</FontString>
-										<FontString name="TRP3_RegisterAbout_AboutPanel_MusicPlayer_URL" text="[URL]" inherits="GameFontNormalSmall">
+										<FontString name="TRP3_RegisterAbout_AboutPanel_MusicPlayer_URL" text="[URL]" wordwrap="false" justifyV="TOP" inherits="GameFontNormalSmall">
 											<Anchors>
 												<Anchor point="TOP" relativePoint="BOTTOM" relativeTo="TRP3_RegisterAbout_AboutPanel_MusicPlayer_Title" x="0" y="-3"/>
 												<Anchor point="LEFT" x="15" y="0"/>
 												<Anchor point="RIGHT" x="-15" y="0"/>
 											</Anchors>
-											<Color b="0" r="0" g="1"/>
+											<Color color="GREEN_FONT_COLOR"/>
 										</FontString>
 									</Layer>
 								</Layers>
@@ -542,13 +542,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 									<Button name="TRP3_RegisterAbout_AboutPanel_MusicPlayer_Play" inherits="TRP3_CommonButton">
 										<Size x="70" y="22"/>
 										<Anchors>
-											<Anchor point="BOTTOMLEFT" x="20" y="10"/>
+											<Anchor point="BOTTOMLEFT" x="20" y="8"/>
 										</Anchors>
 									</Button>
 									<Button name="TRP3_RegisterAbout_AboutPanel_MusicPlayer_Stop" inherits="TRP3_CommonButton">
 										<Size x="70" y="22"/>
 										<Anchors>
-											<Anchor point="BOTTOMRIGHT" x="-17" y="10"/>
+											<Anchor point="BOTTOMRIGHT" x="-20" y="8"/>
 										</Anchors>
 									</Button>
 								</Frames>


### PR DESCRIPTION
The "URL" text in particular (which is really just the music name string) could sometimes position itself awkwardly and end up behind the buttons that were beneath it. This should be resolved by disabling wrapping and forcing the text to vertically align to the top.

Additionally slightly tweaked the play and stop buttons to be more consistently placed.

Before:
![image](https://github.com/user-attachments/assets/475ccd71-eecd-44db-873a-09650f873ee7)

After:
![Wow_2024-07-14_12-57-43](https://github.com/user-attachments/assets/545c782b-1a1d-4bfb-9c71-f320f8c7c34c)
