### PR TITLE
Avoid GameTooltip:IsOwned API

### DIFF
--- a/totalRP3/Modules/Launcher/Launcher_Settings.lua
+++ b/totalRP3/Modules/Launcher/Launcher_Settings.lua
@@ -287,7 +287,7 @@ function TRP3_LauncherClickBindingButtonMixin:GetTooltipFrame()
 end
 
 function TRP3_LauncherClickBindingButtonMixin:IsTooltipShown()
-	return self.tooltipFrame:IsOwned(self);
+	return TRP3_TooltipUtil.IsOwned(self.tooltipFrame, self);
 end
 
 function TRP3_LauncherClickBindingButtonMixin:SetTooltipShown(shown)

--- a/totalRP3/UI/Menu/MenuUtil.lua
+++ b/totalRP3/UI/Menu/MenuUtil.lua
@@ -136,7 +136,7 @@ function TRP3_MenuUtil.HideTooltip(owner)
 	else
 		local tooltip = TRP3_MainTooltip;
 
-		if tooltip:IsOwned(owner) then
+		if TRP3_TooltipUtil.IsOwned(tooltip, owner) then
 			tooltip:Hide();
 		end
 	end

--- a/totalRP3/UI/Tooltip/TooltipScript.lua
+++ b/totalRP3/UI/Tooltip/TooltipScript.lua
@@ -22,7 +22,7 @@ function TRP3_TooltipScriptMixin:OnTooltipShow(description)  -- luacheck: no unu
 end
 
 function TRP3_TooltipScriptMixin:IsTooltipShown()
-	return TRP3_MainTooltip:IsOwned(self);
+	return TRP3_TooltipUtil.IsOwned(TRP3_MainTooltip, self);
 end
 
 function TRP3_TooltipScriptMixin:ShowTooltip()

--- a/totalRP3/UI/Tooltip/TooltipUtil.lua
+++ b/totalRP3/UI/Tooltip/TooltipUtil.lua
@@ -98,7 +98,7 @@ end
 function TRP3_TooltipUtil.HideTooltip(owner)
 	local tooltip = TRP3_MainTooltip;
 
-	if tooltip:IsOwned(owner) then
+	if TRP3_TooltipUtil.IsOwned(tooltip, owner) then
 		tooltip:Hide();
 	end
 end
@@ -107,6 +107,13 @@ function TRP3_TooltipUtil.ShowTooltip(owner, generator, ...)
 	local description = TRP3_Tooltip.CreateTooltipDescription(owner);
 	TRP3_Tooltip.PopulateTooltipDescription(generator, owner, description, ...);
 	TRP3_Tooltip.ProcessTooltipDescription(TRP3_MainTooltip, description);
+end
+
+function TRP3_TooltipUtil.IsOwned(tooltip, owner)
+	-- GameTooltip:IsOwned(owner) cannot be used if the owner is a
+	-- non-frame region; as such we need to obtain the owner and test
+	-- manually.
+	return tooltip:GetOwner() == owner;
 end
 
 ---@class TRP3_TooltipUtil.LineOptions


### PR DESCRIPTION
The IsOwned API has a bug whereby it'll error if supplied a non-frame region. The error itself is a bug, since tooltips can be owned by non-frame regions (like fontstrings) just fine.

We can work around this by just using GetOwner instead and testing the return value - so let's do so consistently everywhere.