### PR TITLE
Add centralized search string cache

### DIFF
--- a/totalRP3/UI/Browsers/BackgroundBrowser.lua
+++ b/totalRP3/UI/Browsers/BackgroundBrowser.lua
@@ -3,10 +3,6 @@
 
 local L = TRP3_API.loc;
 
-local function GenerateSearchableString(str)
-	return string.utf8lower(string.trim((string.gsub(str, "%p+", " "))));
-end
-
 -- Background Browser Data Models
 ------------------------------------------------------------------------------
 
@@ -126,7 +122,7 @@ function BackgroundBrowserFilterModel:HasSearchQuery()
 end
 
 function BackgroundBrowserFilterModel:SetSearchQuery(query)
-	query = GenerateSearchableString(query);
+	query = TRP3_StringUtil.GenerateSearchableString(query);
 
 	if self.searchQuery ~= query then
 		self.searchQuery = query;
@@ -150,7 +146,7 @@ function BackgroundBrowserFilterModel:RebuildModel()
 	local results = {};
 
 	for sourceIndex = 1, self.source:GetImageCount() do
-		local backgroundName = GenerateSearchableString(self.source:GetImageName(sourceIndex));
+		local backgroundName = TRP3_StringUtil.GenerateSearchableString(self.source:GetImageName(sourceIndex));
 		local offset = 1;
 		local plain = true;
 

--- a/totalRP3/UI/Browsers/IconBrowser.lua
+++ b/totalRP3/UI/Browsers/IconBrowser.lua
@@ -3,10 +3,6 @@
 
 local LibRPMedia = LibStub:GetLibrary("LibRPMedia-1.0");
 
-local function GenerateSearchableString(str)
-	return string.utf8lower(string.trim((string.gsub(str, "%p+", " "))));
-end
-
 -- Icon Browser Search Task
 ------------------------------------------------------------------------------
 
@@ -98,7 +94,7 @@ function IconBrowserSearchTask:OnUpdate()
 	local j = math.min(self.searched + self.step, self.total);
 
 	for iconIndex = i, j do
-		local iconName = GenerateSearchableString(model:GetIconName(iconIndex));
+		local iconName = TRP3_StringUtil.GenerateSearchableString(model:GetIconName(iconIndex));
 		local offset = 1;
 		local plain = true;
 
@@ -309,7 +305,7 @@ end
 
 ---@param query string
 function IconBrowserFilterModel:SetSearchQuery(query)
-	query = GenerateSearchableString(query);  ---@cast query string
+	query = TRP3_StringUtil.GenerateSearchableString(query);  ---@cast query string
 
 	if self.searchQuery ~= query then
 		self.searchQuery = query;

--- a/totalRP3/UI/Browsers/MusicBrowser.lua
+++ b/totalRP3/UI/Browsers/MusicBrowser.lua
@@ -5,24 +5,13 @@ local L = TRP3_API.loc;
 
 local LRPM12 = LibStub:GetLibrary("LibRPMedia-1.2");
 
-local function GenerateSearchableString(str)
-	return string.utf8lower(string.trim((string.gsub(str, "%p+", " "))));
-end
-
-local SearchableStringCache = setmetatable({}, {
-	__index = function(t, k)
-		t[k] = GenerateSearchableString(k);
-		return rawget(t, k);
-	end,
-});
-
 local function GenerateFilteredMusicList(query)
 	local results = {};
 
-	query = GenerateSearchableString(query);
+	query = TRP3_StringUtil.GenerateSearchableString(query);
 
 	local function CheckStringMatch(musicName)
-		local searchName = SearchableStringCache[musicName];
+		local searchName = TRP3_StringUtil.GenerateSearchableString(musicName);
 		local offset = 1;
 		local plain = true;
 


### PR DESCRIPTION
The "make-searchable-string" function in all the browsers is similar-ish to a function already present in StringUtil, so let's make everything use that instead and also add a cache there to speed up the generation of search strings.

Note I've worked this atop the music browser changes in #1087. We could merge this in for 3.0, but until that's merged this will remain a draft and the diff will be a bit messy.