### PR TITLE
Fix double click sounds on Links button

### DIFF
--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -528,7 +528,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 
 		button.BindButton:SetText(loc.REG_COMPANION_BOUNDS);
 		button.BindButton:Show();
-		button.BindButton:SetScript("OnMouseDown", onBoundClicked);
+		button.BindButton:SetScript("OnClick", onBoundClicked);
 
 		decorateProfileList(button, profileID);
 	end


### PR DESCRIPTION
Clicking the Links button in the companion profile list also triggers the double-click sound from the context menu changes.