### PR TITLE
Swap template for action button in Characteristics tab of other players

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -509,7 +509,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					</ScrollFrame>
 				</Frames>
 			</Frame>
-			<Button name="TRP3_RegisterCharact_ActionButton" inherits="TRP3_BorderedIconTemplate">
+			<Button name="TRP3_RegisterCharact_ActionButton" inherits="TRP3_BorderedIconButtonTemplate">
 				<Size x="45" y="45" />
 				<HighlightTexture parentKey="HighlightBorder" file="Interface\AddOns\totalRP3\Resources\UI\ui-frame-slice-sm-glow" alphaMode="ADD">
 					<Color r="0.92" g="0.68" b="0"/>


### PR DESCRIPTION
Swapping TRP3_BorderedIconTemplate into TRP3_BorderedIconButtonTemplate for the action button on other players profiles, since that one was changed to use the new bordered icon template.