### PR TITLE
Strip consecutive spaces from FT fields

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -12,7 +12,9 @@ function TRP3_NamePlatesUtil.GenerateCroppedNameText(name)
 end
 
 function TRP3_NamePlatesUtil.GenerateCroppedTitleText(fullTitle)
-	return TRP3_API.utils.str.crop(fullTitle, TRP3_NamePlatesSettings.MaximumTitleLength);
+	fullTitle = string.gsub(fullTitle, "%s+", " ");
+	fullTitle = TRP3_API.utils.str.crop(fullTitle, TRP3_NamePlatesSettings.MaximumTitleLength);
+	return fullTitle;
 end
 
 function TRP3_NamePlatesUtil.GenerateCroppedGuildName(guildName)

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -308,7 +308,7 @@ local function setConsultDisplay(context)
 	-- Icon, complete name and titles
 	local completeName = getCompleteName(dataTab, UNKNOWN);
 	TRP3_RegisterCharact_NamePanel_Name:SetText("|cff" .. (dataTab.CH or "ffffff") .. completeName);
-	TRP3_RegisterCharact_NamePanel_Title:SetText(dataTab.FT or "");
+	TRP3_RegisterCharact_NamePanel_Title:SetText((string.gsub(dataTab.FT or "", "%s+", " ")));
 	TRP3_RegisterCharact_NamePanel.Icon:SetIconTexture(dataTab.IC);
 
 	setBkg(dataTab.bkg or 1);

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsPage.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsPage.lua
@@ -190,7 +190,7 @@ function displayConsult(context)
 	local dataTab = context.profile.data or Globals.empty;
 
 	TRP3_CompanionsPageInformationConsult_NamePanel_Name:SetText("|cff" .. (dataTab.NH or "ffffff") .. (dataTab.NA or UNKNOWN));
-	TRP3_CompanionsPageInformationConsult_NamePanel_Title:SetText(dataTab.TI or "");
+	TRP3_CompanionsPageInformationConsult_NamePanel_Title:SetText((string.gsub(dataTab.TI or "", "%s+", " ")));
 	TRP3_CompanionsPageInformationConsult_NamePanel.Icon:SetIconTexture(dataTab.IC or TRP3_InterfaceIcons.ProfileDefault);
 
 	for i=1,5 do

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -629,6 +629,7 @@ local function writeTooltipForCharacter(targetID, targetType)
 
 		if fullTitle and fullTitle ~= "" then
 			if getConfigValue(ConfigKeys.CROP_TEXT) then
+				fullTitle = string.gsub(fullTitle, "%s+", " ");
 				fullTitle = crop(fullTitle, FIELDS_TO_CROP.TITLE);
 			end
 
@@ -1076,6 +1077,7 @@ local function writeCompanionTooltip(companionFullID, targetType, targetMode)
 		if fullTitle and fullTitle ~= "" then
 
 			if getConfigValue(ConfigKeys.CROP_TEXT) then
+				fullTitle = string.gsub(fullTitle, "%s+", " ");
 				fullTitle = crop(fullTitle, FIELDS_TO_CROP.TITLE);
 			end
 			tooltipBuilder:AddLine(fullTitle, colors.TITLE, getSubLineFontSize(), true);

--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1247,6 +1247,7 @@ local function writeTooltipForMount(ownerID, companionFullID, mountName)
 		end
 		if fullTitle and fullTitle ~= "" then
 			if getConfigValue(ConfigKeys.CROP_TEXT) then
+				fullTitle = string.gsub(fullTitle, "%s+", " ");
 				fullTitle = crop(fullTitle, FIELDS_TO_CROP.TITLE);
 			end
 			tooltipCompanionBuilder:AddLine(fullTitle, colors.TITLE, getSubLineFontSize(), true);


### PR DESCRIPTION
People keep putting a silly number of spaces in their title fields to force an effect of having multiple titles split across separate lines.

We've historically discouraged this because it assumes titles are only ever shown in tooltips and will actually wrap the text; this isn't guaranteed to the case (FTs sent over MSP to other addons may not be displayed with wrapping), and in nameplates that's exactly what happens.

As we're adding other tooltip restrictions, let's kill consecutive spaces in the FT field for player profiles and the TI field for companion profiles. This is uniformly applied across the characteristics page views, the tooltip, and nameplates. The stripping occurs before cropping so as to avoid too eagerly truncating text when it doesn't strictly require it.

If this proves successful we can look into applying the same change to other fields potentially.