### PR TITLE
Scrollable switch profile dropdowns if list too big

### DIFF
--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -264,6 +264,14 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)
 						description:CreateTitle(loc.TB_SWITCH_PROFILE);
 
+						-- Make the dropdown list have a scrollbar on mainline.
+						if description.SetScrollMode then
+							local optionHeight = 20; -- 20 is the default height.
+							local maxLines = 20;
+							local maxScrollExtent = optionHeight * maxLines;
+							description:SetScrollMode(maxScrollExtent);
+						end
+
 						for _, profile in ipairs(profileList) do
 							-- Current profile has nil profileID (profile[3])
 							local icon = profile[2] or TRP3_InterfaceIcons.ProfileDefault;

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -415,6 +415,15 @@ local function companionProfileSelectionList(unitID, targetType, buttonClick, bu
 				description:CreateButton("|cnGREEN_FONT_COLOR:" .. loc.REG_COMPANION_TF_CREATE .. "|r", function() onCompanionProfileSelection(2, companionID, targetType); end);
 				local profileList = getPlayerCompanionProfilesAsList(companionID);
 				local profileButton = description:CreateButton( loc.REG_COMPANION_TF_BOUND_TO);
+
+				-- Make the dropdown list have a scrollbar on mainline.
+				if profileButton.SetScrollMode then
+					local optionHeight = 20; -- 20 is the default height.
+					local maxLines = 20;
+					local maxScrollExtent = optionHeight * maxLines;
+					profileButton:SetScrollMode(maxScrollExtent);
+				end
+
 				for _, profile in ipairs(profileList) do
 					-- Current profile has nil profileID (profile[2])
 					if profile[2] then


### PR DESCRIPTION
This applies to both the character and companion profile dropdown lists (toolbar and target frame, respectively).

Note that these do not scroll down to the currently selected profile (this is not an option as-is right now). So if your currently selected profile is at the bottom, you may have to scroll down a bit to see it.