### PR TITLE
Tweak chat links a bit

### DIFF
--- a/totalRP3/Core/ProfilesChatLinksModule.lua
+++ b/totalRP3/Core/ProfilesChatLinksModule.lua
@@ -60,7 +60,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		end
 		if info.character.CU and info.character.CU ~= "" then
 			tooltipLines:AddLine(" ");
-			tooltipLines:AddLine(loc.REG_PLAYER_CURRENT .. ": ");
+			tooltipLines:AddLine(loc.DB_STATUS_CURRENTLY .. ": ");
 			tooltipLines:AddLine(info.character.CU, YELLOW);
 		end
 		if info.character.CO and info.character.CO ~= "" then

--- a/totalRP3/Modules/ChatLinks/ChatLinks.lua
+++ b/totalRP3/Modules/ChatLinks/ChatLinks.lua
@@ -19,10 +19,6 @@ local AddOn_TotalRP3 = AddOn_TotalRP3;
 local ChatLinks = {};
 TRP3_API.ChatLinks = ChatLinks;
 
---region Ellyb imports
-local ORANGE = TRP3_API.Colors.Orange;
---endregion
-
 --region Wow Imports
 local assert = assert;
 local pairs = pairs;
@@ -281,7 +277,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		Ellyb.Assertions.isType(linkType, "string", "linkType");
 		Ellyb.Assertions.isType(callback, "function", "callback");
 
-		TRP3_API.popup.showCustomYesNoPopup(loc.CL_MAKE_IMPORTABLE_SIMPLER:format(TRP3_API.Colors.Orange(linkType)),
+		TRP3_API.popup.showCustomYesNoPopup(loc.CL_MAKE_IMPORTABLE_SIMPLER:format("|cnGREEN_FONT_COLOR:" .. linkType .. "|r"),
 			loc.CL_MAKE_IMPORTABLE_BUTTON_TEXT,
 			loc.CL_MAKE_NON_IMPORTABLE,
 			function()

--- a/totalRP3/Modules/ChatLinks/ChatLinks.lua
+++ b/totalRP3/Modules/ChatLinks/ChatLinks.lua
@@ -40,7 +40,7 @@ local ChatLinkModule = TRP3_API.ChatLinkModule;
 local loc = TRP3_API.loc;
 --endregion
 
-local LINK_CODE = "garrmission:totalrp3";
+local LINK_CODE = "addon:totalrp3";
 local LINK_LENGTHS = LINK_CODE:len();
 
 local LINK_COLOR = TRP3_API.Colors.Yellow;
@@ -178,18 +178,19 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		if IsAltKeyDown() then
 			TRP3_RefTooltip:AddLine(" ");
 			if itemData.moduleName then
-				TRP3_RefTooltip:AddLine(loc.CL_TYPE:format(ORANGE(itemData.moduleName)));
+				TRP3_RefTooltip:AddLine(loc.CL_TYPE:format("|cnWHITE_FONT_COLOR:" .. itemData.moduleName .. "|r"));
 			end
-			TRP3_RefTooltip:AddLine(loc.CL_SENT_BY:format(ORANGE(sender)));
+			TRP3_RefTooltip:AddLine(loc.CL_SENT_BY:format("|cnWHITE_FONT_COLOR:" .. sender.. "|r"));
 			if itemData.size then
-				TRP3_RefTooltip:AddLine(loc.CL_CONTENT_SIZE:format(ORANGE(Ellyb.Strings.formatBytes(itemData.size))));
+				TRP3_RefTooltip:AddLine(loc.CL_CONTENT_SIZE:format("|cnWHITE_FONT_COLOR:" .. Ellyb.Strings.formatBytes(itemData.size).. "|r"));
 			end
 			TRP3_RefTooltip.wasAltKeyDown = true;
 		else
 			TRP3_RefTooltip.wasAltKeyDown = false;
 		end
 
-		local minWidth = 0;
+		local minWidth = 250;
+		TRP3_RefTooltip:SetMinimumWidth(minWidth);
 		local buttonAddedHeight = 0;
 		if actionButtons and ChatLinks:HasModule(itemData.moduleID) then
 			for i, button in pairs(actionButtons) do
@@ -204,9 +205,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		TRP3_RefTooltip.itemData = itemData;
 		TRP3_RefTooltip:Show();
 		TRP3_RefTooltip:SetHeight(TRP3_RefTooltip:GetHeight() + buttonAddedHeight + 5);
-		if TRP3_RefTooltip:GetWidth() < minWidth then
-			TRP3_RefTooltip:SetWidth(minWidth + 20)
-		end
 	end
 
 	function TRP3_RefTooltip:Refresh()

--- a/totalRP3/Modules/ChatLinks/ChatLinks.xml
+++ b/totalRP3/Modules/ChatLinks/ChatLinks.xml
@@ -21,6 +21,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Anchors>
 			<Anchor point="BOTTOM" y="80"/>
 		</Anchors>
+		<Scripts>
+			<OnLoad inherit="prepend">
+				tinsert(UISpecialFrames, self:GetName());
+			</OnLoad>
+		</Scripts>
 		<Frames>
 			<Button parentKey="CloseButton" inherits="TRP3_StyledButtonTemplate">
 				<Size x="24" y="24"/>

--- a/totalRP3/Modules/Register/Main/RegisterPlayerChatLinksModule.lua
+++ b/totalRP3/Modules/Register/Main/RegisterPlayerChatLinksModule.lua
@@ -55,12 +55,12 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		if profile.characteristics and profile.characteristics.FT then
 			tooltipLines:AddLine("< " .. profile.characteristics.FT .. " >", TRP3_API.Colors.Orange);
 		end
-		if profile.character and profile.character.CU then
+		if profile.character and profile.character.CU and profile.character.CU ~= "" then
 			tooltipLines:AddLine(" ");
 			tooltipLines:AddLine(loc.DB_STATUS_CURRENTLY .. ": ");
 			tooltipLines:AddLine(profile.character.CU, TRP3_API.Colors.Yellow);
 		end
-		if profile.character and profile.character.CO then
+		if profile.character and profile.character.CO and profile.character.CO ~= "" then
 			tooltipLines:AddLine(" ");
 			tooltipLines:AddLine(loc.DB_STATUS_CURRENTLY_OOC .. ": ");
 			tooltipLines:AddLine(profile.character.CO, TRP3_API.Colors.Yellow);
@@ -80,6 +80,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 		TRP3_API.register.openPageByProfileID(profileID);
 		TRP3_API.navigation.openMainFrame();
+		TRP3_RefTooltip:Hide();
 	end
 
 	-- Import profile action button


### PR DESCRIPTION
Some changes:
- Addon link code now uses `addon` instead of `garrmission`.
- Chat links can now be escaped out of.
- Default width is now 250px, makes it a bit less cramped.
- Empty currently or other information will hide these fields.
- Fixed a messing loc key that was removed earlier.
- Fixed up the highlight colors (the PURGE).
- Open profile button now hides the frame on success.

Note: This is super dark code of the addon, I don't like being here without a torch... Or a flamethrower..

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/b132ced5-650c-45c5-ba6e-d6f37fe12036) | ![image](https://github.com/user-attachments/assets/0439f3b8-4691-4f7c-91a2-1361d6bfbad0) |
| ![image](https://github.com/user-attachments/assets/793081b6-e961-4f92-b99f-372bdd9af1e9) | ![image](https://github.com/user-attachments/assets/ee2924a2-4320-422f-9d23-0e826fcf6c73) |
| ![image](https://github.com/user-attachments/assets/a613e64e-8176-4955-8514-4622ef9ccd71) | ![2024-07-15_15-22-33-497](https://github.com/user-attachments/assets/a9618232-3d14-4ad4-8186-102e6352d96b) |
