### PR TITLE
Change cursor to glance icon on drag

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -734,7 +734,7 @@ local draggingGlance = false;
 local function onGlanceDragStart(button)
 	if button.isCurrentMine and button.data then
 		draggingGlance = true;
-		SetCursor("Interface\\ICONS\\" .. (button.data.IC or TRP3_InterfaceIcons.Default));
+		SetCursor(GetFileIDFromPath("Interface\\ICONS\\" .. (button.data.IC or TRP3_InterfaceIcons.Default)));
 	end
 end
 TRP3_API.register.glance.onGlanceDragStart = onGlanceDragStart;


### PR DESCRIPTION
It seems SetCursor plays nicer if it is fed a FileID of the icon we want it to look like.

I don't play classic/era, but Meorawr said those also understand FileIDs.


Before

https://github.com/user-attachments/assets/bceadc47-b911-4219-bbb5-3648ea79c7df


After

https://github.com/user-attachments/assets/b0c8ab57-5d29-4d1f-829d-30b0281c22a0

