### PR TITLE
Remove glance click handlers

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -224,11 +224,6 @@ local function setupGlanceButton(button, active, icon, title, text, isMine)
 	button:Enable();
 	button.isCurrentMine = isMine;
 
-	-- Add our click handlers
-	if isMine then
-		text = TRP3_API.register.glance.addClickHandlers(text);
-	end
-
 	if active then
 		button:SetAlpha(1);
 		button:SetIconTexture(icon or GLANCE_NOT_USED_ICON);
@@ -508,11 +503,7 @@ function TRP3_API.register.inits.miscInit()
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
 	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.5, onOOCInfoChanged), {});
 
-	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, loc.REG_PLAYER_GLANCE_CONFIG
-	.. "|n|n" .. TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.REG_PLAYER_GLANCE_CONFIG_EDIT)
-	.. "|n" .. TRP3_API.FormatShortcutWithInstruction("DCLICK", loc.REG_PLAYER_GLANCE_CONFIG_TOGGLE)
-	.. "|n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.REG_PLAYER_GLANCE_CONFIG_PRESETS)
-	.. "|n" .. TRP3_API.FormatShortcutWithInstruction("DRAGDROP", loc.REG_PLAYER_GLANCE_CONFIG_REORDER));
+	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, TRP3_API.register.glance.addClickHandlers(loc.REG_PLAYER_GLANCE_CONFIG));
 
 	for index=1,5,1 do
 		-- DISPLAY

--- a/totalRP3/Modules/Register/Main/RegisterGlance.lua
+++ b/totalRP3/Modules/Register/Main/RegisterGlance.lua
@@ -737,9 +737,6 @@ local function displayGlanceSlots()
 					TTText = crop(TTText, GLANCE_TOOLTIP_CROP);
 					glanceTitle = crop(glanceTitle, GLANCE_TITLE_CROP);
 				end
-				if isCurrentMine then
-					TTText = TRP3_API.register.glance.addClickHandlers(TTText);
-				end
 				setTooltipForSameFrame(button, "TOP", 0, 5, Utils.str.icon(icon, 30) .. " " .. glanceTitle, TTText);
 				updateGlanceButtonsTooltips();
 			else
@@ -753,9 +750,6 @@ local function displayGlanceSlots()
 						end
 						TTText = glance.TX;
 						glanceTitle = glance.TI or loc.REG_PLAYER_GLANCE_UNUSED;
-					end
-					if isCurrentMine then
-						TTText = TRP3_API.register.glance.addClickHandlers(TTText);
 					end
 					setTooltipForSameFrame(button, "TOP", 0, 5, Utils.str.icon(icon, 30) .. " " .. glanceTitle, TTText);
 					updateGlanceButtonsTooltips();


### PR DESCRIPTION
We've opted that for now we'll keep it on just the `i` (info) button in Misc info.

We'll revisit this one day if it turns out too many people don't know these options also work on the target frame's glance bar.

![image](https://github.com/user-attachments/assets/c83b865d-d7da-4ed3-ba70-6db511965260)
![image](https://github.com/user-attachments/assets/7cf278da-670b-41b8-869c-045d1993b484)
![image](https://github.com/user-attachments/assets/fed6f390-bfa4-4490-9520-7fea17fefbbb)
