### PR TITLE
Only check world cursor config if TT module is on

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -212,7 +212,7 @@ local function fadeOutEnabled()
 end
 
 local function showWorldCursor()
-	return getConfigValue(ConfigKeys.SHOW_WORLD_CURSOR);
+	return registerTooltipModuleIsEnabled and getConfigValue(ConfigKeys.SHOW_WORLD_CURSOR);
 end
 
 local function getCurrentMaxLines()


### PR DESCRIPTION
Fixes #1096.

The tooltip setup code initializes hooks on GTT in order to drive the internal event for mouseover changes. As part of this, we'd also check for world cursor units. In 3.0.0 we added a setting to disable the world cursor units, but this setting is only initialized if the TT module is actually enabled.

As such - if the module is disabled, we shouldn't query the unregistered config key.