### PR TITLE
Defer combat status toggle by one frame

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -422,8 +422,12 @@ function TRP3_NamePlates:OnUnitNameUpdate(unitToken)
 end
 
 function TRP3_NamePlates:OnCombatStatusChanged()
-	isInCombat = InCombatLockdown();
-	self:UpdateAllNamePlates();
+	local function OnTick()
+		isInCombat = InCombatLockdown();
+		self:UpdateAllNamePlates();
+	end
+
+	C_Timer.After(0, OnTick);
 end
 
 function TRP3_NamePlates:OnPlayerEnteringWorld()


### PR DESCRIPTION
I'm 90% sure the logic for our combat status change detection historically did defer the InCombatLockdown query to the next frame, but seemingly that was either removed at some point or I'm completely mistaken.

Probably fixes #1111.