### PR TITLE
Remove special handling of empty custom class on MSP

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -371,10 +371,6 @@ local function onStart()
 					local value = data[field];
 					if value then
 						value = emptyToNil(strtrim(value));
-						-- Preserve empty class field.
-						if not value and CHARACTERISTICS_FIELDS[field] == "CL" then
-							value = " ";
-						end
 					end
 					if CHARACTERISTICS_FIELDS[field] then
 						-- NA/RC color escaping


### PR DESCRIPTION
Once upon a time, special handling was added for the custom class field coming from MSP, presumably so that it wouldn't use the game fallback and instead just show no class, as this was how MRP displayed it.

The Kat Archives mention that the custom class field was only added to MRP in BfA. Presumably, the behaviour was unintended and MRP was fixed to use the game class as a fallback, but we never got the memo. As such, this has been broken forever and we wouldn't show a class if the field was left empty.

I've removed the special handling so that we use the game class as a fallback once again.