### PR TITLE
Add click sounds to many popup close buttons

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -397,6 +397,7 @@ TRP3_API.register.inits.relationsInit = function()
 		TRP3_RelationsList.Title:SetText(loc.CO_RELATIONS);
 		TRP3_RelationsList.CreateNew:SetText(loc.CO_RELATIONS_NEW);
 		TRP3_RelationsList.Editor.Content.CloseButton:SetScript("OnClick", function()
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 			TRP3_RelationsList.Editor:Hide();
 			TRP3_API.popup.hidePopups();
 		end);

--- a/totalRP3/Modules/Register/Filter/RegisterMatureFilter.xml
+++ b/totalRP3/Modules/Register/Filter/RegisterMatureFilter.xml
@@ -155,6 +155,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 				<Scripts>
 					<OnClick>
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 						TRP3_MatureDictionaryEditor:Hide();
 						TRP3_API.popup.hidePopups();
 					</OnClick>

--- a/totalRP3/UI/Browsers/Colors.xml
+++ b/totalRP3/UI/Browsers/Colors.xml
@@ -38,6 +38,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 				<Scripts>
 					<OnClick>
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 						TRP3_ColorBrowser:Hide();
 						TRP3_API.popup.hidePopups();
 					</OnClick>

--- a/totalRP3/UI/Browsers/Images.xml
+++ b/totalRP3/UI/Browsers/Images.xml
@@ -25,6 +25,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 				<Scripts>
 					<OnClick>
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 						TRP3_ImageBrowser:Hide();
 						TRP3_API.popup.hidePopups();
 					</OnClick>

--- a/totalRP3/UI/Browsers/Musics.xml
+++ b/totalRP3/UI/Browsers/Musics.xml
@@ -75,6 +75,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Anchors>
 				<Scripts>
 					<OnClick>
+						PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
 						TRP3_MusicBrowser:Hide();
 						TRP3_API.popup.hidePopups();
 					</OnClick>


### PR DESCRIPTION
The close buttons of a bunch of popups (images, colors, relations, etc.) didn't play sounds when the close buttons were clicked. This has been rectified by force.