### PR TITLE
Add nil check on character ID in GetRoleplayExperience

### DIFF
--- a/totalRP3/Core/Player.lua
+++ b/totalRP3/Core/Player.lua
@@ -210,7 +210,7 @@ function Player:GetRoleplayExperience()
 	-- Note that this will return nil for profiles belonging to this player.
 	local characterInfo;
 
-	if TRP3_API.register.isUnitIDKnown(self:GetCharacterID()) then
+	if self:GetCharacterID() and TRP3_API.register.isUnitIDKnown(self:GetCharacterID()) then
 		characterInfo = TRP3_API.register.getUnitIDCharacter(self:GetCharacterID());
 	end
 


### PR DESCRIPTION
Roleplay proficiency field is tied to the character ID, which might not exist in some profiles (for instance the ones you get linked via chat). This would cause an error when opening the misc tab and trying to display the proficiency line in the Roleplay style box.

This just adds a nil check on the Character ID before trying to check if it's known, the rest of the code already handles a nil return for GetRoleplayExperience.