### PR TITLE
Aggressively trim notes prior to saving

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterNotes.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterNotes.lua
@@ -11,7 +11,6 @@ local hasProfile = TRP3_API.register.hasProfile;
 local openMainFrame = TRP3_API.navigation.openMainFrame;
 local getCurrentContext = TRP3_API.navigation.page.getCurrentContext;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
-local stEtN = TRP3_API.utils.str.emptyToNil;
 
 local GetCurrentUser = AddOn_TotalRP3.Player.GetCurrentUser;
 local getPlayerCurrentProfile = TRP3_API.profile.getPlayerCurrentProfile;
@@ -57,7 +56,10 @@ local function onProfileNotesChanged()
 		profile.notes = {};
 	end
 
-	profile.notes[profileID] = stEtN(TRP3_RegisterNotesViewProfile:GetInputText());
+	local text = TRP3_RegisterNotesViewProfile:GetInputText();
+	text = string.trim(text);
+	text = text ~= "" and text or nil;
+	profile.notes[profileID] = text;
 end
 
 local function onAccountNotesChanged()
@@ -67,7 +69,10 @@ local function onAccountNotesChanged()
 		profileID = getPlayerCurrentProfileID();
 	end
 
-	TRP3_Notes[profileID] = stEtN(TRP3_RegisterNotesViewAccount:GetInputText());
+	local text = TRP3_RegisterNotesViewAccount:GetInputText();
+	text = string.trim(text);
+	text = text ~= "" and text or nil;
+	TRP3_Notes[profileID] = text;
 end
 
 local function showNotesTab()


### PR DESCRIPTION
If the notes field contains solely whitespace characters it'll confusingly result in the note icon showing on player profiles. Let's trim the fields fully before converting empty text to nil just in case a user is a bit silly.