### PR TITLE
Added safety for missing companion name

### DIFF
--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -592,18 +592,18 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				-- Check if the pet has a profile first.
 				if profile and profile.data then
 					-- Retrieve profile name.
-					local name = profile.data.NA;
+					local name = profile.data.NA or "";
 
 					-- Handle if player is the owner of this pet.
 					if ownerID == Globals.player_id then
 						buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.TF_OPEN_COMPANION) .. "\n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.TF_MORE_OPTIONS);
 					else
-						buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION);
-
 						-- If pet data is unread, add alert.
 						if not profile.data.read then
 							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateAtlasMarkup("QuestNormal", { size = 16 }) .. "|cnGREEN_FONT_COLOR:" .. loc.REG_TT_NOTIF .. "|r\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION) .. "|r";
 							buttonStructure.alert = true;
+						else
+							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION);
 						end
 					end
 				else
@@ -673,18 +673,18 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				-- Check if the mount has a profile first.
 				if profile and profile.data then
 					-- Retrieve profile name.
-					local name = profile.data.NA;
+					local name = profile.data.NA or "";
 
 					-- Handle if player is the owner of this mount.
 					if unitID == Globals.player_id then
 						buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.TF_OPEN_MOUNT) .. "\n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.TF_MORE_OPTIONS);
 					else
-						buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT);
-
 						-- If mount data is unread, add alert.
 						if not profile.data.read then
 							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateAtlasMarkup("QuestNormal", { size = 16 }) .. "|cnGREEN_FONT_COLOR:" .. loc.REG_TT_NOTIF .. "|r\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT) .. "|r";
 							buttonStructure.alert = true;
+						else
+							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT);
 						end
 					end
 				else


### PR DESCRIPTION
Similar to player names, if targeting a pet or a player on a mount while companion data has not been fully received, it's possible its name doesn't yet exist. This just adds a safety so the target frame doesn't die now that the companion names appear on the buttons tooltips.

I've also moved a tooltip text creation that would get overwritten if the profile was unread, so we don't do the concatenation needlessly.