### PR TITLE
Adjust tooltip anchors on toolbar and target frame based on screen position

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -436,6 +436,18 @@ TRP3_API.ui.tooltip.setTooltipForSameFrame = function(Frame, GenFrameAnch, GenFr
 	setTooltipForFrame(Frame, Frame, GenFrameAnch, GenFrameX, GenFrameY, titleText, bodyText, rightText);
 end
 
+TRP3_API.ui.tooltip.setTooltipAnchorForFrame = function(Frame, GenFrameAnch, GenFrameX, GenFrameY)
+	if Frame then
+		Frame.GenFrameX = GenFrameX;
+		Frame.GenFrameY = GenFrameY;
+		if GenFrameAnch then
+			Frame.GenFrameAnch = "ANCHOR_"..GenFrameAnch;
+		else
+			Frame.GenFrameAnch = "ANCHOR_RIGHT";
+		end
+	end
+end
+
 -- Setup the frame tooltip and add the Enter and Leave scripts
 TRP3_API.ui.tooltip.setTooltipAll = function(Frame, GenFrameAnch, GenFrameX, GenFrameY, titleText, bodyText, rightText)
 	Frame:SetScript("OnEnter", tooltipSimpleOnEnter);

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -875,7 +875,9 @@ local function onStart()
 
 			replaceBar();
 		end
-		updateGlanceButtonsTooltips();
+		if ui_GlanceBar:IsVisible() then
+			updateGlanceButtonsTooltips();
+		end
 	end
 
 	registerConfigKey(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -847,7 +847,6 @@ local function onStart()
 	-- Config - Position
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local UIParent, GetCursorPosition, TargetFrame = UIParent, GetCursorPosition, TargetFrame;
 	unitIDIsFilteredForMatureContent = TRP3_API.register.unitIDIsFilteredForMatureContent;
 
 	local function replaceBar()

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -60,7 +60,7 @@ local function onStart()
 		return icon .. (buttonStructure.tooltip or buttonStructure.configText);
 	end
 
-	local function updateTargetFrameButtonTooltip(targetButton, buttonStructure)
+	local function updateTargetFrameButtonTooltip(targetButton)
 		-- Refreshing the tooltip
 		local tooltipAnchor = "TOP";
 		local anchorMargin = 5;
@@ -68,7 +68,7 @@ local function onStart()
 			tooltipAnchor = "BOTTOM";
 			anchorMargin = -5;
 		end
-		setTooltipForSameFrame(targetButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+		TRP3_API.ui.tooltip.setTooltipAnchorForFrame(targetButton, tooltipAnchor, 0, anchorMargin);
 	end
 
 	local function createButton(index)
@@ -152,7 +152,8 @@ local function onStart()
 			uiButton.unitID = currentTargetID;
 			uiButton.targetType = currentTargetType;
 			if buttonStructure.tooltip then
-				updateTargetFrameButtonTooltip(uiButton, buttonStructure);
+				setTooltipForSameFrame(uiButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+				updateTargetFrameButtonTooltip(uiButton);
 			else
 				setTooltipForSameFrame(uiButton);
 			end
@@ -310,7 +311,7 @@ local function onStart()
 
 		-- Update tooltip anchors
 		for _,uiButton in pairs(uiButtons) do
-			updateTargetFrameButtonTooltip(uiButton, targetButtons[uiButton.buttonId]);
+			updateTargetFrameButtonTooltip(uiButton);
 		end
 	end);
 

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -3,6 +3,10 @@
 
 local ui_TargetFrame;
 
+local CONFIG_TARGET_POS_X = "CONFIG_TARGET_POS_X";
+local CONFIG_TARGET_POS_Y = "CONFIG_TARGET_POS_Y";
+local CONFIG_TARGET_POS_A = "CONFIG_TARGET_POS_A";
+
 -- Always build UI on init. Because maybe other modules would like to anchor it on start.
 local function onInit()
 	ui_TargetFrame = CreateFrame("Frame", "TRP3_TargetFrame", UIParent, "TRP3_TargetFrameTemplate");
@@ -54,6 +58,17 @@ local function onStart()
 			icon = TRP3_MarkupUtil.GenerateFileMarkup(buttonStructure.iconFile, { size = 32 }) .. " ";
 		end
 		return icon .. (buttonStructure.tooltip or buttonStructure.configText);
+	end
+
+	local function updateTargetFrameButtonTooltip(targetButton, buttonStructure)
+		-- Refreshing the tooltip
+		local tooltipAnchor = "TOP";
+		local anchorMargin = 5;
+		if getConfigValue(CONFIG_TARGET_POS_A):find("TOP") then
+			tooltipAnchor = "BOTTOM";
+			anchorMargin = -5;
+		end
+		setTooltipForSameFrame(targetButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
 	end
 
 	local function createButton(index)
@@ -137,7 +152,7 @@ local function onStart()
 			uiButton.unitID = currentTargetID;
 			uiButton.targetType = currentTargetType;
 			if buttonStructure.tooltip then
-				setTooltipForSameFrame(uiButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+				updateTargetFrameButtonTooltip(uiButton, buttonStructure);
 			else
 				setTooltipForSameFrame(uiButton);
 			end
@@ -265,17 +280,13 @@ local function onStart()
 	-- Position
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local CONFIG_TARGET_POS_X = "CONFIG_TARGET_POS_X";
-	local CONFIG_TARGET_POS_Y = "CONFIG_TARGET_POS_Y";
-	local CONFIG_TARGET_POS_A = "CONFIG_TARGET_POS_A";
-
 	registerConfigKey(CONFIG_TARGET_POS_A, "BOTTOM");
 	registerConfigKey(CONFIG_TARGET_POS_X, 0);
 	registerConfigKey(CONFIG_TARGET_POS_Y, 200);
 
 	local function reposition()
-		ui_TargetFrame:SetPoint(getConfigValue("CONFIG_TARGET_POS_A"), UIParent, getConfigValue("CONFIG_TARGET_POS_A"),
-			getConfigValue("CONFIG_TARGET_POS_X"), getConfigValue("CONFIG_TARGET_POS_Y"));
+		ui_TargetFrame:SetPoint(getConfigValue(CONFIG_TARGET_POS_A), UIParent, getConfigValue(CONFIG_TARGET_POS_A),
+			getConfigValue(CONFIG_TARGET_POS_X), getConfigValue(CONFIG_TARGET_POS_Y));
 	end
 	reposition();
 
@@ -296,6 +307,11 @@ local function onStart()
 		setConfigValue(CONFIG_TARGET_POS_A, anchor);
 		setConfigValue(CONFIG_TARGET_POS_X, x);
 		setConfigValue(CONFIG_TARGET_POS_Y, y);
+
+		-- Update tooltip anchors
+		for _,uiButton in pairs(uiButtons) do
+			updateTargetFrameButtonTooltip(uiButton, targetButtons[uiButton.buttonId]);
+		end
 	end);
 
 	ui_TargetFrame.Header:ClearAllPoints();

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -109,7 +109,7 @@ local function onStart()
 		return TRP3_MarkupUtil.GenerateIconMarkup(buttonStructure.icon, { size = 32 }) .. " " .. (buttonStructure.tooltip or buttonStructure.configText);
 	end
 
-	local function updateToolbarButtonTooltip(toolbarButton, buttonStructure)
+	local function updateToolbarButtonTooltip(toolbarButton)
 		-- Refreshing the tooltip
 		local tooltipAnchor = "TOP";
 		local anchorMargin = 5;
@@ -117,7 +117,7 @@ local function onStart()
 			tooltipAnchor = "BOTTOM";
 			anchorMargin = -5;
 		end
-		setTooltipForSameFrame(toolbarButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+		TRP3_API.ui.tooltip.setTooltipAnchorForFrame(toolbarButton, tooltipAnchor, 0, anchorMargin);
 	end
 
 	local function buildToolbar()
@@ -193,7 +193,8 @@ local function onStart()
 					end
 				end);
 				if buttonStructure.tooltip then
-					updateToolbarButtonTooltip(uiButton, buttonStructure);
+					setTooltipForSameFrame(uiButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+					updateToolbarButtonTooltip(uiButton);
 				end
 				uiButton:SetWidth(buttonSize);
 				uiButton:SetHeight(buttonSize);
@@ -301,7 +302,8 @@ local function onStart()
 		-- Setting the textures
 		toolbarButton:SetIconTexture(buttonStructure.icon);
 
-		updateToolbarButtonTooltip(toolbarButton, buttonStructure);
+		setTooltipForSameFrame(toolbarButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+		updateToolbarButtonTooltip(toolbarButton);
 	end
 	TRP3_API.toolbar.updateToolbarButton = updateToolbarButton;
 
@@ -348,7 +350,7 @@ local function onStart()
 
 		-- Update tooltip anchors
 		for _,uiButton in pairs(uiButtons) do
-			updateToolbarButtonTooltip(uiButton, buttonStructures[uiButton.buttonId]);
+			updateToolbarButtonTooltip(uiButton);
 		end
 	end);
 

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -11,6 +11,10 @@ local CONFIG_CONTENT_PREFIX = "toolbar_content_";
 local CONFIG_HIDE_TITLE = "toolbar_hide_title";
 local CONFIG_TOOLBAR_VISIBILITY = "toolbar_visibility";
 
+local CONFIG_TOOLBAR_POS_X = "CONFIG_TOOLBAR_POS_X";
+local CONFIG_TOOLBAR_POS_Y = "CONFIG_TOOLBAR_POS_Y";
+local CONFIG_TOOLBAR_POS_A = "CONFIG_TOOLBAR_POS_A";
+
 TRP3_ToolbarVisibilityOption = {
 	AlwaysShow = 1,
 	OnlyShowInCharacter = 2,
@@ -179,7 +183,7 @@ local function onStart()
 					end
 				end);
 				if buttonStructure.tooltip then
-					setTooltipForFrame(uiButton, uiButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+					TRP3_API.toolbar.updateToolbarButtonTooltip(uiButton, buttonStructure);
 				end
 				uiButton:SetWidth(buttonSize);
 				uiButton:SetHeight(buttonSize);
@@ -279,6 +283,18 @@ local function onStart()
 	end
 	TRP3_API.toolbar.toolbarAddButton = toolbarAddButton;
 
+	local function updateToolbarButtonTooltip(toolbarButton, buttonStructure)
+		-- Refreshing the tooltip
+		local tooltipAnchor = "TOP";
+		local anchorMargin = 5;
+		if getConfigValue(CONFIG_TOOLBAR_POS_A):find("TOP") then
+			tooltipAnchor = "BOTTOM";
+			anchorMargin = -5;
+		end
+		setTooltipForFrame(toolbarButton, toolbarButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+	end
+	TRP3_API.toolbar.updateToolbarButtonTooltip = updateToolbarButtonTooltip;
+
 	--- Will refresh the UI of a given button (icon, tooltip) using the data provided in the buttonStructure
 	-- @param toolbarButton UI button to refresh
 	-- @param buttonStructure Button structure containing the icon and tooltip text
@@ -287,8 +303,7 @@ local function onStart()
 		-- Setting the textures
 		toolbarButton:SetIconTexture(buttonStructure.icon);
 
-		-- Refreshing the tooltip
-		setTooltipForFrame(toolbarButton, toolbarButton, "TOP", 0, 5, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+		updateToolbarButtonTooltip(toolbarButton, buttonStructure);
 	end
 	TRP3_API.toolbar.updateToolbarButton = updateToolbarButton;
 
@@ -315,15 +330,11 @@ local function onStart()
 	-- Position
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	local CONFIG_TOOLBAR_POS_X = "CONFIG_TOOLBAR_POS_X";
-	local CONFIG_TOOLBAR_POS_Y = "CONFIG_TOOLBAR_POS_Y";
-	local CONFIG_TOOLBAR_POS_A = "CONFIG_TOOLBAR_POS_A";
-
 	registerConfigKey(CONFIG_TOOLBAR_POS_A, "TOP");
 	registerConfigKey(CONFIG_TOOLBAR_POS_X, 0);
 	registerConfigKey(CONFIG_TOOLBAR_POS_Y, -30);
-	toolbar:SetPoint(getConfigValue("CONFIG_TOOLBAR_POS_A"), UIParent, getConfigValue("CONFIG_TOOLBAR_POS_A"),
-	getConfigValue("CONFIG_TOOLBAR_POS_X"), getConfigValue("CONFIG_TOOLBAR_POS_Y"));
+	toolbar:SetPoint(getConfigValue(CONFIG_TOOLBAR_POS_A), UIParent, getConfigValue(CONFIG_TOOLBAR_POS_A),
+	getConfigValue(CONFIG_TOOLBAR_POS_X), getConfigValue(CONFIG_TOOLBAR_POS_Y));
 
 	toolbar:RegisterForDrag("LeftButton");
 	toolbar:SetMovable(true);
@@ -336,6 +347,11 @@ local function onStart()
 		setConfigValue(CONFIG_TOOLBAR_POS_A, anchor);
 		setConfigValue(CONFIG_TOOLBAR_POS_X, x);
 		setConfigValue(CONFIG_TOOLBAR_POS_Y, y);
+
+		-- Update tooltip anchors
+		for _,uiButton in pairs(uiButtons) do
+			TRP3_API.toolbar.updateToolbarButtonTooltip(uiButton, buttonStructures[uiButton.buttonId]);
+		end
 	end);
 
 	function TRP3_API.toolbar.reset()

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -89,7 +89,7 @@ local function onStart()
 	-- imports
 	local toolbarContainer, mainTooltip = TRP3_ToolbarContainer, TRP3_MainTooltip;
 	local getConfigValue, registerConfigKey, registerConfigHandler, setConfigValue = TRP3_API.configuration.getValue, TRP3_API.configuration.registerConfigKey, TRP3_API.configuration.registerHandler, TRP3_API.configuration.setValue;
-	local setTooltipForFrame = TRP3_API.ui.tooltip.setTooltipForFrame;
+	local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
 	local refreshTooltip = TRP3_API.ui.tooltip.refresh;
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -109,6 +109,16 @@ local function onStart()
 		return TRP3_MarkupUtil.GenerateIconMarkup(buttonStructure.icon, { size = 32 }) .. " " .. (buttonStructure.tooltip or buttonStructure.configText);
 	end
 
+	local function updateToolbarButtonTooltip(toolbarButton, buttonStructure)
+		-- Refreshing the tooltip
+		local tooltipAnchor = "TOP";
+		local anchorMargin = 5;
+		if getConfigValue(CONFIG_TOOLBAR_POS_A):find("TOP") then
+			tooltipAnchor = "BOTTOM";
+			anchorMargin = -5;
+		end
+		setTooltipForSameFrame(toolbarButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
+	end
 
 	local function buildToolbar()
 		local maxButtonPerLine = getConfigValue(CONFIG_ICON_MAX_PER_LINE);
@@ -183,7 +193,7 @@ local function onStart()
 					end
 				end);
 				if buttonStructure.tooltip then
-					TRP3_API.toolbar.updateToolbarButtonTooltip(uiButton, buttonStructure);
+					updateToolbarButtonTooltip(uiButton, buttonStructure);
 				end
 				uiButton:SetWidth(buttonSize);
 				uiButton:SetHeight(buttonSize);
@@ -283,18 +293,6 @@ local function onStart()
 	end
 	TRP3_API.toolbar.toolbarAddButton = toolbarAddButton;
 
-	local function updateToolbarButtonTooltip(toolbarButton, buttonStructure)
-		-- Refreshing the tooltip
-		local tooltipAnchor = "TOP";
-		local anchorMargin = 5;
-		if getConfigValue(CONFIG_TOOLBAR_POS_A):find("TOP") then
-			tooltipAnchor = "BOTTOM";
-			anchorMargin = -5;
-		end
-		setTooltipForFrame(toolbarButton, toolbarButton, tooltipAnchor, 0, anchorMargin, getTooltipTitleWithIcon(buttonStructure), buttonStructure.tooltipSub);
-	end
-	TRP3_API.toolbar.updateToolbarButtonTooltip = updateToolbarButtonTooltip;
-
 	--- Will refresh the UI of a given button (icon, tooltip) using the data provided in the buttonStructure
 	-- @param toolbarButton UI button to refresh
 	-- @param buttonStructure Button structure containing the icon and tooltip text
@@ -350,7 +348,7 @@ local function onStart()
 
 		-- Update tooltip anchors
 		for _,uiButton in pairs(uiButtons) do
-			TRP3_API.toolbar.updateToolbarButtonTooltip(uiButton, buttonStructures[uiButton.buttonId]);
+			updateToolbarButtonTooltip(uiButton, buttonStructures[uiButton.buttonId]);
 		end
 	end);
 


### PR DESCRIPTION
Tooltips for toolbar and target frame have always been anchored to a specific side, meaning depending on its position, the tooltip could overlap with the entire frame. Given that we've replaced basically every icon on those frames, this behaviour would be frustrating to learn the new icons, especially for the toolbar whose default position would cause the overlap.

This adjusts the tooltip anchors for the toolbar, target frame and glance bar buttons based on their position on the screen. To avoid having to set the tooltip text every time we want to adjust the anchor (which would be particularly annoying for glances), a new function was made to only adjust the anchor and relative position parameters without touching at the tooltip content.

For toolbar and target frame, we check the anchor point to determine if the frame is closer to the top of the screen, and set the new anchor whenever the tooltip content changes, as well when dragging the frame ends.

For the glance bar buttons, as the bar is almost always anchored to TargetFrame or TRP3_TargetFrame, we check its parent's anchor to know where the bar is on screen. This is not exactly accurate (if the user has dragged the bar far away from its parent, if the parent was changed to be a child of another frame, or UIParent), but should cover the vast majority of cases, and the rest can have subpar tooltip positioning.
Also the tooltip anchor adjustment is done OnUpdate while shown, because tracking when the parent is getting dragged would be annoying.