### PR TITLE
Reset isFading on showing the toast

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -663,6 +663,7 @@ function TRP3_API.ui.tooltip.toast(text, duration)
 	TRP3_Toast:SetOwner(TRP3_MainFramePageContainer, "ANCHOR_BOTTOM", 0, 60);
 	GameTooltip_AddHighlightLine(TRP3_Toast, text, true);
 	TRP3_Toast:Show();
+	TRP3_Toast.isFading = false;
 	TRP3_Toast.delay = duration or 3;
 end
 


### PR DESCRIPTION
As soon as the toast starts fading once, it will never fade again, as isFading was never reset. We're now resetting it as soon as we show the toast.

Might have been noticed by some void elf whose name starts with an R.