### PR TITLE
Allow changing WU field state from default profile

### DIFF
--- a/totalRP3/Core/Player.lua
+++ b/totalRP3/Core/Player.lua
@@ -410,6 +410,7 @@ end
 
 local function ShouldAllowFieldModification(player, subtableName, fieldName)
 	return (subtableName == "character" and fieldName == "RP")
+		or (subtableName == "character" and fieldName == "WU")
 		or (not player:IsProfileDefault());
 end
 


### PR DESCRIPTION
It's a bit confusing that the "Walkup friendly" dropdown does nothing if you're in the default profile. We could disable the dropdown, but let's just take the easier route and allow people to change the field.