### PR TITLE
Issue profile requests on target bar interactions

### DIFF
--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -114,7 +114,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
 		end,
-		onMouseDown = function(Uibutton)
+		onClick = function(Uibutton)
 			TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)
 				description:CreateTitle(loc.TB_LANGUAGE);
 				for _, language in ipairs(Languages.getAvailableLanguages()) do

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -393,7 +393,7 @@ TRP3_API.register.inits.relationsInit = function()
 			condition = function(_, unitID)
 				return UnitIsPlayer("target") and unitID ~= TRP3_API.globals.player_id and hasProfile(unitID);
 			end,
-			onMouseDown = onTargetButtonClicked,
+			onClick = onTargetButtonClicked,
 			adapter = function(buttonStructure, unitID)
 				local profileID = hasProfile(unitID);
 				local relationColoredName = getRelationText(profileID);

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -631,7 +631,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			end,
 			tooltip = loc.REG_COMPANION_TF_PROFILE_SPEECH,
 			tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.REG_COMPANION_TF_PROFILE_SPEECH_TT),
-			onMouseDown = function(characterID)
+			onClick = function(characterID)
 				local ownerID, companionID = companionIDToInfo(characterID);
 				local profile = getCompanionInfo(ownerID, companionID, characterID);
 

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -1069,14 +1069,16 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			id = "aa_player_a_page",
 			configText = loc.TF_OPEN_CHARACTER,
 			onlyForType = AddOn_TotalRP3.Enums.UNIT_TYPE.CHARACTER,
-			condition = function(_, unitID)
-				return unitID == Globals.player_id or (isUnitIDKnown(unitID) and hasProfile(unitID));
+			condition = function(_, characterID)
+				return characterID == Globals.player_id or (isUnitIDKnown(characterID) and hasProfile(characterID));
 			end,
-			onClick = function(unitID)
+			onClick = function(characterID)
 				openMainFrame();
-				openPageByUnitID(unitID);
+				TRP3_API.r.sendQuery(characterID);
+				TRP3_API.r.sendMSPQuery(characterID);
+				openPageByUnitID(characterID);
 			end,
-			adapter = function(buttonStructure, unitID)
+			adapter = function(buttonStructure, characterID)
 				-- Initialize the buttonStructure parts.
 				buttonStructure.alert = false;
 				local factionTag = UnitFactionGroup("target");
@@ -1091,15 +1093,15 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 
 				-- Retrieve the character's profile.
 				local profile;
-				if unitID == Globals.player_id then
+				if characterID == Globals.player_id then
 					profile = TRP3_API.profile.getData("player");
 				else
-					profile = getUnitIDProfile(unitID);
+					profile = getUnitIDProfile(characterID);
 				end
 
 				local tooltipLines = {};
 
-				if unitID ~= Globals.player_id and profile.about and not profile.about.read then
+				if characterID ~= Globals.player_id and profile.about and not profile.about.read then
 					local icon = "Interface\\AddOns\\totalRP3\\Resources\\UI\\ui-icon-unread-overlay";
 					table.insert(tooltipLines, TRP3_MarkupUtil.GenerateFileMarkup(icon, { size = 16 }) .. loc.REG_TT_NOTIF_LONG_TT);
 					buttonStructure.alert = true;


### PR DESCRIPTION
This adjusts the "Open profile" buttons for players and companions to issue a profile request when clicked, to avoid any edge cases where someone updates their profile after having been stared at for 5 minutes by someone else who hasn't bothered to mouseover them even once.

Also I s/unitID/characterID/g'd. Get over it.