### PR TITLE
Add background browser for about pages

### DIFF
--- a/totalRP3/Core/Core.xml
+++ b/totalRP3/Core/Core.xml
@@ -69,6 +69,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Include file="UIMain.lua"/>
 
+	<Include file="..\UI\Browsers\BackgroundBrowser.xml"/>
 	<Include file="..\UI\Browsers\IconBrowser.xml"/>
 	<Include file="..\UI\Browsers\Companions.xml"/>
 	<Include file="..\UI\Browsers\Musics.xml"/>

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -418,6 +418,43 @@ function TRP3_API.popup.hideIconBrowser()
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+-- Background browser
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+
+local function ShowBackgroundBrowser(onSelectCallback, onCancelCallback, scale, selectedImageID)
+	local function OnAccept(imageInfo)
+		hidePopups();
+
+		if onSelectCallback then
+			onSelectCallback(imageInfo);
+		end
+	end
+
+	local function OnCancel()
+		hidePopups();
+
+		if onCancelCallback then
+			onCancelCallback();
+		end
+	end
+
+	TRP3_BackgroundBrowser.Open({
+		onAcceptCallback = OnAccept,
+		onCancelCallback = OnCancel,
+		scale = scale,
+		selectedImage = selectedImageID,
+	});
+end
+
+function TRP3_API.popup.ShowBackgroundBrowser(callback, selectedImageID)
+	TRP3_API.popup.showPopup(TRP3_API.popup.BACKGROUNDS, nil, {callback, nil, nil, selectedImageID});
+end;
+
+function TRP3_API.popup.HideBackgroundBrowser()
+	TRP3_BackgroundBrowser.Close();
+end
+
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Companion browser
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
@@ -1169,6 +1206,7 @@ TRP3_API.popup.COLORS = "colors";
 TRP3_API.popup.MUSICS = "musics";
 TRP3_API.popup.COMPANIONS = "companions";
 TRP3_API.popup.PETS = "pets";
+TRP3_API.popup.BACKGROUNDS = "backgrounds";
 
 local POPUP_STRUCTURE = {
 	[TRP3_API.popup.IMAGES] = {
@@ -1195,6 +1233,10 @@ local POPUP_STRUCTURE = {
 		frame = AddOn_TotalRP3.Ui.GetPetBrowserFrame(),
 		showMethod = TRP3_API.popup.showPetBrowser,
 	} or nil,
+	[TRP3_API.popup.BACKGROUNDS] = {
+		frame = TRP3_BackgroundBrowserFrame,
+		showMethod = ShowBackgroundBrowser,
+	},
 }
 TRP3_API.popup.POPUPS = POPUP_STRUCTURE;
 

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -113,7 +113,7 @@ function TRP3_API.ui.frame.getTiledBackgroundList()
 	local tab = {};
 	for index, info in ipairs(tiledBackgrounds) do
 		if GetFileIDFromPath(info.bgFile) then
-			tinsert(tab, {loc.UI_BKG:format(tostring(index)), index, "|T" .. info.bgFile .. ":200:200|t"});
+			tinsert(tab, {index, info.bgFile});
 		end
 	end
 	return tab;

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -76,6 +76,7 @@ local tiledBackgrounds = {
 	[49] = { bgFile = "interface\\credits\\creditsscreenbackground8shadowlands", tile = true, tileSize = 512 },
 	[50] = { bgFile = "interface\\credits\\creditsscreenbackground9dragonflight", tile = true, tileSize = 512 },
 	[51] = { bgFile = "interface\\credits\\creditsscreenbackground10thewarwithin", tile = true, tileSize = 512 },
+	[52] = { bgFile = "interface\\glues\\characterselect\\glueannouncementpopupbackground", tile = true, tileSize = 256 },
 };
 
 function TRP3_API.ui.frame.getTiledBackground(index)

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -850,6 +850,8 @@ Use the |cnGREEN_FONT_COLOR:Import profile|r option to paste data from a previou
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	UI_BKG = "Background %s",
+	UI_BKG_BROWSER = "Background browser",
+	UI_BKG_BUTTON = "Change background",
 	UI_ICON_BROWSER = "Icon browser",
 	UI_ICON_BROWSER_SEARCHING = "Searching...",
 	UI_COMPANION_BROWSER_HELP = "Select a battle pet",

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -10,7 +10,6 @@ local stEtN = Utils.str.emptyToNil;
 local get = TRP3_API.profile.getData;
 local tcopy = Utils.table.copy;
 local getDefaultProfile = TRP3_API.profile.getDefaultProfile;
-local getTiledBackgroundList = TRP3_API.ui.frame.getTiledBackgroundList;
 local showIfMouseOver = TRP3_API.ui.frame.showIfMouseOverFrame;
 local createRefreshOnFrame = TRP3_API.ui.frame.createRefreshOnFrame;
 local setupListBox = TRP3_API.ui.listbox.setupListBox;
@@ -114,6 +113,7 @@ local function setConsultBkg(bkg)
 end
 
 local function setEditBkg(bkg)
+	draftData.BK = bkg;
 	setBkg(TRP3_RegisterAbout, bkg);
 end
 
@@ -303,7 +303,17 @@ end
 
 local function createTemplate2Frame(frameIndex)
 	local frame = CreateFrame("Frame", "TRP3_RegisterAbout_Template2_Edit"..frameIndex, TRP3_RegisterAbout_Edit_Template2_Container, "TRP3_RegisterAbout_Template2_Edit");
-	setupListBox(_G["TRP3_RegisterAbout_Template2_Edit"..frameIndex.."Bkg"], getTiledBackgroundList(), setTemplate2EditBkg, nil, 120, true);
+
+	local BackgroundButton = _G["TRP3_RegisterAbout_Template2_Edit"..frameIndex.."Bkg"];
+	BackgroundButton:SetText(loc.UI_BKG_BUTTON);
+	BackgroundButton:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setTemplate2EditBkg(imageInfo and imageInfo.id or nil, BackgroundButton);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, frame.frameData.BK);
+	end);
+
 	_G[frame:GetName().."Delete"]:SetScript("OnClick", template2DeleteFrame);
 	_G[frame:GetName().."Delete"]:SetText(loc.CM_REMOVE);
 	_G[frame:GetName().."Up"]:SetScript("OnClick", template2UpFrame);
@@ -344,7 +354,6 @@ function refreshTemplate2EditDisplay()
 		-- Values
 		frame.index = frameIndex;
 		frame.frameData = frameData;
-		_G[frame:GetName().."Bkg"]:SetSelectedIndex(frameData.BK or 1);
 		_G[frame:GetName().."TextScrollText"]:SetText(frameData.TX or "");
 		setupIconButton(_G[frame:GetName().."Icon"], frameData.IC or TRP3_InterfaceIcons.Default);
 		_G[frame:GetName().."Icon"]:SetScript("onMouseDown", function(self, button)
@@ -408,14 +417,17 @@ local TEMPLATE3_ICON_PSYCHO = TRP3_InterfaceIcons.TraitSection;
 local TEMPLATE3_ICON_HISTORY = TRP3_InterfaceIcons.HistorySection;
 
 local function setTemplate3PhysBkg(bkg)
+	draftData.T3.PH.BK = bkg;
 	setBkg(TRP3_RegisterAbout_Edit_Template3_Phys, bkg);
 end
 
 local function setTemplate3PsyBkg(bkg)
+	draftData.T3.PS.BK = bkg;
 	setBkg(TRP3_RegisterAbout_Edit_Template3_Psy, bkg);
 end
 
 local function setTemplate3HistBkg(bkg)
+	draftData.T3.HI.BK = bkg;
 	setBkg(TRP3_RegisterAbout_Edit_Template3_Hist, bkg);
 end
 
@@ -616,16 +628,12 @@ end
 
 function saveInDraft()
 	assert(type(draftData) == "table", "Error: Nil draftData or not a table.");
-	draftData.BK = TRP3_RegisterAbout_Edit_BckField:GetSelectedValue();
 	draftData.TE = TRP3_RegisterAbout_Edit_TemplateField:GetSelectedValue();
 	-- Template 1
 	draftData.T1.TX = TRP3_RegisterAbout_Edit_Template1ScrollText:GetText();
 	-- Template 2
 	template2SaveToDraft();
 	-- Template 3
-	draftData.T3.PH.BK = TRP3_RegisterAbout_Edit_Template3_PhysBkg:GetSelectedValue();
-	draftData.T3.PS.BK = TRP3_RegisterAbout_Edit_Template3_PsyBkg:GetSelectedValue();
-	draftData.T3.HI.BK = TRP3_RegisterAbout_Edit_Template3_HistBkg:GetSelectedValue();
 	draftData.T3.PH.TX = stEtN(TRP3_RegisterAbout_Edit_Template3_PhysTextScrollText:GetText());
 	draftData.T3.PS.TX = stEtN(TRP3_RegisterAbout_Edit_Template3_PsyTextScrollText:GetText());
 	draftData.T3.HI.TX = stEtN(TRP3_RegisterAbout_Edit_Template3_HistTextScrollText:GetText());
@@ -674,7 +682,6 @@ local function refreshEditDisplay()
 		tcopy(draftData, dataTab);
 	end
 
-	TRP3_RegisterAbout_Edit_BckField:SetSelectedIndex(draftData.BK or 1);
 	TRP3_RegisterAbout_Edit_TemplateField:SetSelectedIndex(draftData.TE or 1);
 	selectMusic(draftData.MU);
 	-- Template 1
@@ -689,9 +696,6 @@ local function refreshEditDisplay()
 	setTemplate3PhysBkg(template3Data.PH.BK or 1);
 	setTemplate3PsyBkg(template3Data.PS.BK or 1);
 	setTemplate3HistBkg(template3Data.HI.BK or 1);
-	TRP3_RegisterAbout_Edit_Template3_PhysBkg:SetSelectedIndex(template3Data.PH.BK or 1);
-	TRP3_RegisterAbout_Edit_Template3_PsyBkg:SetSelectedIndex(template3Data.PS.BK or 1);
-	TRP3_RegisterAbout_Edit_Template3_HistBkg:SetSelectedIndex(template3Data.HI.BK or 1);
 	setupIconButton(TRP3_RegisterAbout_Edit_Template3_PhysIcon, template3Data.PH.IC or TEMPLATE3_ICON_PHYSICAL);
 	setupIconButton(TRP3_RegisterAbout_Edit_Template3_PsyIcon, template3Data.PS.IC or TEMPLATE3_ICON_PSYCHO);
 	setupIconButton(TRP3_RegisterAbout_Edit_Template3_HistIcon, template3Data.HI.IC or TEMPLATE3_ICON_HISTORY);
@@ -958,12 +962,17 @@ function TRP3_API.register.inits.aboutInit()
 
 	-- UI
 	createRefreshOnFrame(TRP3_RegisterAbout_AboutPanel, 0.2, onPlayerAboutRefresh);
-	local bkgTab = getTiledBackgroundList();
-	setupListBox(TRP3_RegisterAbout_Edit_BckField, bkgTab, setEditBkg, nil, 150, true);
+
+	TRP3_RegisterAbout_Edit_BckField:SetText(loc.UI_BKG_BUTTON);
+	TRP3_RegisterAbout_Edit_BckField:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setEditBkg(imageInfo and imageInfo.id or nil);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, draftData.BK);
+	end);
+
 	setupListBox(TRP3_RegisterAbout_Edit_TemplateField, {{"Template 1", 1}, {"Template 2", 2}, {"Template 3", 3}}, setEditTemplate, nil, 150, true);
-	setupListBox(TRP3_RegisterAbout_Edit_Template3_PhysBkg, bkgTab, setTemplate3PhysBkg, nil, 150, true);
-	setupListBox(TRP3_RegisterAbout_Edit_Template3_PsyBkg, bkgTab, setTemplate3PsyBkg, nil, 150, true);
-	setupListBox(TRP3_RegisterAbout_Edit_Template3_HistBkg, bkgTab, setTemplate3HistBkg, nil, 150, true);
 	setTooltipAll(TRP3_RegisterAbout_Edit_Template3_PhysIcon, "RIGHT", 0, 5, loc.UI_ICON_SELECT, TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.UI_ICON_OPENBROWSER) .. "|n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.UI_ICON_OPTIONS));
 	TRP3_RegisterAbout_Edit_Template3_PhysIcon:SetScript("onMouseDown", function(self, button)
 		if button == "LeftButton" then
@@ -976,6 +985,33 @@ function TRP3_API.register.inits.aboutInit()
 				description:CreateButton(loc.UI_ICON_PASTE, function() onPhisIconSelected(TRP3_API.GetLastCopiedIcon()); end);
 			end);
 		end
+	end);
+
+	TRP3_RegisterAbout_Edit_Template3_PhysBkg:SetText(loc.UI_BKG_BUTTON);
+	TRP3_RegisterAbout_Edit_Template3_PhysBkg:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setTemplate3PhysBkg(imageInfo and imageInfo.id or nil);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, draftData.T3.PH.BK);
+	end);
+
+	TRP3_RegisterAbout_Edit_Template3_PsyBkg:SetText(loc.UI_BKG_BUTTON);
+	TRP3_RegisterAbout_Edit_Template3_PsyBkg:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setTemplate3PsyBkg(imageInfo and imageInfo.id or nil);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, draftData.T3.PS.BK);
+	end);
+
+	TRP3_RegisterAbout_Edit_Template3_HistBkg:SetText(loc.UI_BKG_BUTTON);
+	TRP3_RegisterAbout_Edit_Template3_HistBkg:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setTemplate3HistBkg(imageInfo and imageInfo.id or nil);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, draftData.T3.HI.BK);
 	end);
 
 	setTooltipAll(TRP3_RegisterAbout_Edit_Template3_PsyIcon, "RIGHT", 0, 5, loc.UI_ICON_SELECT, TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.UI_ICON_OPENBROWSER) .. "|n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.UI_ICON_OPTIONS));

--- a/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
@@ -85,19 +85,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Anchor point="TOPLEFT" x="15" y="-12"/>
 				</Anchors>
 			</Button>
-			<Frame name="$parentBkg" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
+			<Button name="$parentBkg" inherits="TRP3_CommonButton">
+				<Size x="170" y="22"/>
 				<Anchors>
 					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="$parentIcon" x="-7" y="-5"/>
 				</Anchors>
-				<Scripts>
-					<OnEnter inherit="prepend">
-						TRP3_RefreshTooltipForFrame(self);
-					</OnEnter>
-					<OnLeave inherit="prepend">
-						TRP3_MainTooltip:Hide();
-					</OnLeave>
-				</Scripts>
-			</Frame>
+			</Button>
 			<Frame name="$parentText" inherits="TRP3_TextArea">
 				<Anchors>
 					<Anchor point="TOP" x="0" y="-10"/>
@@ -172,20 +165,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<PushedTexture file="Interface\Buttons\UI-Panel-CollapseButton-Down"/>
 				<HighlightTexture file="Interface\Buttons\UI-Panel-MinimizeButton-Highlight" alphaMode="ADD"/>
 			</Button>
-			<Frame name="$parentBkg" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
-				<Size x="170" y="32"/>
+			<Button name="$parentBkg" inherits="TRP3_CommonButton">
+				<Size x="170" y="22"/>
 				<Anchors>
-					<Anchor point="BOTTOMLEFT" x="58" y="5"/>
+					<Anchor point="BOTTOMLEFT" x="58" y="10"/>
 				</Anchors>
-				<Scripts>
-					<OnEnter inherit="prepend">
-						TRP3_RefreshTooltipForFrame(self);
-					</OnEnter>
-					<OnLeave inherit="prepend">
-						TRP3_MainTooltip:Hide();
-					</OnLeave>
-				</Scripts>
-			</Frame>
+			</Button>
 			<Frame name="$parentText" inherits="TRP3_TextArea">
 				<Anchors>
 					<Anchor point="TOP" x="0" y="-10"/>
@@ -224,16 +209,16 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						</Anchors>
 						<Frames>
 							<Button name="TRP3_RegisterAbout_Edit_Music_Action" inherits="TRP3_CommonButton">
-								<Size x="100" y="22"/>
+								<Size x="180" y="22"/>
 								<Anchors>
-									<Anchor point="TOPLEFT" x="15" y="-5"/>
+									<Anchor point="TOPLEFT" x="13" y="-5"/>
 								</Anchors>
 							</Button>
 						</Frames>
 						<Layers>
 							<Layer level="OVERLAY">
 								<FontString name="TRP3_RegisterAbout_Edit_Music_Text" inherits="GameFontNormal" justifyH="LEFT" text="[Music_title]">
-									<Size x="350" y="10"/>
+									<Size x="270" y="10"/>
 									<Anchors>
 										<Anchor point="LEFT" relativePoint="RIGHT" relativeTo="TRP3_RegisterAbout_Edit_Music_Action" x="0" y="0"/>
 									</Anchors>
@@ -242,12 +227,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							</Layer>
 						</Layers>
 					</Frame>
-					<Frame name="TRP3_RegisterAbout_Edit_BckField" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
-						<Size x="170" y="32"/>
+					<Button name="TRP3_RegisterAbout_Edit_BckField" inherits="TRP3_CommonButton">
+						<Size x="180" y="22"/>
 						<Anchors>
 							<Anchor point="TOPLEFT" x="13" y="-35"/>
 						</Anchors>
-					</Frame>
+					</Button>
 					<Frame name="TRP3_RegisterAbout_Edit_TemplateField" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
 						<Anchors>
 							<Anchor point="LEFT" relativePoint="RIGHT" x="10" y="0" relativeTo="TRP3_RegisterAbout_Edit_BckField"/>

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsPage.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsPage.lua
@@ -15,8 +15,6 @@ local hidePopups = TRP3_API.popup.hidePopups;
 local displayConsult;
 local tcopy, tsize, EMPTY = Utils.table.copy, Utils.table.size, Globals.empty;
 local stEtN = Utils.str.emptyToNil;
-local getTiledBackgroundList = TRP3_API.ui.frame.getTiledBackgroundList;
-local setupListBox = TRP3_API.ui.listbox.setupListBox;
 local isUnitIDKnown, hasProfile, getUnitProfile = TRP3_API.register.isUnitIDKnown, TRP3_API.register.hasProfile, TRP3_API.register.getProfile;
 local getCompleteName, openPageByUnitID = TRP3_API.register.getCompleteName;
 local deleteProfile = TRP3_API.companions.register.deleteProfile;
@@ -112,7 +110,6 @@ local function saveInDraft(profileName)
 	assert(type(draftData) == "table", "Error: Nil draftData or not a table.");
 	draftData.NA = stEtN(strtrim(TRP3_CompanionsPageInformationEdit_NamePanel_NameField:GetText())) or profileName;
 	draftData.TI = stEtN(strtrim(TRP3_CompanionsPageInformationEdit_NamePanel_TitleField:GetText()));
-	draftData.BK = TRP3_CompanionsPageInformationEdit_About_BckField:GetSelectedValue();
 	draftData.TX = stEtN(strtrim(TRP3_CompanionsPageInformationEdit_About_TextScrollText:GetText()));
 end
 
@@ -126,6 +123,11 @@ local function onNameColorSelected(red, green, blue)
 end
 
 local function setBkg(frame, bkg)
+	TRP3_API.ui.frame.setBackdropToBackground(frame, bkg);
+end
+
+local function setEditBkg(frame, bkg)
+	draftData.BK = bkg;
 	TRP3_API.ui.frame.setBackdropToBackground(frame, bkg);
 end
 
@@ -169,7 +171,6 @@ local function displayEdit()
 	setupIconButton(TRP3_CompanionsPageInformationEdit_NamePanel_Icon, draftData.IC or TRP3_InterfaceIcons.ProfileDefault);
 	TRP3_CompanionsPageInformationEdit_NamePanel_TitleField:SetText(draftData.TI or "");
 	TRP3_CompanionsPageInformationEdit_NamePanel_NameField:SetText(draftData.NA or Globals.player);
-	TRP3_CompanionsPageInformationEdit_About_BckField:SetSelectedIndex(draftData.BK or 1);
 	TRP3_CompanionsPageInformationEdit_About_TextScrollText:SetText(draftData.TX or "");
 
 	if draftData.NH then
@@ -448,8 +449,16 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 	TRP3_CompanionsPageInformationEdit_NamePanel_TitleFieldText:SetText(loc.REG_COMPANION_TITLE);
 	TRP3_CompanionsPageInformationEdit_NamePanel_CancelButton:SetText(loc.CM_CANCEL);
 	TRP3_CompanionsPageInformationEdit_NamePanel_SaveButton:SetText(loc.CM_SAVE);
-	local bkgTab = getTiledBackgroundList();
-	setupListBox(TRP3_CompanionsPageInformationEdit_About_BckField, bkgTab, function(value) setBkg(TRP3_CompanionsPageInformationEdit_About, value) end, nil, 120, true);
+
+	TRP3_CompanionsPageInformationEdit_About_BckField:SetText(loc.UI_BKG_BUTTON);
+	TRP3_CompanionsPageInformationEdit_About_BckField:SetScript("OnClick", function()
+		local function OnBackgroundSelected(imageInfo)
+			setEditBkg(TRP3_CompanionsPageInformationEdit_About, imageInfo and imageInfo.id or nil);
+		end
+
+		TRP3_API.popup.ShowBackgroundBrowser(OnBackgroundSelected, draftData.BK);
+	end);
+
 	TRP3_API.ui.text.setupToolbar(TRP3_CompanionsPageInformationEdit_About_Toolbar, TRP3_CompanionsPageInformationEdit_About_TextScrollText);
 
 	setTooltipForSameFrame(TRP3_CompanionsPageInformationConsult_GlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, loc.REG_PLAYER_GLANCE_CONFIG);

--- a/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
+++ b/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
@@ -222,12 +222,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<Anchor point="RIGHT" x="-10" y="0"/>
 						</Anchors>
 						<Frames>
-							<Frame name="$parent_BckField" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
-								<Size x="170" y="32"/>
+							<Button name="$parent_BckField" inherits="TRP3_CommonButton">
+								<Size x="180" y="22"/>
 								<Anchors>
 									<Anchor point="TOPLEFT" x="13" y="-15"/>
 								</Anchors>
-							</Frame>
+							</Button>
 
 							<!-- Toolbar -->
 							<Frame name="$parent_Toolbar" inherits="TRP3_TextToolbar">

--- a/totalRP3/UI/Tooltip/TooltipTemplates.lua
+++ b/totalRP3/UI/Tooltip/TooltipTemplates.lua
@@ -65,6 +65,11 @@ function TRP3_TooltipTemplates.CreateInstructionLine(binding, instruction, short
 	return line;
 end
 
+function TRP3_TooltipTemplates.CreateDelimitedLine(title, text, wrap, leftOffset)
+	text = string.format("|cnNORMAL_FONT_COLOR:%s:|r %s", title, text);
+	return TRP3_TooltipTemplates.CreateLine(text, HIGHLIGHT_FONT_COLOR, wrap, leftOffset);
+end
+
 function TRP3_TooltipTemplates.CreateBlankLine()
 	local line = TRP3_Tooltip.CreateLineDescription();
 	line:SetShouldShow(true);


### PR DESCRIPTION
Closes #964. This implements a basic browser to visually select backgrounds for about pages, replacing the now almost 50 element long dropdown. Most of the code is just a copy/paste of the icon browser, followed by some of the worst code ever to integrate its use into all of our about editors.

This is barely tested. Might have issues, might not - frankly the about integration was painful enough that if this feature were scrapped and the work deleted I'd be just as happy.