### PR TITLE
Prefer unmodified unit names in certain contexts

### DIFF
--- a/totalRP3/Core/Globals.lua
+++ b/totalRP3/Core/Globals.lua
@@ -45,7 +45,7 @@ TRP3_API.globals = {
 	--@end-non-debug@]===]
 
 
-	player = UnitName("player"),
+	player = UnitNameUnmodified("player"),
 	player_realm = GetRealmName(),
 	player_race_loc = race_loc,
 	player_class_loc = class_loc,
@@ -96,7 +96,7 @@ setmetatable(TRP3_API.globals.empty, emptyMeta);
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 TRP3_API.globals.build = function()
-	local fullName = UnitName("player");
+	local fullName = UnitNameUnmodified("player");
 	local realm = GetRealmName():gsub("[%s*%-*]", "");
 	TRP3_API.globals.player_realm_id = realm;
 	TRP3_API.globals.player_id = fullName .. "-" .. realm;

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -612,7 +612,7 @@ end
 TRP3_API.ui.misc.getCompanionOwner = getCompanionOwner;
 
 function TRP3_API.ui.misc.getCompanionShortID(unitToken, unitType)
-	local shortID = UnitName(unitToken);
+	local shortID = UnitNameUnmodified(unitToken);
 
 	if not C_PetJournal and unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.BATTLE_PET then
 		-- Classic: Companions can't be renamed nor can their names be

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -173,7 +173,7 @@ end
 -- Create a unit ID based on a targetType (target, player, mouseover ...)
 -- The returned id can be nil.
 function Utils.str.getUnitID(unit)
-	local playerName, realm = UnitFullName(unit);
+	local playerName, realm = UnitNameUnmodified(unit);
 	if not playerName or playerName:len() == 0 or playerName == UNKNOWNOBJECT then
 		return nil;
 	end

--- a/totalRP3/Libs/Ellyb/Tools/Unit.lua
+++ b/totalRP3/Libs/Ellyb/Tools/Unit.lua
@@ -46,13 +46,12 @@ end
 
 ---@return string unitID @ Returns the unit ID in the format PlayerName-ServerName
 function Unit:GetUnitID()
-	local playerName, realm = UnitFullName(_private[self].rawUnitID);
+	local playerName, realm = UnitNameUnmodified(_private[self].rawUnitID);
 	if not playerName or playerName:len() == 0 or playerName == UNKNOWNOBJECT then
 		return nil;
 	end
 	if not realm then
-		local _, playerRealmName = UnitFullName("player");
-		realm = playerRealmName;
+		realm = GetNormalizedRealmName();
 	end
 	if not realm then
 		return playerName;

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -319,7 +319,7 @@ function TRP3_API.companions.player.getCurrentBattlePetQueryLine()
 end
 
 function TRP3_API.companions.player.getCurrentPetQueryLine()
-	local summonedPet = UnitName("pet");
+	local summonedPet = UnitNameUnmodified("pet");
 	if summonedPet then
 		local queryLine = summonedPet;
 		if getCompanionProfileID(summonedPet) then

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -306,7 +306,7 @@ local displayMessage = Utils.message.displayMessage;
 local getCurrentPageID = TRP3_API.navigation.page.getCurrentPageID;
 
 ui_boundPlayerCompanion = function (companionID, profileID, targetType)
-	if targetType == TRP3_Enums.UNIT_TYPE.PET and UnitName("pet") == companionID and PetCanBeAbandoned() then
+	if targetType == TRP3_Enums.UNIT_TYPE.PET and UnitNameUnmodified("pet") == companionID and PetCanBeAbandoned() then
 		showConfirmPopup(loc.PR_CO_WARNING_RENAME, function()
 			boundPlayerCompanion(companionID, profileID, targetType);
 		end);

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -655,7 +655,7 @@ local function writeTooltipForCharacter(targetID, targetType)
 	-- Realm
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local _, realm = UnitName(targetType);
+	local _, realm = UnitNameUnmodified(targetType);
 	if showRealm() and realm then
 		tooltipBuilder:AddLine(loc.REG_TT_REALM:format(colors.SECONDARY:WrapTextInColorCode(realm)), colors.MAIN, getSubLineFontSize());
 	end


### PR DESCRIPTION
In contexts where we need to build a "name-realm" character ID (or similar construct for companions) we should prefer to use the UnitNameUnmodified API.

This function will return the unit's real name unmodified by whatever toys or other special effects they may have that would obscure it. Not sure precisely on which toys can have this effect, but if we use the normal UnitName or UnitFullName APIs then we can get into situations where we display incorrect profiles on players.