### PR TITLE
Small tweaks to CO/CU debouncing on Misc page

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -392,6 +392,22 @@ local function onOOCInfoChanged()
 	player:SetOutOfCharacterInfo(text);
 end
 
+local UpdateCurrentlyText = TRP3_FunctionUtil.Debounce(0.2, onCurrentlyChanged);
+
+local function OnCurrentlyTextChanged(_, userInput)
+	if userInput then
+		UpdateCurrentlyText();
+	end
+end
+
+local UpdateOOCText = TRP3_FunctionUtil.Debounce(0.2, onOOCInfoChanged);
+
+local function OnOOCTextChanged(_, userInput)
+	if userInput then
+		UpdateOOCText();
+	end
+end
+
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Misc logic
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -497,11 +513,11 @@ function TRP3_API.register.inits.miscInit()
 
 	TRP3_RegisterMiscViewCurrentlyIC.Title:SetText(loc.DB_STATUS_CURRENTLY);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyIC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY, loc.DB_STATUS_CURRENTLY_TT);
-	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.5, onCurrentlyChanged), {});
+	TRP3_RegisterMiscViewCurrentlyIC:RegisterCallback("OnTextChanged", OnCurrentlyTextChanged);
 
 	TRP3_RegisterMiscViewCurrentlyOOC.Title:SetText(loc.DB_STATUS_CURRENTLY_OOC);
 	setTooltipForSameFrame(TRP3_RegisterMiscViewCurrentlyOOC.HelpButton, "RIGHT", 0, 5, loc.DB_STATUS_CURRENTLY_OOC, loc.DB_STATUS_CURRENTLY_OOC_TT);
-	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", TRP3_FunctionUtil.Debounce(0.5, onOOCInfoChanged), {});
+	TRP3_RegisterMiscViewCurrentlyOOC:RegisterCallback("OnTextChanged", OnOOCTextChanged);
 
 	setTooltipForSameFrame(TRP3_RegisterMiscViewGlanceHelp, "RIGHT", 0, 5, loc.REG_PLAYER_GLANCE, TRP3_API.register.glance.addClickHandlers(loc.REG_PLAYER_GLANCE_CONFIG));
 


### PR DESCRIPTION
Ensure that we only process changes to the fields that are initiated via user input rather than both input and SetText calls. This *may* resolve an edge case where the CO/CU fields from other profiles could be copied to the user's own profile.

Additionally, lower the debounce timeout to 0.2s for this page specifically. With 0.5s it's possible in some cases to type input, open another profile, and lose your input. Ideally we'd flush the input when the page is hidden but that's more effort than this code deserves, so tightening it to 0.2s feels a bit more sane.