### PR TITLE
Debounce CU/CO field edits

### DIFF
--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -9,7 +9,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 	-- Called whenever the OnTextChanged event fires for the currentlyText scrollbox,
 	-- which checks if it was triggered by userInput before changing the "Currently" text.
-	local updateCurrentlyText = TRP3_FunctionUtil.Debounce(0.25, function()
+	local updateCurrentlyText = TRP3_FunctionUtil.Debounce(0.5, function()
 		local editBox = frame.CurrentlyText.scroll.text;
 		local multiLine = true;
 		local text = TRP3_API.utils.str.sanitize(editBox:GetText(), multiLine);

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -9,12 +9,17 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 	-- Called whenever the OnTextChanged event fires for the currentlyText scrollbox,
 	-- which checks if it was triggered by userInput before changing the "Currently" text.
-	local function onCurrentlyChanged(editBox, userInput)
+	local updateCurrentlyText = TRP3_FunctionUtil.Debounce(0.25, function()
+		local editBox = frame.CurrentlyText.scroll.text;
+		AddOn_TotalRP3.Player.GetCurrentUser():SetCurrentlyText(editBox:GetText());
+	end);
+
+	local function onCurrentlyChanged(_, userInput)
 		if not userInput then
 			return;
 		end
 
-		AddOn_TotalRP3.Player.GetCurrentUser():SetCurrentlyText(editBox:GetText());
+		updateCurrentlyText();
 	end
 
 	-- Prepares to show frame, gets player's "currently" and writes it to the scrollbox.

--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -11,7 +11,10 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	-- which checks if it was triggered by userInput before changing the "Currently" text.
 	local updateCurrentlyText = TRP3_FunctionUtil.Debounce(0.25, function()
 		local editBox = frame.CurrentlyText.scroll.text;
-		AddOn_TotalRP3.Player.GetCurrentUser():SetCurrentlyText(editBox:GetText());
+		local multiLine = true;
+		local text = TRP3_API.utils.str.sanitize(editBox:GetText(), multiLine);
+
+		AddOn_TotalRP3.Player.GetCurrentUser():SetCurrentlyText(text);
 	end);
 
 	local function onCurrentlyChanged(_, userInput)

--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -494,11 +494,11 @@ function TRP3_API.register.inits.miscInit()
 
 	TRP3_RegisterMiscViewCurrentlyIC.Title:SetText(loc.DB_STATUS_CURRENTLY);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyIC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY, loc.DB_STATUS_CURRENTLY_TT);
-	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.25, onCurrentlyChanged), {});
+	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.5, onCurrentlyChanged), {});
 
 	TRP3_RegisterMiscViewCurrentlyOOC.Title:SetText(loc.DB_STATUS_CURRENTLY_OOC);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
-	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.25, onOOCInfoChanged), {});
+	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.5, onOOCInfoChanged), {});
 
 	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, loc.REG_PLAYER_GLANCE_CONFIG
 	.. "|n|n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.REG_PLAYER_GLANCE_CONFIG_EDIT)

--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -374,33 +374,19 @@ local function displayCurrently(context)
 end
 
 local function onCurrentlyChanged()
-	if getCurrentContext().isPlayer then
-		local character = get("player/character");
-		local old = character.CU;
-		character.CU = TRP3_RegisterMiscViewCurrentlyIC:GetInputText();
+	local multiLine = true;
+	local text = Utils.str.sanitize(TRP3_RegisterMiscViewCurrentlyIC:GetInputText(), multiLine);
 
-		character.CU = Utils.str.sanitize(character.CU, true);
-
-		if old ~= character.CU then
-			character.v = Utils.math.incrementNumber(character.v or 1, 2);
-			TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, getPlayerCurrentProfileID(), "character");
-		end
-	end
+	local player = AddOn_TotalRP3.Player.GetCurrentUser();
+	player:SetCurrentlyText(text);
 end
 
 local function onOOCInfoChanged()
-	if getCurrentContext().isPlayer then
-		local character = get("player/character");
-		local old = character.CO;
-		character.CO = TRP3_RegisterMiscViewCurrentlyOOC:GetInputText();
+	local multiLine = true;
+	local text = Utils.str.sanitize(TRP3_RegisterMiscViewCurrentlyOOC:GetInputText(), multiLine);
 
-		character.CO = Utils.str.sanitize(character.CO, true);
-
-		if old ~= character.CO then
-			character.v = Utils.math.incrementNumber(character.v or 1, 2);
-			TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, getPlayerCurrentProfileID(), "character");
-		end
-	end
+	local player = AddOn_TotalRP3.Player.GetCurrentUser();
+	player:SetOutOfCharacterInfo(text);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -508,11 +494,11 @@ function TRP3_API.register.inits.miscInit()
 
 	TRP3_RegisterMiscViewCurrentlyIC.Title:SetText(loc.DB_STATUS_CURRENTLY);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyIC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY, loc.DB_STATUS_CURRENTLY_TT);
-	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", onCurrentlyChanged, {});
+	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.25, onCurrentlyChanged), {});
 
 	TRP3_RegisterMiscViewCurrentlyOOC.Title:SetText(loc.DB_STATUS_CURRENTLY_OOC);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
-	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", onOOCInfoChanged, {});
+	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.25, onOOCInfoChanged), {});
 
 	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, loc.REG_PLAYER_GLANCE_CONFIG
 	.. "|n|n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.REG_PLAYER_GLANCE_CONFIG_EDIT)


### PR DESCRIPTION
When a user edits their CU or CO fields we don't debounce inputs, and so each keystroke immediately applies the change to the field and increments the vernum rapidly.

We now only commit changes to these fields 250ms after users stop inputting text for them, both from within the Misc. panel and from our new shiny "Currently" editor on the toolbar. This should stop the vernum field cycling quite so eagerly and us firing so many events while editing the fields.

Additionally as with #1056 the Misc. page was directly modifying these fields instead of going through the Player class. This is no longer the case, so we've got two less instances of manual vernum updating going on.