### PR TITLE
Fix pin button passthrough for 11.0.2

### DIFF
--- a/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapPin.lua
+++ b/totalRP3/Modules/Register/Characters/PlayerMapScan/PlayerMapPin.lua
@@ -154,3 +154,9 @@ function TRP3_PlayerMapPinMixin:OnTooltipAboutToShow(tooltip)
 	tooltip:AddTempLine([[|TInterface\Common\UI-TooltipDivider-Transparent:8:128:0:0:8:8:0:128:0:8:255:255:255|t]]);
 	tooltip:AddTempLine(TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.CL_OPEN_PROFILE), WHITE_FONT_COLOR);
 end
+
+function TRP3_PlayerMapPinMixin:CheckMouseButtonPassthrough()
+	-- Intentional no-op; this is called by Blizzard *after* pin acquisition
+	-- logic and would reset explicit configuration of our button passthrough
+	-- in the OnAcquire handler.
+end


### PR DESCRIPTION
Blizzard changed the logic for map pins such that they attempt to configure button passthrough *after* the OnAcquire method is called on the pin.

This causes issues with our player map scan as we only respond to right-clicks for that pin, and disable the passthrough in its OnAcquire handler. Blizzard then goes and resets the passthrough to include right-clicks again, thus eliminating our change entirely.

To resolve this we can just nop out the CheckMouseButtonPassthrough method which is called by Blizzard to apply the passthrough change on their end.