### PR TITLE
Reduce crop lengths on NA and FT by 50 characters

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -523,8 +523,8 @@ local function writeTooltipForCharacter(targetID, targetType)
 	local profileID = player:GetProfileID();
 
 	local FIELDS_TO_CROP = {
-		TITLE = 150,
-		NAME = 100,
+		TITLE = 100,
+		NAME = 50,
 		RACE = 50,
 		CLASS = 50,
 		PRONOUNS = 30,
@@ -1028,8 +1028,8 @@ local function writeCompanionTooltip(companionFullID, targetType, targetMode)
 	local colors = getTooltipTextColors();
 
 	local FIELDS_TO_CROP = {
-		TITLE = 150,
-		NAME  = 100,
+		TITLE = 100,
+		NAME  = 50,
 	}
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -1209,8 +1209,8 @@ local function writeTooltipForMount(ownerID, companionFullID, mountName)
 
 
 	local FIELDS_TO_CROP = {
-		TITLE = 150,
-		NAME  = 100
+		TITLE = 100,
+		NAME  = 50
 	}
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*


### PR DESCRIPTION
There's no reason for these fields to be as long as they are, and when viewed in the main window with these new limits they still get truncated at shorter points anyway.

![image](https://github.com/user-attachments/assets/14d46652-c94b-49bc-b7c3-6e70426c8a61)
