### PR TITLE
Bump TOC versions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create Package
         uses: BigWigsMods/packager@v2
         with:
-          args: -d -S -z
+          args: -dz
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Create Package
         uses: BigWigsMods/packager@v2
-        with:
-          args: -S
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create Package
         uses: BigWigsMods/packager@v2
         with:
-          args: -S -w 0
+          args: -w 0
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check: schema
 	pre-commit run --all-files
 
 dist:
-	curl -s $(PACKAGER_URL) | bash -s -- -dS
+	curl -s $(PACKAGER_URL) | bash -s -- -d
 
 libs:
 	curl -s $(PACKAGER_URL) | bash -s -- -cdlz

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -1,6 +1,4 @@
-## Interface: 100207
-## Interface-Cata: 40400
-## Interface-Vanilla: 11502
+## Interface: 110000, 40400, 11503
 ## Title: Total RP 3
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -1,6 +1,4 @@
-## Interface: 100207
-## Interface-Cata: 40400
-## Interface-Vanilla: 11502
+## Interface: 110000, 40400, 11503
 ## Title: Total RP 3: Data
 ## Author: Telkostrasz & Ellypse
 ## Version: @project-version@


### PR DESCRIPTION
The game client supports comma-delimited interface versions on all clients at this point, so we can now just go down to using the single `Interface` line with all the versions and disable TOC splitting in the packager.

Note that Classic users will need to be told to fully exit the game before updating. If they upgrade while the client is open, TRP3 will disappear from their addon list until they restart the game. Reason being that with TOC splitting being disabled the "_Cata.toc" and "_Vanilla.toc" files in the release packages will no longer exist, but the client doesn't process file deletions until a full restart. For Retail users they should notice nothing as the packager doesn't create "_Mainline.toc" files for us today.