### PR TITLE
Truncate race/class texts to 30 chars in TTs

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -525,8 +525,8 @@ local function writeTooltipForCharacter(targetID, targetType)
 	local FIELDS_TO_CROP = {
 		TITLE = 100,
 		NAME = 50,
-		RACE = 50,
-		CLASS = 50,
+		RACE = 30,
+		CLASS = 30,
 		PRONOUNS = 30,
 		GUILD_NAME = 30,
 		GUILD_RANK = 30,


### PR DESCRIPTION
The previous values of 50 each were on the higher side; let's take the opportunity to reduce these to 30 each which makes them consistent with many other fields we truncate in the tooltip.