### PR TITLE
Don't show minimum frame size as invalid

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1113,7 +1113,7 @@ end
 local VALID_SIZE_COLOR = TRP3_API.Colors.Green;
 local INVALID_SIZE_COLOR = TRP3_API.Colors.Red;
 resizeShadowFrame:SetScript("OnUpdate", function(self)
-	local height, width = self:GetHeight(), self:GetWidth();
+	local height, width = math.ceil(self:GetHeight()), math.ceil(self:GetWidth());
 	local heightColor, widthColor = VALID_SIZE_COLOR, VALID_SIZE_COLOR;
 	if height < self.minHeight then
 		heightColor = INVALID_SIZE_COLOR;
@@ -1121,7 +1121,7 @@ resizeShadowFrame:SetScript("OnUpdate", function(self)
 	if width < self.minWidth then
 		widthColor = INVALID_SIZE_COLOR;
 	end
-	resizeShadowFrame.text:SetText(widthColor(math.ceil(width)) .. " x " .. heightColor(math.ceil(height)));
+	resizeShadowFrame.text:SetText(widthColor(width) .. " x " .. heightColor(height));
 end);
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*


### PR DESCRIPTION
The resize frame logic doesn't too consistently round its height and width values when updating the size text. Somehow this results in it treating the minimum size (840x600) as invalid and renders it in red.

Rounding values up a bit earlier for some reason resolves this. Not sure why, don't care why.