### PR TITLE
Mark empty abouts as read (combined flyway with inactive glances)

### DIFF
--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -3,7 +3,7 @@
 
 TRP3_API.flyway = {};
 
-local SCHEMA_VERSION = 20;
+local SCHEMA_VERSION = 21;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -359,7 +359,7 @@ TRP3_API.flyway.patches["21"] = function()
 	local profileList = TRP3_Register.profiles;
 	for profileID, profile in pairs(profileList) do
 		-- Don't check default profiles
-		if not TRP3_API.profile.isDefaultProfile(profileID) and profile.characteristics and next(profile.characteristics) ~= nil then
+		if not TRP3_API.profile.isDefaultProfile(profileID) then
 			-- Handle the wrong about unread situation first.
 			local aboutData = profile.about;
 

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -373,26 +373,22 @@ TRP3_API.flyway.patches["21"] = function()
 					filledDescription = templateData.TX and strtrim(templateData.TX):len() > 0;
 				elseif aboutData.TE == 2 then
 					local templateData = aboutData.T2 or {};
-					local atLeastOneFrame = false;
 					for _, frameTab in pairs(templateData) do
 						if frameTab.TX and strtrim(frameTab.TX):len() > 0 then
-							atLeastOneFrame = true;
+							filledDescription = true;
 							break;
 						end
 					end
-					filledDescription = atLeastOneFrame;
 				elseif aboutData.TE == 3 then
-					local atLeastOneFrame = false;
 					local templateData = aboutData.T3 or {};
 					local datas = {templateData.PH, templateData.PS, templateData.HI};
 					for i=1, 3 do
 						local data = datas[i] or {};
 						if data.TX and strtrim(data.TX):len() > 0 then
-							atLeastOneFrame = true;
+							filledDescription = true;
 							break;
 						end
 					end
-					filledDescription = atLeastOneFrame;
 				end
 
 				-- If a profile has both an empty description but is also
@@ -400,18 +396,18 @@ TRP3_API.flyway.patches["21"] = function()
 				if not filledDescription and not profile.about.read then
 					profile.about.read = true;
 				end
+			end
 
-				-- Handle the inactive glance situation next.
-				local miscData = profile.misc;
+			-- Handle the inactive glance situation next.
+			local miscData = profile.misc;
 
-				-- Skip profiles without miscData or no glances set up.
-				if miscData and miscData.PE then
-					for i=1,5 do
-						local index = tostring(i);
-						-- If glance is inactive, wipe its data.
-						if miscData.PE[index] and miscData.PE[index].AC == false then
-							miscData.PE[index] = nil;
-						end
+			-- Skip profiles without miscData or no glances set up.
+			if miscData and miscData.PE then
+				for i=1,5 do
+					local index = tostring(i);
+					-- If glance is inactive, wipe its data.
+					if miscData.PE[index] and miscData.PE[index].AC == false then
+						miscData.PE[index] = nil;
 					end
 				end
 			end

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -377,6 +377,7 @@ TRP3_API.flyway.patches["21"] = function()
 					for _, frameTab in pairs(templateData) do
 						if frameTab.TX and strtrim(frameTab.TX):len() > 0 then
 							atLeastOneFrame = true;
+							break;
 						end
 					end
 					filledDescription = atLeastOneFrame;
@@ -388,6 +389,7 @@ TRP3_API.flyway.patches["21"] = function()
 						local data = datas[i] or {};
 						if data.TX and strtrim(data.TX):len() > 0 then
 							atLeastOneFrame = true;
+							break;
 						end
 					end
 					filledDescription = atLeastOneFrame;

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -170,6 +170,7 @@ local function shouldShowTemplate2(dataTab)
 	for _, frameTab in pairs(templateData) do
 		if frameTab.TX and strtrim(frameTab.TX):len() > 0 then
 			atLeastOneFrame = true;
+			return atLeastOneFrame;
 		end
 	end
 	return atLeastOneFrame;
@@ -437,6 +438,7 @@ local function shouldShowTemplate3(dataTab)
 		local data = datas[i] or {};
 		if data.TX and strtrim(data.TX):len() > 0 then
 			atLeastOneFrame = true;
+			return atLeastOneFrame;
 		end
 	end
 	return atLeastOneFrame;
@@ -808,9 +810,9 @@ local function onSave()
 end
 
 local function onAboutReceived(profileID)
-	local aboutData = getProfile(profileID).about;
+	local aboutData = getProfile(profileID);
 	-- Check that there is a description. If not => set read to true !
-	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData));
+	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData))
 	if noDescr then
 		aboutData.read = true;
 		TRP3_Addon:TriggerEvent(Events.REGISTER_ABOUT_READ);

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -808,9 +808,9 @@ local function onSave()
 end
 
 local function onAboutReceived(profileID)
-	local aboutData = getProfile(profileID);
+	local aboutData = getProfile(profileID).about;
 	-- Check that there is a description. If not => set read to true !
-	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData))
+	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData));
 	if noDescr then
 		aboutData.read = true;
 		TRP3_Addon:TriggerEvent(Events.REGISTER_ABOUT_READ);

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -810,9 +810,9 @@ local function onSave()
 end
 
 local function onAboutReceived(profileID)
-	local aboutData = getProfile(profileID);
+	local aboutData = getProfile(profileID).about;
 	-- Check that there is a description. If not => set read to true !
-	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData))
+	local noDescr = (aboutData.TE == 1 and not shouldShowTemplate1(aboutData)) or (aboutData.TE == 2 and not shouldShowTemplate2(aboutData)) or (aboutData.TE == 3 and not shouldShowTemplate3(aboutData));
 	if noDescr then
 		aboutData.read = true;
 		TRP3_Addon:TriggerEvent(Events.REGISTER_ABOUT_READ);

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -138,6 +138,9 @@ end
 -- TEMPLATE 1
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
+--- shouldShowTemplate1 checks if the frame in T1 has data in it.
+---@param dataTab table Given profile's about tab data.
+---@return boolean # Whether the T1 frame has data in it.
 local function shouldShowTemplate1(dataTab)
 	local templateData = dataTab.T1 or {};
 	return templateData.TX and strtrim(templateData.TX):len() > 0;
@@ -164,16 +167,17 @@ end
 local template2Frames = {};
 local TEMPLATE2_PADDING = 30;
 
+--- shouldShowTemplate2 checks if at least one frame in T2 has data in it.
+---@param dataTab table Given profile's about tab data.
+---@return boolean # Whether at least one frame has data in it.
 local function shouldShowTemplate2(dataTab)
 	local templateData = dataTab.T2 or {};
-	local atLeastOneFrame = false;
 	for _, frameTab in pairs(templateData) do
 		if frameTab.TX and strtrim(frameTab.TX):len() > 0 then
-			atLeastOneFrame = true;
-			return atLeastOneFrame;
+			return true;
 		end
 	end
-	return atLeastOneFrame;
+	return false;
 end
 
 local function resizeTemplate2()
@@ -430,18 +434,19 @@ local function onHistoIconSelected(icon)
 	setupIconButton(TRP3_RegisterAbout_Edit_Template3_HistIcon, icon or TEMPLATE3_ICON_HISTORY);
 end
 
+--- shouldShowTemplate3 checks if at least one frame in T3 has data in it.
+---@param dataTab table Given profile's about tab data.
+---@return boolean # Whether at least one frame has data in it.
 local function shouldShowTemplate3(dataTab)
-	local atLeastOneFrame = false;
 	local templateData = dataTab.T3 or {};
 	local datas = {templateData.PH, templateData.PS, templateData.HI};
 	for i=1, 3 do
 		local data = datas[i] or {};
 		if data.TX and strtrim(data.TX):len() > 0 then
-			atLeastOneFrame = true;
-			return atLeastOneFrame;
+			return true;
 		end
 	end
-	return atLeastOneFrame;
+	return false;
 end
 
 local function resizeTemplate3()


### PR DESCRIPTION
About changes were always marked as unread, which is fine 9/10 of the time. However due to an incorrect check in `onAboutReceived` we also applied unread to empty abouts. These should not marked as unread.

This includes a flyway (21) to update people's directory to mark all the profiles with empty abouts that were wrongly marked as unread.. As read.

Updated: This also adds to the same flyway the removal of inactive glance data that we were not intending to send (handled in #980).