### PR TITLE
Popups on escape now just close themselves

### DIFF
--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -1285,7 +1285,7 @@ function TRP3_API.popup.showPopup(popupID, popupPosition, popupArgs)
 	popup.frame:SetScript("OnKeyDown", function(_, key)
 		-- Do not steal input if we're in combat.
 		if InCombatLockdown() then return; end
-		
+
 		if key == "ESCAPE" then
 			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 			popup.frame:SetPropagateKeyboardInput(false);

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -766,6 +766,20 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 	else
 		TRP3_CompanionBrowserTitle:SetText(loc.REG_COMPANION_BROWSER_MOUNT);
 	end
+	-- Do not steal input if we're in combat.
+	if not InCombatLockdown() then
+		local frame = TRP3_CompanionBrowser;
+		frame:SetScript("OnKeyDown", function(_, key)
+			if key == "ESCAPE" then
+				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+				frame:SetPropagateKeyboardInput(false);
+				frame:Hide();
+				hidePopups();
+			else
+				frame:SetPropagateKeyboardInput(true);
+			end
+		end);
+	end
 	ui_CompanionBrowserContent.onSelectCallback = onSelectCallback;
 	ui_CompanionBrowserContent.onCancelCallback = onCancelCallback;
 	TRP3_CompanionBrowserFilterBox:SetText("");
@@ -778,6 +792,20 @@ function TRP3_API.popup.showPetBrowser(profileID, onSelectCallback, onCancelCall
 	local frame = AddOn_TotalRP3.Ui.GetPetBrowserFrame();
 	if not frame then
 		return;
+	end
+
+	-- Do not steal input if we're in combat.
+	if not InCombatLockdown() then
+		frame:SetScript("OnKeyDown", function(_, key)
+			if key == "ESCAPE" then
+				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+				frame:SetPropagateKeyboardInput(false);
+				frame:Hide();
+				hidePopups();
+			else
+				frame:SetPropagateKeyboardInput(true);
+			end
+		end);
 	end
 
 	onSelectCallback = onSelectCallback or nop;
@@ -1248,6 +1276,19 @@ function TRP3_API.popup.showPopup(popupID, popupPosition, popupArgs)
 	local popup = POPUP_STRUCTURE[popupID];
 
 	popup.frame:ClearAllPoints();
+
+	-- Do not steal input if we're in combat.
+	if not InCombatLockdown() then
+		popup.frame:SetScript("OnKeyDown", function(_, key)
+			if key == "ESCAPE" then
+				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+				popup.frame:SetPropagateKeyboardInput(false);
+				hidePopups();
+			else
+				popup.frame:SetPropagateKeyboardInput(true);
+			end
+		end);
+	end
 
 	if popupPosition and popupPosition.parent then
 		popup.frame:SetParent(popupPosition.parent);

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -766,6 +766,10 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 	else
 		TRP3_CompanionBrowserTitle:SetText(loc.REG_COMPANION_BROWSER_MOUNT);
 	end
+
+	ui_CompanionBrowserContent.onSelectCallback = onSelectCallback;
+	ui_CompanionBrowserContent.onCancelCallback = onCancelCallback;
+
 	-- Do not steal input if we're in combat.
 	if not InCombatLockdown() then
 		local frame = TRP3_CompanionBrowser;
@@ -773,15 +777,14 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 			if key == "ESCAPE" then
 				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 				frame:SetPropagateKeyboardInput(false);
-				frame:Hide();
-				hidePopups();
+				-- Hiding frames & Cancel callback is handled within.
+				onCompanionClose();
 			else
 				frame:SetPropagateKeyboardInput(true);
 			end
 		end);
 	end
-	ui_CompanionBrowserContent.onSelectCallback = onSelectCallback;
-	ui_CompanionBrowserContent.onCancelCallback = onCancelCallback;
+
 	TRP3_CompanionBrowserFilterBox:SetText("");
 	filteredCompanionBrowser();
 	showPopup(TRP3_CompanionBrowser);
@@ -794,6 +797,9 @@ function TRP3_API.popup.showPetBrowser(profileID, onSelectCallback, onCancelCall
 		return;
 	end
 
+	onSelectCallback = onSelectCallback or nop;
+	onCancelCallback = onCancelCallback or nop;
+
 	-- Do not steal input if we're in combat.
 	if not InCombatLockdown() then
 		frame:SetScript("OnKeyDown", function(_, key)
@@ -802,14 +808,13 @@ function TRP3_API.popup.showPetBrowser(profileID, onSelectCallback, onCancelCall
 				frame:SetPropagateKeyboardInput(false);
 				frame:Hide();
 				hidePopups();
+				-- Handle cancel callback through function.
+				onCancelCallback();
 			else
 				frame:SetPropagateKeyboardInput(true);
 			end
 		end);
 	end
-
-	onSelectCallback = onSelectCallback or nop;
-	onCancelCallback = onCancelCallback or nop;
 
 	frame:SetDialogProfileID(profileID);
 	frame:SetDialogCallback(function(result, ...)

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -770,20 +770,20 @@ function TRP3_API.popup.showCompanionBrowser(onSelectCallback, onCancelCallback,
 	ui_CompanionBrowserContent.onSelectCallback = onSelectCallback;
 	ui_CompanionBrowserContent.onCancelCallback = onCancelCallback;
 
-	-- Do not steal input if we're in combat.
-	if not InCombatLockdown() then
-		local frame = TRP3_CompanionBrowser;
-		frame:SetScript("OnKeyDown", function(_, key)
-			if key == "ESCAPE" then
-				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-				frame:SetPropagateKeyboardInput(false);
-				-- Hiding frames & Cancel callback is handled within.
-				onCompanionClose();
-			else
-				frame:SetPropagateKeyboardInput(true);
-			end
-		end);
-	end
+	local frame = TRP3_CompanionBrowser;
+	frame:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "ESCAPE" then
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+			frame:SetPropagateKeyboardInput(false);
+			-- Hiding frames & Cancel callback is handled within.
+			onCompanionClose();
+		else
+			frame:SetPropagateKeyboardInput(true);
+		end
+	end);
 
 	TRP3_CompanionBrowserFilterBox:SetText("");
 	filteredCompanionBrowser();
@@ -800,21 +800,21 @@ function TRP3_API.popup.showPetBrowser(profileID, onSelectCallback, onCancelCall
 	onSelectCallback = onSelectCallback or nop;
 	onCancelCallback = onCancelCallback or nop;
 
-	-- Do not steal input if we're in combat.
-	if not InCombatLockdown() then
-		frame:SetScript("OnKeyDown", function(_, key)
-			if key == "ESCAPE" then
-				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-				frame:SetPropagateKeyboardInput(false);
-				frame:Hide();
-				hidePopups();
-				-- Handle cancel callback through function.
-				onCancelCallback();
-			else
-				frame:SetPropagateKeyboardInput(true);
-			end
-		end);
-	end
+	frame:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "ESCAPE" then
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+			frame:SetPropagateKeyboardInput(false);
+			frame:Hide();
+			hidePopups();
+			-- Handle cancel callback through function.
+			onCancelCallback();
+		else
+			frame:SetPropagateKeyboardInput(true);
+		end
+	end);
 
 	frame:SetDialogProfileID(profileID);
 	frame:SetDialogCallback(function(result, ...)
@@ -1282,18 +1282,18 @@ function TRP3_API.popup.showPopup(popupID, popupPosition, popupArgs)
 
 	popup.frame:ClearAllPoints();
 
-	-- Do not steal input if we're in combat.
-	if not InCombatLockdown() then
-		popup.frame:SetScript("OnKeyDown", function(_, key)
-			if key == "ESCAPE" then
-				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-				popup.frame:SetPropagateKeyboardInput(false);
-				hidePopups();
-			else
-				popup.frame:SetPropagateKeyboardInput(true);
-			end
-		end);
-	end
+	popup.frame:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+		
+		if key == "ESCAPE" then
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+			popup.frame:SetPropagateKeyboardInput(false);
+			hidePopups();
+		else
+			popup.frame:SetPropagateKeyboardInput(true);
+		end
+	end);
 
 	if popupPosition and popupPosition.parent then
 		popup.frame:SetParent(popupPosition.parent);

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -171,6 +171,20 @@ local function initRelationEditor(relationID)
 		end, nil, nil, draftRelationTexture});
 	end);
 
+	-- Do not steal input if we're in combat.
+	if not InCombatLockdown() then
+		local frame = TRP3_RelationsList.Editor;
+		frame:SetScript("OnKeyDown", function(_, key)
+			if key == "ESCAPE" then
+				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+				frame:SetPropagateKeyboardInput(false);
+				frame:Hide();
+			else
+				frame:SetPropagateKeyboardInput(true);
+			end
+		end);
+	end
+
 	local nameText = relation.name;
 	if not nameText then
 		nameText = loc:GetText("REG_RELATION_" .. relation.id);

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -171,19 +171,19 @@ local function initRelationEditor(relationID)
 		end, nil, nil, draftRelationTexture});
 	end);
 
-	-- Do not steal input if we're in combat.
-	if not InCombatLockdown() then
-		local frame = TRP3_RelationsList.Editor;
-		frame:SetScript("OnKeyDown", function(_, key)
-			if key == "ESCAPE" then
-				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-				frame:SetPropagateKeyboardInput(false);
-				frame:Hide();
-			else
-				frame:SetPropagateKeyboardInput(true);
-			end
-		end);
-	end
+	local frame = TRP3_RelationsList.Editor;
+	frame:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "ESCAPE" then
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+			frame:SetPropagateKeyboardInput(false);
+			frame:Hide();
+		else
+			frame:SetPropagateKeyboardInput(true);
+		end
+	end);
 
 	local nameText = relation.name;
 	if not nameText then

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -446,6 +446,19 @@ local function openGlanceEditor(slot, slotData, callback, external, arg1, arg2)
 	TRP3_AtFirstGlanceEditorName:SetFocus();
 	TRP3_AtFirstGlanceEditorName:HighlightText();
 
+	TRP3_AtFirstGlanceEditor:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "ESCAPE" then
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+			TRP3_AtFirstGlanceEditor:SetPropagateKeyboardInput(false);
+			TRP3_AtFirstGlanceEditor:Hide();
+		else
+			TRP3_AtFirstGlanceEditor:SetPropagateKeyboardInput(true);
+		end
+	end);
+
 	TRP3_AtFirstGlanceEditorIcon.isExternal = external;
 	setTooltipForSameFrame(TRP3_AtFirstGlanceEditorIcon, "LEFT", 0, 5, loc.UI_ICON_SELECT, TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.UI_ICON_OPENBROWSER) .. "|n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.UI_ICON_OPTIONS));
 	TRP3_AtFirstGlanceEditorIcon:SetScript("onMouseDown", function(self, button)


### PR DESCRIPTION
https://github.com/user-attachments/assets/b61ea850-fc15-4896-87e1-d82580603864

This fixes the fact that escaping a popup would close the whole TRP frame with it as well. Now it behaves similarly to the close button on the popups itself.

Also the popups code is a freaking nightmare, do not recommend.

