### PR TITLE
Disable world cursor unit support by default

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1550,7 +1550,7 @@ local function onModuleInit()
 	registerConfigKey(ConfigKeys.CHARACT_RELATION_LINE, true);
 	registerConfigKey(ConfigKeys.CHARACT_RELATION, true);
 	registerConfigKey(ConfigKeys.CHARACT_SPACING, true);
-	registerConfigKey(ConfigKeys.SHOW_WORLD_CURSOR, true);
+	registerConfigKey(ConfigKeys.SHOW_WORLD_CURSOR, false);
 	registerConfigKey(ConfigKeys.NO_FADE_OUT, false);
 	registerConfigKey(ConfigKeys.PREFER_OOC_ICON, TRP3_OOCIndicatorStyle.Text);
 	registerConfigKey(ConfigKeys.PETS_ICON, true);


### PR DESCRIPTION
Owing to the bugs this feature has, let's ship it off by default for now. Can revisit later if we ever fix it.