### PR TITLE
Toolbar Modernization (and also IC/OOC icons)

### DIFF
--- a/totalRP3/Core/Configuration.lua
+++ b/totalRP3/Core/Configuration.lua
@@ -485,7 +485,5 @@ end);
 AddOn_TotalRP3.Configuration = {}
 
 function TRP3_API.configuration.constructConfigPage()
-	TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TOOLBAR_PAGE);
-	TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
 	TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_STRUCTURE_GENERAL);
 end

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -209,7 +209,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
 			end,
-			onClick = function(_, buttonStructure, button)
+			onClick = function(_, _, button)
 				if UnitIsAFK("player") then
 					SendChatMessage("","AFK");
 				elseif UnitIsDND("player") then
@@ -222,7 +222,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					end
 				end
 				PlaySound(TRP3_InterfaceSounds.ButtonClick);
-				buttonStructure:onModelUpdate();
 			end,
 		};
 		TRP3_API.toolbar.toolbarAddButton(Button_Status);
@@ -255,7 +254,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = OOC_ICON;
 				end
 			end,
-			onClick = function(Uibutton, buttonStructure, button)
+			onClick = function(Uibutton, _, button)
 
 				if button == "RightButton" then
 					local currentProfileID = getPlayerCurrentProfileID();
@@ -286,8 +285,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					TRP3_API.dashboard.switchStatus();
 					PlaySound(TRP3_InterfaceSounds.ButtonClick);
 				end
-
-				buttonStructure:onModelUpdate();
 			end,
 			onLeave = function()
 				TRP3_MainTooltip:Hide();
@@ -327,7 +324,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						refreshTooltip(Uibutton);
 					end
 				end,
-				onClick = function(_, buttonStructure)
+				onClick = function()
 					if ShowingHelm() then
 						ShowHelm(false);
 						PlaySound(1202); -- Putdowncloth_Leather01
@@ -335,7 +332,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						ShowHelm(true);
 						PlaySound(1185); -- Pickupcloth_Leather01
 					end
-					buttonStructure:onModelUpdate();
 				end,
 				onLeave = function()
 					TRP3_MainTooltip:Hide();

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -209,7 +209,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
 			end,
-			onClick = function(_, _, button)
+			onClick = function(_, buttonStructure, button)
 				if UnitIsAFK("player") then
 					SendChatMessage("","AFK");
 				elseif UnitIsDND("player") then
@@ -222,6 +222,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					end
 				end
 				PlaySound(TRP3_InterfaceSounds.ButtonClick);
+				buttonStructure:onModelUpdate();
 			end,
 		};
 		TRP3_API.toolbar.toolbarAddButton(Button_Status);
@@ -237,7 +238,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			id = "aa_trp3_rpstatus",
 			icon = OOC_ICON,
 			configText = loc.CO_TOOLBAR_CONTENT_RPSTATUS,
-			onEnter = function() end,
 			onUpdate = function(Uibutton, buttonStructure)
 				updateToolbarButton(Uibutton, buttonStructure);
 				if Uibutton:IsMouseMotionFocus() then
@@ -255,7 +255,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = OOC_ICON;
 				end
 			end,
-			onClick = function(Uibutton, _, button)
+			onClick = function(Uibutton, buttonStructure, button)
 
 				if button == "RightButton" then
 					local currentProfileID = getPlayerCurrentProfileID();
@@ -286,6 +286,8 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					TRP3_API.dashboard.switchStatus();
 					PlaySound(TRP3_InterfaceSounds.ButtonClick);
 				end
+
+				buttonStructure:onModelUpdate();
 			end,
 			onLeave = function()
 				TRP3_MainTooltip:Hide();
@@ -307,7 +309,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				id = "aa_trp3_b",
 				icon = helmetOnIcon,
 				configText = loc.CO_TOOLBAR_CONTENT_HELMET,
-				onEnter = function() end,
 				onModelUpdate = function(buttonStructure)
 					if ShowingHelm() then
 						buttonStructure.tooltip  = helmTextOn;
@@ -326,7 +327,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						refreshTooltip(Uibutton);
 					end
 				end,
-				onClick = function()
+				onClick = function(_, buttonStructure)
 					if ShowingHelm() then
 						ShowHelm(false);
 						PlaySound(1202); -- Putdowncloth_Leather01
@@ -334,6 +335,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						ShowHelm(true);
 						PlaySound(1185); -- Pickupcloth_Leather01
 					end
+					buttonStructure:onModelUpdate();
 				end,
 				onLeave = function()
 					TRP3_MainTooltip:Hide();
@@ -352,7 +354,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				id = "aa_trp3_c",
 				icon = cloakOnIcon,
 				configText = loc.CO_TOOLBAR_CONTENT_CAPE,
-				onEnter = function() end,
 				onModelUpdate = function(buttonStructure)
 					if ShowingCloak() then
 						buttonStructure.tooltip  = capeTextOn;

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -15,7 +15,6 @@ local getPlayerCurrentProfileID = TRP3_API.profile.getPlayerCurrentProfileID;
 local getProfiles = TRP3_API.profile.getProfiles;
 local Utils = TRP3_API.utils;
 local color = Utils.str.color;
-local refreshTooltip = TRP3_API.ui.tooltip.refresh;
 local registerMenu, registerPage = TRP3_API.navigation.menu.registerMenu, TRP3_API.navigation.page.registerPage;
 local setPage = TRP3_API.navigation.page.setPage;
 
@@ -176,7 +175,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		}
 		TRP3_API.toolbar.toolbarAddButton(Button_TRP3_Open);
 
-		local updateToolbarButton = TRP3_API.toolbar.updateToolbarButton;
 		-- away/dnd
 		local status1Text = loc.TB_STATUS..": "..color("r")..loc.TB_DND_MODE;
 		local status1SubText = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TB_GO_TO_MODE:format(loc.TB_NORMAL_MODE));
@@ -188,12 +186,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			id = "aa_trp3_d",
 			icon = TRP3_InterfaceIcons.ModeNormal,
 			configText = loc.CO_TOOLBAR_CONTENT_STATUS,
-			onUpdate = function(Uibutton, buttonStructure)
-				updateToolbarButton(Uibutton, buttonStructure);
-				if Uibutton:IsMouseMotionFocus() then
-					refreshTooltip(Uibutton);
-				end
-			end,
 			onModelUpdate = function(buttonStructure)
 				if UnitIsDND("player") then
 					buttonStructure.tooltip  = status1Text;
@@ -237,12 +229,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			id = "aa_trp3_rpstatus",
 			icon = OOC_ICON,
 			configText = loc.CO_TOOLBAR_CONTENT_RPSTATUS,
-			onUpdate = function(Uibutton, buttonStructure)
-				updateToolbarButton(Uibutton, buttonStructure);
-				if Uibutton:IsMouseMotionFocus() then
-					refreshTooltip(Uibutton);
-				end
-			end,
 			onModelUpdate = function(buttonStructure)
 				if AddOn_TotalRP3.Player.GetCurrentUser():IsInCharacter() then
 					buttonStructure.tooltip  = rpTextOn;
@@ -318,12 +304,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						buttonStructure.icon = helmetOffIcon;
 					end
 				end,
-				onUpdate = function(Uibutton, buttonStructure)
-					updateToolbarButton(Uibutton, buttonStructure);
-					if Uibutton:IsMouseMotionFocus() then
-						refreshTooltip(Uibutton);
-					end
-				end,
 				onClick = function()
 					if ShowingHelm() then
 						ShowHelm(false);
@@ -360,12 +340,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 						buttonStructure.tooltip  = capeTextOff;
 						buttonStructure.tooltipSub  = capeText2;
 						buttonStructure.icon = cloakOffIcon;
-					end
-				end,
-				onUpdate = function(Uibutton, buttonStructure)
-					updateToolbarButton(Uibutton, buttonStructure);
-					if Uibutton:IsMouseMotionFocus() then
-						refreshTooltip(Uibutton);
 					end
 				end,
 				onClick = function(_)

--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -10,7 +10,6 @@ AddOn_TotalRP3.Languages = Languages;
 local _, TRP3_API = ...;
 
 -- Imports
-local refreshTooltip, mainTooltip = TRP3_API.ui.tooltip.refresh, TRP3_MainTooltip;
 local loc = TRP3_API.loc;
 local Globals = TRP3_API.globals;
 local GetNumLanguages, GetLanguageByIndex, GetDefaultLanguage = GetNumLanguages, GetLanguageByIndex, GetDefaultLanguage;
@@ -98,9 +97,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		id = "ww_trp3_languages",
 		icon = TRP3_InterfaceIcons.ToolbarLanguage,
 		configText = loc.TB_LANGUAGE,
-		onEnter = function(Uibutton)
-			refreshTooltip(Uibutton);
-		end,
 		onUpdate = function(Uibutton, buttonStructure)
 			TRP3_API.toolbar.updateToolbarButton(Uibutton, buttonStructure);
 		end,
@@ -114,7 +110,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
 		end,
-		onMouseDown = function(Uibutton)
+		onClick = function(Uibutton)
 			TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)
 				description:CreateTitle(loc.TB_LANGUAGE);
 				for _, language in ipairs(Languages.getAvailableLanguages()) do
@@ -125,9 +121,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					end
 				end
 			end);
-		end,
-		onLeave = function()
-			mainTooltip:Hide();
 		end,
 	};
 	TRP3_API.toolbar.toolbarAddButton(languagesButton);

--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -97,9 +97,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		id = "ww_trp3_languages",
 		icon = TRP3_InterfaceIcons.ToolbarLanguage,
 		configText = loc.TB_LANGUAGE,
-		onUpdate = function(Uibutton, buttonStructure)
-			TRP3_API.toolbar.updateToolbarButton(Uibutton, buttonStructure);
-		end,
 		onModelUpdate = function(buttonStructure)
 			if buttonStructure.currentLanguageID ~= ChatFrame1EditBox.languageID then
 				buttonStructure.currentLanguageID = ChatFrame1EditBox.languageID

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -378,6 +378,8 @@ local function onStart()
 			end,
 		});
 
+		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
+
 		local ids = {};
 		for buttonID, _ in pairs(targetButtons) do
 			tinsert(ids, buttonID);

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -245,8 +245,8 @@ local function onStart()
 			});
 		end
 
-		BuildToolbar();
 		TRP3_Toolbar:Init();
+		BuildToolbar();
 	end);
 
 	function TRP3_API.toolbar.switch()

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -235,6 +235,8 @@ local function onStart()
 			});
 		end
 
+		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TOOLBAR_PAGE);
+
 		TRP3_ToolbarFrame:Init();
 		BuildToolbar();
 	end);

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -111,23 +111,18 @@ local function onStart()
 
 	-- Add a new button to the toolbar. The toolbar layout is automatically handled.
 	-- Button structure :
-	local function toolbarAddButton(buttonStructure)
+	function TRP3_API.toolbar.toolbarAddButton(buttonStructure)
 		assert(not loaded, "All button must be registered on addon load. You're too late !");
 		assert(buttonStructure and buttonStructure.id, "Usage: button structure containing 'id' field");
 		assert(not buttonStructures[buttonStructure.id], "The toolbar button with id "..buttonStructure.id.." already exists.");
 		buttonStructures[buttonStructure.id] = buttonStructure;
 		registerDatabrokerButton(buttonStructure);
 	end
-	TRP3_API.toolbar.toolbarAddButton = toolbarAddButton;
 
-	--- Will refresh the UI of a given button (icon, tooltip) using the data provided in the buttonStructure
-	-- @param toolbarButton UI button to refresh
-	-- @param buttonStructure Button structure containing the icon and tooltip text
-	--
-	local function updateToolbarButton(toolbarButton, buttonStructure)
-		toolbarButton:SetElementData(buttonStructure);
+	function TRP3_API.toolbar.updateToolbarButton(button, buttonStructure)  -- luacheck: no unused
+		button:Update();
 	end
-	TRP3_API.toolbar.updateToolbarButton = updateToolbarButton;
+
 
 	local function RefreshToolbarButtons()
 		for _, buttonStructure in pairs(buttonStructures) do

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -7,11 +7,6 @@ local color = Utils.str.color;
 
 local CONFIG_CONTENT_PREFIX = "toolbar_content_";
 
--- Always build UI on init. Because maybe other modules would like to anchor it on start.
-local function onInit()
-	CreateFrame("Frame", "TRP3_Toolbar", UIParent, "TRP3_ToolbarFrameTemplate");
-end
-
 local function onStart()
 	-- Public accessor
 	TRP3_API.toolbar = {};
@@ -43,7 +38,7 @@ local function onStart()
 		table.sort(elements, SortToolbarButtons);
 
 		local provider = CreateDataProvider(elements);
-		TRP3_Toolbar:SetDataProvider(provider);
+		TRP3_ToolbarFrame:SetDataProvider(provider);
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -132,7 +127,7 @@ local function onStart()
 			end
 		end
 
-		TRP3_Toolbar:RefreshButtons();
+		TRP3_ToolbarFrame:RefreshButtons();
 	end
 
 	-- Holding off on making toolbutton updates more flexible for now in favour
@@ -154,7 +149,7 @@ local function onStart()
 		setConfigValue(TRP3_ToolbarConfigKeys.AnchorOffsetX, 0);
 		setConfigValue(TRP3_ToolbarConfigKeys.AnchorOffsetY, -30);
 		setConfigValue(TRP3_ToolbarConfigKeys.Visibility, TRP3_ToolbarVisibilityOption.AlwaysShow);
-		TRP3_Toolbar:LoadPosition();
+		TRP3_ToolbarFrame:LoadPosition();
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -240,12 +235,12 @@ local function onStart()
 			});
 		end
 
-		TRP3_Toolbar:Init();
+		TRP3_ToolbarFrame:Init();
 		BuildToolbar();
 	end);
 
 	function TRP3_API.toolbar.switch()
-		TRP3_Toolbar:Toggle();
+		TRP3_ToolbarFrame:Toggle();
 	end
 end
 
@@ -255,7 +250,6 @@ local MODULE_STRUCTURE = {
 	["version"] = 1.000,
 	["id"] = "trp3_tool_bar",
 	["onStart"] = onStart,
-	["onInit"] = onInit,
 	["minVersion"] = 3,
 };
 

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -307,6 +307,15 @@ local function onStart()
 					local LDBButton = LDBObjects[buttonStructure.id];
 					tooltip:AddLine(color("w") .. LDBButton.tooltipTitle);
 					tooltip:AddLine(LDBButton.tooltipSub, nil, nil, nil, true);
+
+					if buttonStructure.tooltipInstructions then
+						tooltip:AddLine(" ");
+
+						for _, instruction in ipairs(buttonStructure.tooltipInstructions) do
+							local text = TRP3_API.FormatShortcutWithInstruction(instruction[1], instruction[2]);
+							tooltip:AddLine(text);
+						end
+					end
 				end
 			});
 		LDBObjects[buttonStructure.id] = LDBObject;

--- a/totalRP3/Modules/Toolbar/Toolbar.xml
+++ b/totalRP3/Modules/Toolbar/Toolbar.xml
@@ -4,20 +4,10 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
-	<!-- Toolbar button -->
-	<Button name="TRP3_ToolbarButtonTemplate" mixin="TRP3_ToolbarButtonMixin" inherits="TRP3_BorderedIconButtonTemplate" registerForClicks="LeftButtonUp, RightButtonUp" virtual="true">
-		<Size x="30" y="30"/>
-		<Scripts>
-			<OnLoad method="OnLoad"/>
-			<OnShow method="OnShow"/>
-			<OnClick method="OnClick"/>
-			<OnEnter method="OnEnter"/>
-			<OnLeave method="OnLeave"/>
-			<OnUpdate method="OnUpdate"/>
-		</Scripts>
-	</Button>
+	<Include file="ToolbarConstants.lua"/>
+	<Include file="ToolbarButton.xml"/>
+	<Include file="ToolbarUtil.lua"/>
 
-	<!-- Toolbar -->
 	<Frame name="TRP3_ToolbarTemplate" frameStrata="MEDIUM" toplevel="true" parent="UIParent" enableMouse="true" virtual="true">
 		<Size x="190" y="60" />
 		<Scripts>

--- a/totalRP3/Modules/Toolbar/Toolbar.xml
+++ b/totalRP3/Modules/Toolbar/Toolbar.xml
@@ -6,41 +6,7 @@
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="ToolbarConstants.lua"/>
 	<Include file="ToolbarButton.xml"/>
+	<Include file="ToolbarFrame.xml"/>
 	<Include file="ToolbarUtil.lua"/>
-
-	<Frame name="TRP3_ToolbarTemplate" frameStrata="MEDIUM" toplevel="true" parent="UIParent" enableMouse="true" virtual="true">
-		<Size x="190" y="60" />
-		<Scripts>
-			<OnLoad>
-				self:SetClampedToScreen(true);
-			</OnLoad>
-		</Scripts>
-		<Frames>
-			<Frame name="$parentContainer" inherits="TRP3_ThinDialogBackdropTemplate">
-				<Anchors>
-					<Anchor point="TOP" x="0" y="-18" />
-				</Anchors>
-			</Frame>
-			<!-- Cadre Titre -->
-			<Frame name="$parentTopFrame" inherits="TRP3_ThinDialogBackdropTemplate">
-				<Size x="80" y="25" />
-				<Anchors>
-					<Anchor point="TOP" x="0" y="0" />
-				</Anchors>
-				<Layers>
-					<Layer level="OVERLAY">
-						<FontString name="$parentText" inherits="GameFontNormalSmall" justifyH="CENTER">
-							<Anchors>
-								<Anchor point="CENTER" x="0" y="0" />
-							</Anchors>
-							<Color r="0.95" g="0.95" b="0.95" />
-						</FontString>
-					</Layer>
-				</Layers>
-			</Frame>
-		</Frames>
-	</Frame>
-
 	<Include file="Toolbar.lua"/>
-
 </Ui>

--- a/totalRP3/Modules/Toolbar/Toolbar.xml
+++ b/totalRP3/Modules/Toolbar/Toolbar.xml
@@ -5,8 +5,16 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<!-- Toolbar button -->
-	<Button name="TRP3_ToolbarButtonTemplate" inherits="TRP3_BorderedIconButtonTemplate" virtual="true">
-		<Size x="30" y="30" />
+	<Button name="TRP3_ToolbarButtonTemplate" mixin="TRP3_ToolbarButtonMixin" inherits="TRP3_BorderedIconButtonTemplate" registerForClicks="LeftButtonUp, RightButtonUp" virtual="true">
+		<Size x="30" y="30"/>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+			<OnShow method="OnShow"/>
+			<OnClick method="OnClick"/>
+			<OnEnter method="OnEnter"/>
+			<OnLeave method="OnLeave"/>
+			<OnUpdate method="OnUpdate"/>
+		</Scripts>
 	</Button>
 
 	<!-- Toolbar -->

--- a/totalRP3/Modules/Toolbar/ToolbarButton.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarButton.lua
@@ -119,6 +119,10 @@ function TRP3_ToolbarButtonMixin:SetElementData(elementData)
 	self:MarkDirty();
 end
 
+function TRP3_ToolbarButtonMixin:Update()
+	self:MarkDirty();
+end
+
 function TRP3_ToolbarButtonMixin:UpdateImmediately()
 	self:MarkClean();
 

--- a/totalRP3/Modules/Toolbar/ToolbarButton.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarButton.lua
@@ -1,0 +1,140 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_ToolbarButtonMixin = CreateFromMixins(TRP3_TooltipScriptMixin);
+
+function TRP3_ToolbarButtonMixin:OnLoad()
+	self.timeSinceLastUpdate = math.huge;
+end
+
+function TRP3_ToolbarButtonMixin:OnShow()
+	self:MarkDirty();
+end
+
+function TRP3_ToolbarButtonMixin:OnHide()
+	self:SetElementData(nil);
+end
+
+function TRP3_ToolbarButtonMixin:OnClick(mouseButtonName)
+	local elementData = self:GetElementData();
+
+	if not elementData or not elementData.onClick then
+		return;
+	end
+
+	securecallfunction(elementData.onClick, self, elementData, mouseButtonName);
+
+	-- Clicks often end up invalidating models, so see if we can do so to
+	-- improve responsiveness of some buttons.
+
+	if elementData.onModelUpdate then
+		securecallfunction(elementData.onModelUpdate, elementData);
+		self:MarkDirty();
+	end
+end
+
+function TRP3_ToolbarButtonMixin:OnEnter()
+	local elementData = self:GetElementData();
+
+	if not elementData then
+		return;
+	end
+
+	if elementData.onEnter then
+		securecallfunction(elementData.onEnter, self, elementData);
+	else
+		TRP3_TooltipScriptMixin.OnEnter(self);
+	end
+end
+
+function TRP3_ToolbarButtonMixin:OnLeave()
+	local elementData = self:GetElementData();
+
+	if not elementData then
+		return;
+	end
+
+	if elementData.onLeave then
+		securecallfunction(elementData.onLeave, self, elementData);
+	else
+		TRP3_TooltipScriptMixin.OnLeave(self);
+	end
+end
+
+function TRP3_ToolbarButtonMixin:OnUpdate(elapsed)
+	local elementData = self:GetElementData();
+
+	if not elementData then
+		return;
+	end
+
+	self.timeSinceLastUpdate = self.timeSinceLastUpdate + elapsed;
+
+	if self.timeSinceLastUpdate < 0.2 then
+		return;
+	end
+
+	if elementData.onUpdate then
+		securecallfunction(elementData.onUpdate, self, elementData);
+	end
+
+	self:MarkClean();
+	self:UpdateImmediately();
+end
+
+function TRP3_ToolbarButtonMixin:OnTooltipShow(description)
+	local elementData = self:GetElementData();
+
+	if not elementData then
+		return;
+	end
+
+	local title = TRP3_ToolbarUtil.GetFormattedTooltipTitle(elementData);
+	local text = elementData.tooltipSub;
+	local instructions = elementData.tooltipInstructions;
+
+	TRP3_TooltipTemplates.CreateInstructionTooltip(description, title, text, instructions);
+
+	-- Tooltip anchoring is special as we want to dodge screen edges without
+	-- overlapping the bar.
+
+	local toolbarAnchor = TRP3_ToolbarUtil.GetToolbarAnchor();
+	local anchor = "ANCHOR_TOP";
+	local offsetX = 0;
+	local offsetY = 5;
+
+	if string.find(toolbarAnchor.point, "^TOP") then
+		anchor = "ANCHOR_BOTTOM";
+		offsetY = -offsetY;
+	end
+
+	description:SetAnchorWithOffset(anchor, offsetX, offsetY);
+end
+
+function TRP3_ToolbarButtonMixin:GetElementData()
+	return self.elementData;
+end
+
+function TRP3_ToolbarButtonMixin:SetElementData(elementData)
+	self.elementData = elementData;
+	self:MarkDirty();
+end
+
+function TRP3_ToolbarButtonMixin:UpdateImmediately()
+	local elementData = self:GetElementData();
+
+	if not elementData then
+		return;
+	end
+
+	self:SetIconTexture(elementData.icon);
+	self:RefreshTooltip();
+end
+
+function TRP3_ToolbarButtonMixin:MarkDirty()
+	self.timeSinceLastUpdate = math.huge;
+end
+
+function TRP3_ToolbarButtonMixin:MarkClean()
+	self.timeSinceLastUpdate = 0;
+end

--- a/totalRP3/Modules/Toolbar/ToolbarButton.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarButton.lua
@@ -78,7 +78,6 @@ function TRP3_ToolbarButtonMixin:OnUpdate(elapsed)
 		securecallfunction(elementData.onUpdate, self, elementData);
 	end
 
-	self:MarkClean();
 	self:UpdateImmediately();
 end
 
@@ -121,6 +120,8 @@ function TRP3_ToolbarButtonMixin:SetElementData(elementData)
 end
 
 function TRP3_ToolbarButtonMixin:UpdateImmediately()
+	self:MarkClean();
+
 	local elementData = self:GetElementData();
 
 	if not elementData then

--- a/totalRP3/Modules/Toolbar/ToolbarButton.xml
+++ b/totalRP3/Modules/Toolbar/ToolbarButton.xml
@@ -1,0 +1,20 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="ToolbarButton.lua"/>
+
+	<Button name="TRP3_ToolbarButtonTemplate" mixin="TRP3_ToolbarButtonMixin" inherits="TRP3_BorderedIconButtonTemplate" registerForClicks="LeftButtonUp, RightButtonUp" virtual="true">
+		<Size x="30" y="30"/>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+			<OnShow method="OnShow"/>
+			<OnClick method="OnClick"/>
+			<OnEnter method="OnEnter"/>
+			<OnLeave method="OnLeave"/>
+			<OnUpdate method="OnUpdate"/>
+		</Scripts>
+	</Button>
+</Ui>

--- a/totalRP3/Modules/Toolbar/ToolbarConstants.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarConstants.lua
@@ -1,0 +1,12 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_ToolbarConfigKeys = {
+	AnchorOffsetX = "CONFIG_TOOLBAR_POS_X",
+	AnchorOffsetY = "CONFIG_TOOLBAR_POS_Y",
+	AnchorPoint = "CONFIG_TOOLBAR_POS_A",
+	ButtonSize = "toolbar_icon_size",
+	HideTitle = "toolbar_hide_title",
+	RowSize = "toolbar_max_per_line",
+	Visibility = "toolbar_visibility",
+};

--- a/totalRP3/Modules/Toolbar/ToolbarConstants.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarConstants.lua
@@ -5,8 +5,19 @@ TRP3_ToolbarConfigKeys = {
 	AnchorOffsetX = "CONFIG_TOOLBAR_POS_X",
 	AnchorOffsetY = "CONFIG_TOOLBAR_POS_Y",
 	AnchorPoint = "CONFIG_TOOLBAR_POS_A",
-	ButtonSize = "toolbar_icon_size",
+	ButtonExtent = "toolbar_icon_size",
+	ButtonStride = "toolbar_max_per_line",
 	HideTitle = "toolbar_hide_title",
-	RowSize = "toolbar_max_per_line",
 	Visibility = "toolbar_visibility",
+};
+
+TRP3_ToolbarVisibilityOption = {
+	AlwaysShow = 1,
+	OnlyShowInCharacter = 2,
+	AlwaysHidden = 3,
+};
+
+TRP3_ToolbarConstants = {
+	-- Additional internal padding added to each button to accomodate borders.
+	ButtonExtraExtent = 8,
 };

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.lua
@@ -149,7 +149,7 @@ end
 
 function TRP3_ToolbarFrameMixin:UpdateTitleBar()
 	self.TitleBar.Text:SetText(TRP3_API.globals.addon_name);
-	self.TitleBar:SetShown(TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.HideTitle));
+	self.TitleBar:SetShown(not TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.HideTitle));
 end
 
 function TRP3_ToolbarFrameMixin:LoadPosition()

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.lua
@@ -9,7 +9,7 @@ function TRP3_ToolbarFrameMixin:Init()
 
 	self:LoadPosition();
 	self:UpdateFrameVisibility();
-	self:UpdateTitleVisibility();
+	self:UpdateTitleBar();
 end
 
 function TRP3_ToolbarFrameMixin:OnLoad()
@@ -46,7 +46,7 @@ function TRP3_ToolbarFrameMixin:OnConfigurationChanged(_, key)
 	if key == TRP3_ToolbarConfigKeys.Visibility then
 		self:UpdateFrameVisibility();
 	elseif key == TRP3_ToolbarConfigKeys.HideTitle then
-		self:UpdateTitleVisibility();
+		self:UpdateTitleBar();
 	end
 end
 
@@ -81,16 +81,23 @@ function TRP3_ToolbarFrameMixin:UpdateButtons()
 		table.insert(buttons, button);
 	end
 
-	local direction = GridLayoutMixin.Direction.TopLeftToBottomRight;
-	local stride = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.ButtonStride);
-	local spacingX = 0;
-	local spacingY = 0;
+	if #buttons > 0 then
+		local direction = GridLayoutMixin.Direction.TopLeftToBottomRight;
+		local stride = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.ButtonStride);
+		local spacingX = 0;
+		local spacingY = 0;
 
-	local initialAnchor = AnchorUtil.CreateAnchor("TOPLEFT", self.Container, "TOPLEFT", 8, -8);
-	local layout = AnchorUtil.CreateGridLayout(direction, stride, spacingX, spacingY);
+		local initialAnchor = AnchorUtil.CreateAnchor("TOPLEFT", self.Container, "TOPLEFT", 8, -8);
+		local layout = AnchorUtil.CreateGridLayout(direction, stride, spacingX, spacingY);
 
-	AnchorUtil.GridLayout(buttons, initialAnchor, layout);
-	self.Container:Layout();
+		AnchorUtil.GridLayout(buttons, initialAnchor, layout);
+		self.Container:Layout();
+		self.Container:Show();
+	else
+		self.Container:Hide();
+	end
+
+	self:Layout();
 end
 
 function TRP3_ToolbarFrameMixin:GetDataProvider()
@@ -140,9 +147,9 @@ function TRP3_ToolbarFrameMixin:UpdateFrameVisibility(forcedVisibility)
 	self:SetShown(shouldShow);
 end
 
-function TRP3_ToolbarFrameMixin:UpdateTitleVisibility()
-	self.Title.Text:SetText(TRP3_API.globals.addon_name);
-	self.Title:SetShown(TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.HideTitle));
+function TRP3_ToolbarFrameMixin:UpdateTitleBar()
+	self.TitleBar.Text:SetText(TRP3_API.globals.addon_name);
+	self.TitleBar:SetShown(TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.HideTitle));
 end
 
 function TRP3_ToolbarFrameMixin:LoadPosition()
@@ -157,4 +164,21 @@ function TRP3_ToolbarFrameMixin:SavePosition()
 	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorPoint, anchor);
 	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorOffsetX, x);
 	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorOffsetY, y);
+end
+
+function TRP3_ToolbarFrameMixin:Layout()
+	local width = 0;
+	local height = 0;
+
+	if self.TitleBar:IsShown() then
+		width = math.max(width, self.TitleBar:GetWidth());
+		height = height + self.TitleBar:GetHeight();
+	end
+
+	if self.Container:IsShown() then
+		width = math.max(width, self.Container:GetWidth());
+		height = height + self.Container:GetHeight();
+	end
+
+	self:SetSize(width, height);
 end

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.lua
@@ -1,0 +1,160 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_ToolbarFrameMixin = {};
+
+function TRP3_ToolbarFrameMixin:Init()
+	TRP3_Addon.RegisterCallback(self, "CONFIGURATION_CHANGED", "OnConfigurationChanged");
+	TRP3_Addon.RegisterCallback(self, "ROLEPLAY_STATUS_CHANGED", "OnRoleplayStatusChanged");
+
+	self:LoadPosition();
+	self:UpdateFrameVisibility();
+	self:UpdateTitleVisibility();
+end
+
+function TRP3_ToolbarFrameMixin:OnLoad()
+	self.buttonPool = CreateFramePool("Button", self.Container, "TRP3_ToolbarButtonTemplate");
+	self.buttonDataProvider = nil;
+end
+
+function TRP3_ToolbarFrameMixin:OnShow()
+	self:MarkDirty();
+end
+
+function TRP3_ToolbarFrameMixin:OnUpdate()
+	self:UpdateButtons();
+end
+
+function TRP3_ToolbarFrameMixin:OnDragStart()
+	self:StartMoving();
+end
+
+function TRP3_ToolbarFrameMixin:OnDragStop()
+	self:StopMovingOrSizing();
+	self:SavePosition();
+end
+
+function TRP3_ToolbarFrameMixin:OnRoleplayStatusChanged()
+	local configuredVisibility = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.Visibility);
+
+	if configuredVisibility == TRP3_ToolbarVisibilityOption.OnlyShowInCharacter then
+		self:UpdateFrameVisibility();
+	end
+end
+
+function TRP3_ToolbarFrameMixin:OnConfigurationChanged(_, key)
+	if key == TRP3_ToolbarConfigKeys.Visibility then
+		self:UpdateFrameVisibility();
+	elseif key == TRP3_ToolbarConfigKeys.HideTitle then
+		self:UpdateTitleVisibility();
+	end
+end
+
+function TRP3_ToolbarFrameMixin:MarkDirty()
+	self:SetScript("OnUpdate", self.UpdateButtons);
+end
+
+function TRP3_ToolbarFrameMixin:MarkClean()
+	self:SetScript("OnUpdate", nil);
+end
+
+function TRP3_ToolbarFrameMixin:UpdateButtons()
+	local provider = self:GetDataProvider();
+	local pool = self.buttonPool;
+
+	self:MarkClean();
+	pool:ReleaseAll();
+
+	if not provider or not self:IsShown() then
+		return;
+	end
+
+	local buttons = {};
+	local extent = TRP3_ToolbarUtil.GetToolbarButtonExtent();
+
+	for _, elementData in provider:EnumerateEntireRange() do
+		local button = pool:Acquire();
+		button:SetElementData(elementData);
+		button:SetSize(extent, extent);
+		button:Show();
+
+		table.insert(buttons, button);
+	end
+
+	local direction = GridLayoutMixin.Direction.TopLeftToBottomRight;
+	local stride = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.ButtonStride);
+	local spacingX = 0;
+	local spacingY = 0;
+
+	local initialAnchor = AnchorUtil.CreateAnchor("TOPLEFT", self.Container, "TOPLEFT", 8, -8);
+	local layout = AnchorUtil.CreateGridLayout(direction, stride, spacingX, spacingY);
+
+	AnchorUtil.GridLayout(buttons, initialAnchor, layout);
+	self.Container:Layout();
+end
+
+function TRP3_ToolbarFrameMixin:GetDataProvider()
+	return self.buttonDataProvider;
+end
+
+function TRP3_ToolbarFrameMixin:RemoveDataProvider()
+	self.buttonDataProvider = nil;
+	self.buttonPool:ReleaseAll();
+end
+
+function TRP3_ToolbarFrameMixin:SetDataProvider(provider)
+	self.buttonDataProvider = provider;
+	self:MarkDirty();
+end
+
+function TRP3_ToolbarFrameMixin:RefreshButtons()
+	for button in self.buttonPool:EnumerateActive() do
+		button:MarkDirty();
+	end
+end
+
+function TRP3_ToolbarFrameMixin:Toggle()
+	self:UpdateFrameVisibility(not self:IsShown());
+
+	if self:IsShown() then
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPEN);
+	else
+		PlaySound(SOUNDKIT.IG_MAINMENU_CLOSE);
+	end
+end
+
+function TRP3_ToolbarFrameMixin:UpdateFrameVisibility(forcedVisibility)
+	local configuredVisibility = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.Visibility);
+	local shouldShow;
+
+	if forcedVisibility ~= nil then
+		shouldShow = forcedVisibility;
+	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.AlwaysHidden then
+		shouldShow = false;
+	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.OnlyShowInCharacter then
+		shouldShow = AddOn_TotalRP3.Player.GetCurrentUser():IsInCharacter();
+	else
+		shouldShow = true;
+	end
+
+	self:SetShown(shouldShow);
+end
+
+function TRP3_ToolbarFrameMixin:UpdateTitleVisibility()
+	self.Title.Text:SetText(TRP3_API.globals.addon_name);
+	self.Title:SetShown(TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.HideTitle));
+end
+
+function TRP3_ToolbarFrameMixin:LoadPosition()
+	local anchor = TRP3_ToolbarUtil.GetToolbarAnchor();
+
+	self:ClearAllPoints();
+	self:SetPoint(anchor:Get());
+end
+
+function TRP3_ToolbarFrameMixin:SavePosition()
+	local anchor, _, _, x, y = self:GetPoint(1);
+	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorPoint, anchor);
+	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorOffsetX, x);
+	TRP3_API.configuration.setValue(TRP3_ToolbarConfigKeys.AnchorOffsetY, y);
+end

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.xml
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.xml
@@ -1,0 +1,52 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="ToolbarFrame.lua"/>
+
+	<Frame name="TRP3_ToolbarFrameTemplate" mixin="TRP3_ToolbarFrameMixin" toplevel="true" enableMouse="true" clampedToScreen="true" registerForDrag="LeftButton" movable="true" dontSavePosition="true" virtual="true">
+		<Size x="190" y="60"/>
+		<Frames>
+			<Frame parentKey="Title" inherits="TRP3_ThinDialogBackdropTemplate">
+				<Size x="80" y="25"/>
+				<Anchors>
+					<Anchor point="TOP"/>
+				</Anchors>
+				<Layers>
+					<Layer level="OVERLAY">
+						<FontString parentKey="Text" inherits="GameFontHighlightSmall" justifyH="CENTER" wordwrap="false">
+							<Anchors>
+								<Anchor point="LEFT" x="4"/>
+								<Anchor point="RIGHT" x="-4"/>
+							</Anchors>
+						</FontString>
+					</Layer>
+				</Layers>
+			</Frame>
+			<Frame parentKey="Container" inherits="ResizeLayoutFrame">
+				<KeyValues>
+					<KeyValue key="heightPadding" value="16" type="number"/>
+					<KeyValue key="widthPadding" value="16" type="number"/>
+				</KeyValues>
+				<Anchors>
+					<Anchor point="TOP" y="-18"/>
+				</Anchors>
+				<Frames>
+					<Frame parentKey="Backdrop" inherits="TRP3_ThinDialogBackdropTemplate" useParentLevel="true" setAllPoints="true">
+						<KeyValues>
+							<KeyValue key="ignoreInLayout" value="true" type="boolean"/>
+						</KeyValues>
+					</Frame>
+				</Frames>
+			</Frame>
+		</Frames>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+			<OnShow method="OnShow"/>
+			<OnDragStart method="OnDragStart"/>
+			<OnDragStop method="OnDragStop"/>
+		</Scripts>
+	</Frame>
+</Ui>

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.xml
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.xml
@@ -9,7 +9,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Frame name="TRP3_ToolbarFrame" mixin="TRP3_ToolbarFrameMixin" parent="UIParent" toplevel="true" enableMouse="true" clampedToScreen="true" registerForDrag="LeftButton" movable="true" dontSavePosition="true" hidden="true">
 		<Size x="190" y="60"/>
 		<Frames>
-			<Frame parentKey="Title" inherits="TRP3_ThinDialogBackdropTemplate">
+			<Frame parentKey="TitleBar" inherits="TRP3_ThinDialogBackdropTemplate">
 				<Size x="80" y="25"/>
 				<Anchors>
 					<Anchor point="TOP"/>

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.xml
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.xml
@@ -6,7 +6,7 @@
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="ToolbarFrame.lua"/>
 
-	<Frame name="TRP3_ToolbarFrameTemplate" mixin="TRP3_ToolbarFrameMixin" toplevel="true" enableMouse="true" clampedToScreen="true" registerForDrag="LeftButton" movable="true" dontSavePosition="true" virtual="true">
+	<Frame name="TRP3_ToolbarFrame" mixin="TRP3_ToolbarFrameMixin" parent="UIParent" toplevel="true" enableMouse="true" clampedToScreen="true" registerForDrag="LeftButton" movable="true" dontSavePosition="true" hidden="true">
 		<Size x="190" y="60"/>
 		<Frames>
 			<Frame parentKey="Title" inherits="TRP3_ThinDialogBackdropTemplate">

--- a/totalRP3/Modules/Toolbar/ToolbarUtil.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarUtil.lua
@@ -18,3 +18,10 @@ function TRP3_ToolbarUtil.GetToolbarAnchor()
 
 	return AnchorUtil.CreateAnchor(point, relativeTo, relativePoint, offsetX, offsetY);
 end
+
+function TRP3_ToolbarUtil.GetToolbarButtonExtent()
+	local configuredExtent = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.ButtonExtent);
+	local extraExtent = TRP3_ToolbarConstants.ButtonExtraExtent;
+
+	return configuredExtent + extraExtent;
+end

--- a/totalRP3/Modules/Toolbar/ToolbarUtil.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarUtil.lua
@@ -1,0 +1,20 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_ToolbarUtil = {};
+
+function TRP3_ToolbarUtil.GetFormattedTooltipTitle(elementData)
+	local icon = TRP3_MarkupUtil.GenerateIconMarkup(elementData.icon, { size = 32 });
+	local text = elementData.tooltip or elementData.configText;
+	return string.trim(string.join(" ", icon, text));
+end
+
+function TRP3_ToolbarUtil.GetToolbarAnchor()
+	local point = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.AnchorPoint);
+	local relativeTo = UIParent;
+	local relativePoint = point;
+	local offsetX = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.AnchorOffsetX);
+	local offsetY = TRP3_API.configuration.getValue(TRP3_ToolbarConfigKeys.AnchorOffsetY);
+
+	return AnchorUtil.CreateAnchor(point, relativeTo, relativePoint, offsetX, offsetY);
+end

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -151,7 +151,7 @@ TRP3_API.module.registerModule({
 			function skinFrame(skinnableFrames)
 				-- Go through each skinnable frames from our table
 				for _, frameName in pairs(skinnableFrames) do
-					local frame = ResolveFrame(_G, string.split(frameName, "."));
+					local frame = ResolveFrame(_G, string.split(".", frameName));
 
 					if frame then
 						TT:SecureHookScript(frame, 'OnShow', SetStyleForFrame);

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -62,9 +62,9 @@ TRP3_API.module.registerModule({
 		}
 
 		local SKINNABLE_TOOLBAR_FRAMES = {
-			"TRP3_Toolbar",
-			"TRP3_Toolbar.Container.Backdrop",
-			"TRP3_Toolbar.Title",
+			"TRP3_ToolbarFrame",
+			"TRP3_ToolbarFrame.Container.Backdrop",
+			"TRP3_ToolbarFrame.Title",
 		}
 
 		TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()
@@ -155,6 +155,10 @@ TRP3_API.module.registerModule({
 
 					if frame then
 						TT:SecureHookScript(frame, 'OnShow', SetStyleForFrame);
+
+						if frame:IsShown() then
+							SetStyleForFrame(frame);
+						end
 					end
 				end
 			end
@@ -174,11 +178,6 @@ TRP3_API.module.registerModule({
 			end
 			if TRP3_API.configuration.getValue(CONFIG.SKIN_TOOLBAR_FRAME) then
 				skinFrame(SKINNABLE_TOOLBAR_FRAMES);
-
-				if TRP3_Toolbar:IsShown() then
-					TRP3_Toolbar:Hide();
-					TRP3_Toolbar:Show();
-				end
 			end
 
 			-- Adjusting the default border color to be black for ElvUI tooltips

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -64,7 +64,7 @@ TRP3_API.module.registerModule({
 		local SKINNABLE_TOOLBAR_FRAMES = {
 			"TRP3_ToolbarFrame",
 			"TRP3_ToolbarFrame.Container.Backdrop",
-			"TRP3_ToolbarFrame.Title",
+			"TRP3_ToolbarFrame.TitleBar",
 		}
 
 		TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -63,7 +63,7 @@ TRP3_API.module.registerModule({
 
 		local SKINNABLE_TOOLBAR_FRAMES = {
 			"TRP3_Toolbar",
-			"TRP3_Toolbar.Container",
+			"TRP3_Toolbar.Container.Backdrop",
 			"TRP3_Toolbar.Title",
 		}
 

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -5,6 +5,16 @@
 local _, TRP3_API = ...;
 local loc = TRP3_API.loc;
 
+local function ResolveFrame(tbl, name, ...)
+	local frame = tbl[name];
+
+	if frame and ... then
+		return ResolveFrame(frame, ...);
+	else
+		return frame;
+	end
+end
+
 TRP3_API.module.registerModule({
 	["name"] = "ElvUI",
 	["id"] = "trp3_elvui",
@@ -53,8 +63,8 @@ TRP3_API.module.registerModule({
 
 		local SKINNABLE_TOOLBAR_FRAMES = {
 			"TRP3_Toolbar",
-			"TRP3_ToolbarContainer",
-			"TRP3_ToolbarTopFrame",
+			"TRP3_Toolbar.Container",
+			"TRP3_Toolbar.Title",
 		}
 
 		TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()
@@ -140,17 +150,11 @@ TRP3_API.module.registerModule({
 
 			function skinFrame(skinnableFrames)
 				-- Go through each skinnable frames from our table
-				for _, frame in pairs(skinnableFrames) do
-					local parentKey;
-					frame, parentKey = string.split(".", frame, 2);
+				for _, frameName in pairs(skinnableFrames) do
+					local frame = ResolveFrame(_G, string.split(frameName, "."));
 
-					if _G[frame] then
-						-- If parentKey is not nil, check if a frame exists with said parentKey within this frame
-						if parentKey ~= nil and _G[frame][parentKey] then
-							TT:SecureHookScript(_G[frame][parentKey], 'OnShow', SetStyleForFrame);
-						elseif parentKey == nil then
-							TT:SecureHookScript(_G[frame], 'OnShow', SetStyleForFrame);
-						end
+					if frame then
+						TT:SecureHookScript(frame, 'OnShow', SetStyleForFrame);
 					end
 				end
 			end

--- a/totalRP3/Resources/InterfaceIcons.lua
+++ b/totalRP3/Resources/InterfaceIcons.lua
@@ -50,8 +50,8 @@ TRP3_InterfaceIcons = {
 	--
 
 	ToolbarNPCTalk    = { "ability_warrior_commandingshout" },
-	ToolbarStatusIC   = { "Inv_collections_armor_hood_b_01_green", "spell_shadow_charm" },
-	ToolbarStatusOOC  = { "Inv_collections_armor_hood_b_01_red", "achievement_guildperk_everybodysfriend" },
+	ToolbarStatusIC   = { "Inv_collections_armor_hood_b_01_white", "spell_shadow_charm" },
+	ToolbarStatusOOC  = { "Inv_collections_armor_hood_b_01_black", "achievement_guildperk_everybodysfriend" },
 	ToolbarCloakOn    = { "inv_misc_cape_18" },
 	ToolbarCloakOff   = { "inv_misc_cape_20" },
 	ToolbarHelmetOn   = { "inv_helmet_13" },

--- a/totalRP3/UI/Tooltip/Tooltip.lua
+++ b/totalRP3/UI/Tooltip/Tooltip.lua
@@ -324,13 +324,14 @@ function TooltipDescription:SetAnchor(anchor)
 	self.anchor = anchor or "ANCHOR_RIGHT";
 end
 
-function TooltipDescription:GetAnchorOffset()
-	return self.anchorOffsetX, self.anchorOffsetY;
-end
-
-function TooltipDescription:GetAnchorOffset(offsetX, offsetY)
+function TooltipDescription:SetAnchorWithOffset(anchor, offsetX, offsetY)
+	self.anchor = anchor or "ANCHOR_RIGHT";
 	self.anchorOffsetX = tonumber(offsetX or 0);
 	self.anchorOffsetY = tonumber(offsetY or 0);
+end
+
+function TooltipDescription:GetAnchorOffset()
+	return self.anchorOffsetX, self.anchorOffsetY;
 end
 
 function TooltipDescription:AddPreTooltipCallback(callback)

--- a/totalRP3/UI/Tooltip/TooltipTemplates.lua
+++ b/totalRP3/UI/Tooltip/TooltipTemplates.lua
@@ -93,8 +93,10 @@ function TRP3_TooltipTemplates.CreateInstructionTooltip(description, title, text
 		description:QueueBlankLine();
 	end
 
-	for _, instruction in ipairs(instructions) do
-		description:AddInstructionLine(instruction[1], instruction[2]);
+	if instructions then
+		for _, instruction in ipairs(instructions) do
+			description:AddInstructionLine(instruction[1], instruction[2]);
+		end
 	end
 end
 


### PR DESCRIPTION
What begun as a simple foray into making the IC/OOC icons less problematic for people who suffer from colorblindness escalated into a discovery that the hacks around padding icons in the layout logic of the toolbar were absolute nonsense that didn't work unless you had the exact number of buttons on the toolbar that we seem to enable by default, and with the same row size as the default.

So I basically said "fuck this" and rewrote most of the toolbar code to properly separate out all the responsibilities. Buttons now have mixins and are responsible for handling all their own stuff themselves without requiring us to basically micromanage their displays from five different locations of the main toolbar script. The toolbar frame itself outsources the layout logic to a combination of ResizeLayoutFrame and AnchorUtil.GridLayout, completely solving the woes with the added button padding.

A few notable changes:

- Removed onMouseDown support from toolbar buttons to try and force us into consistently using onClick handlers.
- Added untested support for a `tooltipInstructions` key to button descriptions that can be used to populate tooltip instruction lines without having to do the stupid amounts of string concatenation logic that we're doing elsewhere.
- The tooltip code is using our new TooltipScriptMixin and tooltip description logic. Yay.

Note that this isn't the full toolbar rewrite from ages back, but it gets us like 50% of the way there and will make implementing button reordering and drag-drop a bit easier.