### PR TITLE
Fix constant related error in pet browser

### DIFF
--- a/totalRP3/UI/Browsers/PetBrowser.lua
+++ b/totalRP3/UI/Browsers/PetBrowser.lua
@@ -37,7 +37,9 @@ local function GetPetCompanionProfile(petName)
 end
 
 local function GetNumPetSlots()
-	return Constants.PetConsts.NUM_PET_SLOTS;
+	-- Blizzard can't decide on a consistent or sane naming scheme that lasts
+	-- more than a single patch.
+	return 200;
 end
 
 local function IsValidPetSlot(slotIndex)


### PR DESCRIPTION
Blizzard keep renaming the constants used to determine the number of pet slots a hunter can have, so we're just going to hardcode it and hope they never bother to add more stable slots.