### PR TITLE
Fix action button position for companions

### DIFF
--- a/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
+++ b/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
@@ -44,7 +44,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							</Button>
 							<Button name="$parent_ActionButton" inherits="TRP3_IconButton">
 								<Anchors>
-									<Anchor point="TOP" relativePoint="BOTTOM" relativeTo="$parent_EditButton" x="0" y="5"/>
+									<Anchor point="LEFT" relativePoint="RIGHT" x="30"/>
 								</Anchors>
 							</Button>
 						</Frames>


### PR DESCRIPTION
This was tied to the edit button for some reason.
![image](https://github.com/user-attachments/assets/41c6b521-ddb3-4d82-8d33-37980b2ea912)

It now centered:
![image](https://github.com/user-attachments/assets/2ec5ce89-f36e-4fe4-a6ee-43aba3597531)
