### PR TITLE
Trim spaces from race/class text

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -645,7 +645,7 @@ local function writeTooltipForCharacter(targetID, targetType)
 			race = crop(race, FIELDS_TO_CROP.RACE);
 			class = crop(class, FIELDS_TO_CROP.CLASS);
 		end
-		lineLeft = strconcat(race, " ", color:WrapTextInColorCode(class));
+		lineLeft = string.trim(strconcat(race, " ", color:WrapTextInColorCode(class)));
 		lineRight = loc.REG_TT_LEVEL:format(getLevelIconOrText(targetType), getFactionIcon(targetType));
 
 		tooltipBuilder:AddDoubleLine(lineLeft, lineRight, colors.MAIN, colors.MAIN, getSubLineFontSize());


### PR DESCRIPTION
After concatenating the race and class string together, re-trim the string to deal with cases where the user has entered a space-only string for either field. In the case of races, this would have previously caused the class text to be slightly indented.