### PR TITLE
Tooltip on about unread tab

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -245,6 +245,7 @@ These slots will also be visible on the target frame's |cnGREEN_FONT_COLOR:"At f
 	REG_TT_ZONE = "Zone",
 	REG_TT_NOTIF = "Unread description",
 	REG_TT_NOTIF_TT = "The content of this section changed since your last visit.",
+	REG_TT_NOTIF_LONG_TT = "The content of this profile's description has changed since your last visit.",
 	REG_TT_IGNORED = "< Character is ignored >",
 	REG_TT_IGNORED_OWNER = "< Owner is ignored >",
 	REG_LIST_CHAR_TITLE = "Characters",

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -244,6 +244,7 @@ These slots will also be visible on the target frame's |cnGREEN_FONT_COLOR:"At f
 	REG_TT_TARGET = "Target: %s",
 	REG_TT_ZONE = "Zone",
 	REG_TT_NOTIF = "Unread description",
+	REG_TT_NOTIF_TT = "The content of this section changed since your last visit.",
 	REG_TT_IGNORED = "< Character is ignored >",
 	REG_TT_IGNORED_OWNER = "< Owner is ignored >",
 	REG_LIST_CHAR_TITLE = "Characters",

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -461,11 +461,11 @@ local function updateAboutTabIcon(context)
 		aboutUnread = true;
 	end
 
-	local function OnTooltipShow(button, description)
-		local unreadMarkup = TRP3_MarkupUtil.GenerateFileMarkup(unreadIcon, { size = 16 });
+	local function OnTooltipShow(_, description)
+		local unreadMarkup = TRP3_MarkupUtil.GenerateFileMarkup(unreadIcon, { size = 24 });
 
-		description:AddTitleLine(button:GetText());
-		description:AddNormalLine(string.join(" ", unreadMarkup, loc.REG_TT_NOTIF_TT));
+		description:AddTitleLine(string.join(" ", unreadMarkup, loc.REG_TT_NOTIF));
+		description:AddNormalLine(loc.REG_TT_NOTIF_TT);
 	end
 
 	tabGroup.tabs[2]:SetIcon(aboutUnread and unreadIcon or nil);

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -455,12 +455,21 @@ local function onMouseOver()
 end
 
 local function updateAboutTabIcon(context)
+	local unreadIcon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread";
 	local aboutUnread = false;
 	if not context.isPlayer and context.profile.about and not context.profile.about.read then
 		aboutUnread = true;
 	end
-	tabGroup.tabs[2]:SetIcon(aboutUnread and "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread" or nil);
-	TRP3_API.ui.tooltip.setTooltipAll(tabGroup.tabs[2].Icon, "RIGHT", 0, 5, loc.REG_TT_NOTIF, loc.REG_TT_NOTIF_TT);
+
+	local function OnTooltipShow(button, description)
+		local unreadMarkup = TRP3_MarkupUtil.GenerateFileMarkup(unreadIcon, { size = 16 });
+
+		description:AddTitleLine(button:GetText());
+		description:AddNormalLine(string.join(" ", unreadMarkup, loc.REG_TT_NOTIF_TT));
+	end
+
+	tabGroup.tabs[2]:SetIcon(aboutUnread and unreadIcon or nil);
+	tabGroup.tabs[2]:SetTooltip(aboutUnread and OnTooltipShow or nil);
 end
 
 local function onInformationUpdated(profileID, infoType)

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -460,6 +460,7 @@ local function updateAboutTabIcon(context)
 		aboutUnread = true;
 	end
 	tabGroup.tabs[2]:SetIcon(aboutUnread and "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread" or nil);
+	TRP3_API.ui.tooltip.setTooltipAll(tabGroup.tabs[2].Icon, "RIGHT", 0, 5, loc.REG_TT_NOTIF, loc.REG_TT_NOTIF_TT);
 end
 
 local function onInformationUpdated(profileID, infoType)

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -588,20 +588,17 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 				-- Check if the pet has a profile first.
 				if profile and profile.data then
-					-- Retrieve profile name.
-					local name = profile.data.NA or "";
-
 					-- Handle if player is the owner of this pet.
 					if ownerID == Globals.player_id then
-						buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.TF_OPEN_COMPANION) .. "\n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.TF_MORE_OPTIONS);
+						buttonStructure.tooltipSub = TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.TF_OPEN_COMPANION) .. "\n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.TF_MORE_OPTIONS);
 					else
 						-- If pet data is unread, add alert.
 						if not profile.data.read then
 							local icon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread-overlay";
-							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. "|cnGREEN_FONT_COLOR:" .. loc.REG_TT_NOTIF .. "|r\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION) .. "|r";
+							buttonStructure.tooltipSub = TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. loc.REG_TT_NOTIF_LONG_TT .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION) .. "|r";
 							buttonStructure.alert = true;
 						else
-							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION);
+							buttonStructure.tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_COMPANION);
 						end
 					end
 				else
@@ -680,7 +677,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						-- If mount data is unread, add alert.
 						if not profile.data.read then
 							local icon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread-overlay";
-							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. "|cnGREEN_FONT_COLOR:" .. loc.REG_TT_NOTIF .. "|r\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT) .. "|r";
+							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. loc.REG_TT_NOTIF_LONG_TT .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT) .. "|r";
 							buttonStructure.alert = true;
 						else
 							buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_MOUNT);

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -1097,14 +1097,16 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					profile = getUnitIDProfile(unitID);
 				end
 
-				local name = getCompleteName(profile.characteristics or {}, "", true);
-				buttonStructure.tooltipSub = name .. "\n\n" ..  TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_CHARACTER);
+				local tooltipLines = {};
 
 				if unitID ~= Globals.player_id and profile.about and not profile.about.read then
 					local icon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread-overlay";
-					buttonStructure.tooltipSub = name .. "\n\n" .. TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. "|cnGREEN_FONT_COLOR:" .. loc.REG_TT_NOTIF .. "|r"  .. "\n\n" .. TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_CHARACTER);
+					table.insert(tooltipLines, TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. loc.REG_TT_NOTIF_LONG_TT);
 					buttonStructure.alert = true;
 				end
+
+				table.insert(tooltipLines, TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TF_OPEN_CHARACTER));
+				buttonStructure.tooltipSub = table.concat(tooltipLines, "|n|n");
 			end,
 			alertIcon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread-overlay",
 		});

--- a/totalRP3/UI/TabSystem.lua
+++ b/totalRP3/UI/TabSystem.lua
@@ -8,10 +8,18 @@ function TRP3_TabButtonMixin:OnLoad()
 end
 
 function TRP3_TabButtonMixin:OnEnter()
-	if self.Text:IsTruncated() then
-		TRP3_TooltipUtil.ShowTooltip(self, function(_, tooltip)
-			tooltip:AddTitleLine(self:GetText());
-		end);
+	local tooltipFunction = self.tooltipFunction;
+
+	if not tooltipFunction and self.Text:IsTruncated() then
+		local function ShowTruncatedTooltip(_, description)
+			description:AddTitleLine(self:GetText());
+		end
+
+		tooltipFunction = ShowTruncatedTooltip;
+	end
+
+	if tooltipFunction then
+		TRP3_TooltipUtil.ShowTooltip(self, tooltipFunction);
 	end
 end
 
@@ -37,6 +45,10 @@ function TRP3_TabButtonMixin:SetIcon(icon)
 		self.Icon:SetTexture(nil);
 		self.Icon:Hide();
 	end
+end
+
+function TRP3_TabButtonMixin:SetTooltip(tooltipFunction)
+	self.tooltipFunction = tooltipFunction;
 end
 
 function TRP3_TabButtonMixin:SetTabState(state)


### PR DESCRIPTION
This adds a tooltip when hovering the About tab while its unread icon is present to better explain what the icon means. Unlike the initial attempt, this tooltip will show irrespective of what part of the tab button you hover over - so you don't need to solely mouseover the icon to get an explanation.

![image](https://github.com/user-attachments/assets/67f09148-5772-44c2-a60e-226694e40e22)

Also tweaks the toolbar button tooltips to use long-form text and omit names for all but mounts.

![image](https://github.com/user-attachments/assets/6283f838-5bf6-439e-b199-9e5e6a19a4cc)
![image](https://github.com/user-attachments/assets/129bb328-810c-440f-a985-74a041581e86)
![image](https://github.com/user-attachments/assets/2670e572-3c3a-4d19-8e7d-1018e4b2f44e)



