### PR TITLE
Use same anchors when scrollbar is and isn't present for register list

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -979,20 +979,13 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 		local scrollBoxAnchorsWithBar = {
 			AnchorUtil.CreateAnchor("TOP", self.Header, "BOTTOM", 0, -3),
 			AnchorUtil.CreateAnchor("LEFT", self, "LEFT", 16, 0),
-			AnchorUtil.CreateAnchor("RIGHT", self.ScrollBar, "LEFT", -8, 0),
-			AnchorUtil.CreateAnchor("BOTTOM", self, "BOTTOM", 0, 88),
-		};
-
-		local scrollBoxAnchorsWithoutBar = {
-			scrollBoxAnchorsWithBar[1],
-			scrollBoxAnchorsWithBar[2],
 			AnchorUtil.CreateAnchor("RIGHT", self, "RIGHT", -16, 0),
-			scrollBoxAnchorsWithBar[4],
+			AnchorUtil.CreateAnchor("BOTTOM", self, "BOTTOM", 0, 88),
 		};
 
 		self.ScrollView = CreateScrollBoxListLinearView();
 		ScrollUtil.InitScrollBoxListWithScrollBar(self.ScrollBox, self.ScrollBar, self.ScrollView);
-		ScrollUtil.AddManagedScrollBarVisibilityBehavior(self.ScrollBox, self.ScrollBar, scrollBoxAnchorsWithBar, scrollBoxAnchorsWithoutBar);
+		ScrollUtil.AddManagedScrollBarVisibilityBehavior(self.ScrollBox, self.ScrollBar, scrollBoxAnchorsWithBar, scrollBoxAnchorsWithBar);
 	end
 
 	TRP3_RegisterListFilterCharactNotes:SetChecked(false);


### PR DESCRIPTION
Currently the new scrollbox-based register list adjusts its anchors so that the scrollbox frame doesn't overlap the scrollbar.

Visually, the overlap causes no issues if it occurs - and avoiding the overlap means our "Flags" and a few other columns end up being positioned too far left of their actual headers when the window is resized horizontally, so things look weird.

Until this entire UI is blown up and rewritten from scratch, for now just let the scrollbox always use the same anchors and allow it to overlap the scrollbar a bit in terms of its rect. This brings the columns *mostly* back into alignment.

![image](https://github.com/user-attachments/assets/2f6272a5-89dd-4d93-baa5-85071ba8470b)
