### PR TITLE
Fix duplicate or missing click sounds

### DIFF
--- a/totalRP3/Modules/Automation/Automation_Settings.lua
+++ b/totalRP3/Modules/Automation/Automation_Settings.lua
@@ -233,6 +233,7 @@ function TRP3_AutomationSettingsMixin:OnSaveButtonClicked()
 	local expression = self:GetEditorInputText();
 
 	TRP3_AutomationUtil.SetActionExpression(actionID, expression);
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 end
 
 function TRP3_AutomationSettingsMixin:OnTestButtonClicked()
@@ -241,6 +242,7 @@ function TRP3_AutomationSettingsMixin:OnTestButtonClicked()
 
 	TRP3_Automation:ResetMessageCooldowns();
 	TRP3_Addon:Printf(L.AUTOMATION_TEST_OUTPUT, string.format("|cff33ff99%s|r", result));
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 end
 
 function TRP3_AutomationSettingsMixin:GetSelectedAction()

--- a/totalRP3/Modules/Map/Map.xml
+++ b/totalRP3/Modules/Map/Map.xml
@@ -15,6 +15,9 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Frames>
 			<Cooldown parentKey="Cooldown" setAllPoints="true" inherits="CooldownFrameTemplate" />
 		</Frames>
+		<Scripts>
+			<PostClick/>
+		</Scripts>
 	</Button>
 
 	<Frame name="TRP3_ScanLoaderFrame" parent="UIParent" hidden="true">

--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -1040,7 +1040,7 @@ function TRP3_API.register.inits.aboutInit()
 			end);
 		end
 	end);
-	TRP3_RegisterAbout_Edit_Music_Action:SetScript("OnMouseDown", onMusicEditClicked);
+	TRP3_RegisterAbout_Edit_Music_Action:SetScript("OnClick", onMusicEditClicked);
 	TRP3_RegisterAbout_Edit_Template2_Add:SetScript("OnClick", template2AddFrame);
 	TRP3_RegisterAbout_AboutPanel_EditButton:SetScript("OnClick", onEdit);
 	TRP3_RegisterAbout_Edit_SaveButton:SetScript("OnClick", onSave);

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -1703,7 +1703,7 @@ function TRP3_API.register.inits.characteristicsInit()
 	TRP3_RegisterCharact_Edit_ClassButton.onSelection = onClassColorSelected;
 	TRP3_RegisterCharact_Edit_EyeButton.onSelection = onEyeColorSelected;
 
-	TRP3_RegisterCharact_Edit_PsychoAdd:SetScript("OnMouseDown", function(button)
+	TRP3_RegisterCharact_Edit_PsychoAdd:SetScript("OnClick", function(button)
 		TRP3_MenuUtil.CreateContextMenu(button, function(_, description)
 			for _, preset in pairs(PSYCHO_PRESETS_DROPDOWN) do
 				-- If there is no index or action, it is a title

--- a/totalRP3/UI/Menu/Menu.lua
+++ b/totalRP3/UI/Menu/Menu.lua
@@ -338,6 +338,7 @@ function TRP3_Menu.OpenContextMenu(ownerRegion, menuGenerator)
 	local anchorName = "cursor";
 	TRP3_ContextMenuParent:SetParent(ownerRegion);
 	TRP3_Menu.SetMenuInitializer(TRP3_ContextMenuParent, menuDescription);
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 	return OpenMenuInternal(TRP3_ContextMenuParent, anchorName);
 end
 

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -166,9 +166,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<OnLeave>
 				TRP3_MainTooltip:Hide();
 			</OnLeave>
-			<PostClick>
-				TRP3_API.ui.misc.playUISound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
-			</PostClick>
 		</Scripts>
 	</Button>
 


### PR DESCRIPTION
The upcoming 11.0 API for menus performs a click sound when opening a context menu, however our legacy backport to UIDD didn't do this.

As a result in 11.0 we have a few cases where clicking buttons that pop open context menus result in two sounds playing; one from our awful button templates and one from the API.

We now play sound effects within the legacy context menu implementation upon opening a context menu, and a few changes have been made to mask sounds elsewhere in the UI to prevent the double-play occurring. Not sure if I've found all of them, but this seems to cover a few common cases like "Actions" buttons in the module/relation lists, the character theme button, etc.