### PR TITLE
Add chat token replacement support for player names

### DIFF
--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -801,12 +801,16 @@ function hooking()
 		if text and send == 1 then
 			textBeforeParse = text;
 			parsedEditBox = editBox;
+			local player = AddOn_TotalRP3.Player.GetCurrentUser();
 			text = text:gsub("%%xtf", getUnitRPFirstName("target") or TARGET_TOKEN_NOT_FOUND);
 			text = text:gsub("%%xtl", getUnitRPLastName("target") or TARGET_TOKEN_NOT_FOUND);
 			text = text:gsub("%%xff", getUnitRPFirstName("focus") or FOCUS_TOKEN_NOT_FOUND);
 			text = text:gsub("%%xfl", getUnitRPLastName("focus") or FOCUS_TOKEN_NOT_FOUND);
+			text = text:gsub("%%xpf", player:GetFirstName() or "");
+			text = text:gsub("%%xpl", player:GetLastName() or "");
 			text = text:gsub("%%xt", getUnitRPName("target") or TARGET_TOKEN_NOT_FOUND);
 			text = text:gsub("%%xf", getUnitRPName("focus") or FOCUS_TOKEN_NOT_FOUND);
+			text = text:gsub("%%xp", player:GetFullName() or "");
 			editBox:SetText(text);
 		end
 	end);


### PR DESCRIPTION
This adds a trio of new chat tokens (%xp[lf]) for inserting the player character RP name into chat messages. Banana.