### PR TITLE
Read summoned pet IDs from correct location

### DIFF
--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -279,7 +279,7 @@ end
 local function GetSummonedPetGUID()
 	if C_PetJournal then
 		return C_PetJournal.GetSummonedPetGUID();
-	else
+	elseif TRP3_Companions then
 		return TRP3_Companions.summonedPetID;
 	end
 end

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -240,9 +240,9 @@ local function UpdateSummonedPetGUID(speciesID)
 end
 
 local function UpdateSummonedPetGUIDFromCast(unitToken, castGUID)
-	-- For Classic clients we need to be creative with how we know what
-	-- non-combat pet the player has summoned. None of the companion API
-	-- exists, nor does the COMPANION_UPDATE event.
+	-- For Classic era we need to be creative with how we know what non-combat
+	-- pet the player has summoned. None of the companion API exists, nor does
+	-- the COMPANION_UPDATE event.
 	--
 	-- Our approach is to monitor for successful spellcasts whose spell IDs
 	-- are associated with that of a known companion pet. We assume that the
@@ -254,10 +254,9 @@ local function UpdateSummonedPetGUIDFromCast(unitToken, castGUID)
 	-- if it's dismissed other players can't see the unit to request the data
 	-- anyway.
 	--
-	-- For persistence across UI reloads we store the summoned pet data in a
-	-- temporary CVar. When logging out pets aren't resummoned in Classic, so
-	-- we don't need to worry about the case where a player switches
-	-- characters.
+	-- For persistence across UI reloads we store the summoned pet data in our
+	-- saved variables, and reset it upon initial login of a new character.
+	-- When logging out pets aren't resummoned in Classic Era.
 
 	if unitToken ~= "player" then
 		return;
@@ -281,7 +280,7 @@ local function GetSummonedPetGUID()
 	if C_PetJournal then
 		return C_PetJournal.GetSummonedPetGUID();
 	else
-		return GetCVar("totalRP3_SummonedPetID");
+		return TRP3_Companions.summonedPetID;
 	end
 end
 


### PR DESCRIPTION
This has been broken ever since we migrated away from using temporary CVars. Odds are we've not been sending the correct query line data for non-combat pets in Era this entire time.