### PR TITLE
Fix height of non-additional info lines

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -424,6 +424,7 @@ local function setConsultDisplay(context)
 			local frame = miscCharFrame[frameIndex];
 			if frame == nil then
 				frame = CreateFrame("Frame", "TRP3_RegisterCharact_MiscInfoLine" .. frameIndex, TRP3_RegisterCharact_CharactPanel_Container, "TRP3_RegisterCharact_RegisterInfoLine");
+				frame:SetHeight(32);
 				scaleField(frame, TRP3_RegisterCharact_CharactPanel_Container:GetWidth());
 				tinsert(miscCharFrame, frame);
 			end

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -357,7 +357,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<!-- Register characteristics register line -->
 	<Frame name="TRP3_RegisterCharact_RegisterInfoLine" virtual="true">
-		<Size y="32"/>
+		<Size y="26"/>
 		<Frames>
 			<Frame parentKey="Icon" inherits="TRP3_BorderedIconTemplate" useParentLevel="true">
 				<Size x="32" y="32"/>


### PR DESCRIPTION
Info lines for (soon to be renamed) Directory Information and Additional Information fields shared a template which made the former look much more spread out after the change to increase additional info icon sizes. This restores the original size to the template and only increases the line height for additional info lines.

![image](https://github.com/user-attachments/assets/22eaec8a-c4e3-4d0b-85f7-f2003e150f13)
