### PR TITLE
Use fixed height for notification lines in all TTs

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1167,7 +1167,7 @@ local function writeCompanionTooltip(companionFullID, targetType, targetMode)
 			notifText = notifText .. " " .. NEW_ABOUT_ICON;
 		end
 		if notifText and notifText ~= "" then
-			tooltipBuilder:AddLine(notifText, colors.MAIN, getSmallLineFontSize());
+			tooltipBuilder:AddLine(notifText, colors.MAIN, 10);
 		end
 	end
 
@@ -1271,7 +1271,7 @@ local function writeTooltipForMount(ownerID, companionFullID, mountName)
 			notifText = notifText .. " " .. NEW_ABOUT_ICON;
 		end
 		if notifText and notifText ~= "" then
-			tooltipCompanionBuilder:AddLine(notifText, colors.MAIN, getSmallLineFontSize());
+			tooltipCompanionBuilder:AddLine(notifText, colors.MAIN, 10);
 		end
 	end
 


### PR DESCRIPTION
Rae's tweak to make notifications use a fixed height of 10 only applied to tooltips shown for player characters and not companions, which can show the line for unread abouts.