### PR TITLE
Murder the FieldSetFrame template

### DIFF
--- a/totalRP3/Deprecated.lua
+++ b/totalRP3/Deprecated.lua
@@ -3,14 +3,3 @@
 
 -- Anything in this file is deprecated and will be removed in future versions
 -- of TRP, potentially without warning.
-
-local FIELDSET_DEFAULT_CAPTION_WIDTH = 100;
-
-function TRP3_API.ui.frame.setupFieldPanel(fieldset, text, size)
-	if fieldset and _G[fieldset:GetName().."CaptionPanelCaption"] then
-		_G[fieldset:GetName().."CaptionPanelCaption"]:SetText(text);
-		if _G[fieldset:GetName().."CaptionPanel"] then
-			_G[fieldset:GetName().."CaptionPanel"]:SetWidth(size or FIELDSET_DEFAULT_CAPTION_WIDTH);
-		end
-	end
-end

--- a/totalRP3/Deprecated.xml
+++ b/totalRP3/Deprecated.xml
@@ -8,34 +8,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="Deprecated.lua"/>
-
-
-	<!-- A bordered frame with a title -->
-	<Frame name="TRP3_FieldSetFrame" virtual="true" inherits="TRP3_TooltipBackdropTemplate">
-		<KeyValues>
-			<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
-		</KeyValues>
-		<Frames>
-			<Frame name="$parentCaptionPanel" parentKey="caption" inherits="TRP3_SolidTooltipBackdropTemplate">
-				<Size x="150" y="23"/>
-				<KeyValues>
-					<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
-				</KeyValues>
-				<Layers>
-					<Layer level="OVERLAY">
-						<FontString name="$parentCaption" text="[Caption text]" inherits="GameFontNormal" wordwrap="false">
-							<Anchors>
-								<Anchor point="LEFT" x="10" y="0"/>
-								<Anchor point="RIGHT" x="-10" y="0"/>
-							</Anchors>
-							<Color r="0.95" g="0.95" b="0.95"/>
-						</FontString>
-					</Layer>
-				</Layers>
-				<Anchors>
-					<Anchor point="TOPLEFT" x="16" y="10"/>
-				</Anchors>
-			</Frame>
-		</Frames>
-	</Frame>
 </Ui>


### PR DESCRIPTION
Extended cleaned up all of its usages of the template, so no longer required yay poggers let's go boys.