### PR TITLE
Notification (and version) line hardcoded size 10

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -962,7 +962,7 @@ local function writeTooltipForCharacter(targetID, targetType)
 			if notifText == "" then
 				notifText = " "; -- Prevent bad right line height
 			end
-			tooltipBuilder:AddDoubleLine(notifText, clientText, colors.MAIN, colors.MAIN, getSmallLineFontSize());
+			tooltipBuilder:AddDoubleLine(notifText, clientText, colors.MAIN, colors.MAIN, 10);
 		end
 
 		SetProgressSpinnerShown(TRP3_CharacterTooltip, TRP3_API.register.HasActiveRequest(targetID));


### PR DESCRIPTION
It seems silly that if you increase your tertiary text on tooltips (to read CU/CO if your eyes are worse) that the version of your TRP and the other two should explode in your face as well.