### PR TITLE
Add truncation tooltips to most fields

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -191,7 +191,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 		<Layers>
 			<Layer level="OVERLAY">
-				<FontString name="$parentLeftText" parentKey="LeftText" text="[left text]" inherits="GameFontNormal" justifyH="RIGHT">
+				<FontString name="$parentLeftText" parentKey="LeftText" text="[left text]" font="GameFontNormal" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="RIGHT">
 					<Size x="0" y="10"/>
 					<Anchors>
 						<Anchor point="RIGHT" relativePoint="LEFT" x="-5" y="0" relativeKey="$parent.LeftIcon"/>
@@ -202,7 +202,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						<KeyValue key="HideOnCustom" value="true" type="boolean"/>
 					</KeyValues>
 				</FontString>
-				<FontString name="$parentRightText" parentKey="RightText" text="[right text]" inherits="GameFontNormal" justifyH="LEFT">
+				<FontString name="$parentRightText" parentKey="RightText" text="[right text]" font="GameFontNormal" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="LEFT">
 					<Size x="0" y="10"/>
 					<Anchors>
 						<Anchor point="LEFT" relativePoint="RIGHT" x="5" y="0" relativeKey="$parent.RightIcon"/>
@@ -428,15 +428,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Frames>
 				<Layers>
 					<Layer level="OVERLAY">
-						<FontString name="TRP3_RegisterCharact_NamePanel_Name" text="[Name and titles]" inherits="GameFontNormalLarge" justifyH="LEFT">
+						<FontString name="TRP3_RegisterCharact_NamePanel_Name" text="[Name and titles]" font="GameFontHighlightLarge" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="LEFT">
 							<Size x="0" y="15"/>
 							<Anchors>
 								<Anchor point="LEFT" relativePoint="RIGHT" x="10" y="10" relativeKey="$parent.Icon"/>
 								<Anchor point="RIGHT" x="-35" y="0"/>
 							</Anchors>
-							<Color b="0.95" r="0.95" g="0.95"/>
 						</FontString>
-						<FontString name="TRP3_RegisterCharact_NamePanel_Title" text="[Complete subtitle]" inherits="GameFontNormal" justifyH="LEFT">
+						<FontString name="TRP3_RegisterCharact_NamePanel_Title" text="[Complete subtitle]" font="GameFontNormal" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="LEFT">
 							<Size x="0" y="15"/>
 							<Anchors>
 								<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" x="0" y="-5" relativeTo="TRP3_RegisterCharact_NamePanel_Name"/>

--- a/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
+++ b/totalRP3/Modules/Register/Companions/RegisterUICompanionsPage.xml
@@ -50,15 +50,14 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						</Frames>
 						<Layers>
 							<Layer level="OVERLAY">
-								<FontString name="$parent_Name" text="[Name and titles]" inherits="GameFontNormalLarge" justifyH="LEFT">
+								<FontString name="$parent_Name" text="[Name and titles]" font="GameFontHighlightLarge" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="LEFT">
 									<Size x="0" y="15"/>
 									<Anchors>
 										<Anchor point="LEFT" relativePoint="RIGHT" x="10" y="10" relativeKey="$parent.Icon"/>
 										<Anchor point="RIGHT" x="-10" y="0"/>
 									</Anchors>
-									<Color b="0.95" r="0.95" g="0.95"/>
 								</FontString>
-								<FontString name="$parent_Title" text="[Complete subtitle]" inherits="GameFontNormal" justifyH="LEFT">
+								<FontString name="$parent_Title" text="[Complete subtitle]" font="GameFontNormal" inherits="TRP3_TruncatedFontStringTooltipTemplate" justifyH="LEFT">
 									<Size x="0" y="15"/>
 									<Anchors>
 										<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" x="0" y="-5" relativeTo="$parent_Name"/>

--- a/totalRP3/UI/TabSystem.lua
+++ b/totalRP3/UI/TabSystem.lua
@@ -8,18 +8,10 @@ function TRP3_TabButtonMixin:OnLoad()
 end
 
 function TRP3_TabButtonMixin:OnEnter()
-	local tooltipFunction = self.tooltipFunction;
-
-	if not tooltipFunction and self.Text:IsTruncated() then
-		local function ShowTruncatedTooltip(_, description)
-			description:AddTitleLine(self:GetText());
-		end
-
-		tooltipFunction = ShowTruncatedTooltip;
-	end
-
-	if tooltipFunction then
-		TRP3_TooltipUtil.ShowTooltip(self, tooltipFunction);
+	if self.tooltipFunction then
+		TRP3_TooltipUtil.ShowTooltip(self, self.tooltipFunction);
+	elseif self.Text:IsTruncated() then
+		TRP3_TooltipTemplates.ShowTruncationTooltip(self, self.Text:GetText());
 	end
 end
 

--- a/totalRP3/UI/Tooltip/TooltipScript.lua
+++ b/totalRP3/UI/Tooltip/TooltipScript.lua
@@ -46,3 +46,15 @@ function TRP3_TooltipScriptMixin:SetTooltipShown(shown)
 		self:HideTooltip();
 	end
 end
+
+TRP3_TruncatedFontStringTooltipMixin = {};
+
+function TRP3_TruncatedFontStringTooltipMixin:OnEnter()
+	if self:IsTruncated() then
+		TRP3_TooltipTemplates.ShowTruncationTooltip(self, self:GetText());
+	end
+end
+
+function TRP3_TruncatedFontStringTooltipMixin:OnLeave()
+	TRP3_TooltipUtil.HideTooltip(self);
+end

--- a/totalRP3/UI/Tooltip/TooltipScript.xml
+++ b/totalRP3/UI/Tooltip/TooltipScript.xml
@@ -12,4 +12,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			<OnLeave method="OnLeave"/>
 		</Scripts>
 	</Frame>
+
+	<FontString name="TRP3_TruncatedFontStringTooltipTemplate" mixin="TRP3_TruncatedFontStringTooltipMixin" virtual="true">
+		<Scripts>
+			<OnEnter method="OnEnter"/>
+			<OnLeave method="OnLeave"/>
+		</Scripts>
+	</FontString>
 </Ui>

--- a/totalRP3/UI/Tooltip/TooltipTemplates.lua
+++ b/totalRP3/UI/Tooltip/TooltipTemplates.lua
@@ -112,3 +112,11 @@ function TRP3_TooltipTemplates.ShowInstructionTooltip(owner, title, text, instru
 
 	TRP3_TooltipUtil.ShowTooltip(owner, GenerateInstructionTooltip);
 end
+
+function TRP3_TooltipTemplates.ShowTruncationTooltip(owner, text)
+	local function GenerateTruncationTooltip(_, description)
+		description:AddTitleLine(text, NORMAL_FONT_COLOR);
+	end
+
+	TRP3_TooltipUtil.ShowTooltip(owner, GenerateTruncationTooltip);
+end

--- a/totalRP3/UI/Widgets.lua
+++ b/totalRP3/UI/Widgets.lua
@@ -138,11 +138,7 @@ end
 
 function TRP3_CategoryButtonMixin:OnEnter()
 	if self.Text:IsTruncated() then
-		local function Initializer(_, tooltip)
-			tooltip:AddTitleLine(self:GetText());
-		end
-
-		TRP3_TooltipUtil.ShowTooltip(self, Initializer);
+		TRP3_TooltipTemplates.ShowTruncationTooltip(self, self:GetText());
 	end
 end
 


### PR DESCRIPTION
We'll now show tooltips when mousing over the name, title, and PS trait name fields for profiles if the text is too large to be displayed.

Additionally the styling of truncation tooltips should be more uniform now, however one exception to this is the name and eye color fields as these use embedded "|c" markup and so override the color used by the tooltip line description.

![Wow_2024-07-21_21-37-11](https://github.com/user-attachments/assets/e8a18dc5-7ada-416d-be71-e3042b4c1426)
![Wow_2024-07-21_21-37-06](https://github.com/user-attachments/assets/5946c208-2359-4a1a-9e1d-c95be2d82641)
![Wow_2024-07-21_21-36-58](https://github.com/user-attachments/assets/74b1ecf5-2303-41be-9de3-072636e489a3)
![Wow_2024-07-21_21-36-51](https://github.com/user-attachments/assets/ed583f39-a0fd-43a4-bfd9-8c5127d73803)
![image](https://github.com/user-attachments/assets/a6c5cf06-ab4f-4bdf-8f09-e32f92de7d7d)
