### PR TITLE
Color swatch tweaks

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -431,23 +431,12 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						<OnLeave method="OnLeave"/>
 					</Scripts>
 				</FontString>
-			</Layer>
-		</Layers>
-		<Frames>
-			<Frame parentKey="Swatch" mixin="TRP3_RegisterColorSwatchMixin" inherits="TRP3_ColorSwatchTemplate, TRP3_TooltipScriptTemplate">
-				<Anchors>
-					<Anchor point="LEFT" relativeKey="$parent.Title" relativePoint="RIGHT" x="15"/>
-				</Anchors>
-			</Frame>
-		</Frames>
-		<Layers>
-			<Layer level="OVERLAY">
 				<FontString parentKey="Value" inherits="GameFontHighlight" mixin="TRP3_ReadableTextMixin, TRP3_TruncatedTextMixin" justifyH="LEFT" wordwrap="false">
 					<KeyValues>
 						<KeyValue key="readableTextBackgroundColor" value="TRP3_PARCHMENT_BACKGROUND_COLOR" type="global"/>
 					</KeyValues>
 					<Anchors>
-						<Anchor point="LEFT" relativeKey="$parent.Swatch" relativePoint="RIGHT" x="5"/>
+						<Anchor point="LEFT" relativeKey="$parent.Title" relativePoint="RIGHT" x="15"/>
 						<Anchor point="RIGHT"/>
 					</Anchors>
 					<Scripts>
@@ -457,6 +446,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</FontString>
 			</Layer>
 		</Layers>
+		<Frames>
+			<Frame parentKey="Swatch" mixin="TRP3_RegisterColorSwatchMixin" inherits="TRP3_ColorSwatchTemplate, TRP3_TooltipScriptTemplate">
+				<Anchors>
+					<Anchor point="RIGHT" relativeKey="$parent.Value" relativePoint="LEFT" x="-5"/>
+				</Anchors>
+			</Frame>
+		</Frames>
 		<Scripts>
 			<OnLoad method="OnLoad"/>
 			<OnSizeChanged method="OnSizeChanged"/>

--- a/totalRP3/Modules/Register/Main/RegisterTemplates.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTemplates.lua
@@ -110,13 +110,11 @@ end
 function TRP3_RegisterInfoSwatchLineMixin:SetValueColor(color)
 	if color then
 		self.Value:SetReadableTextColor(color);
-		self.Value:SetPoint("LEFT", self.Swatch, "RIGHT", 5, 0);
 		self.Swatch:SetColor(color);
 		self.Swatch:SetShowContrastTooltip(not TRP3_API.IsColorReadable(color, TRP3_PARCHMENT_BACKGROUND_COLOR));
 		self.Swatch:Show();
 	else
 		self.Value:SetTextColor(HIGHLIGHT_FONT_COLOR:GetRGB());
-		self.Value:SetPoint("LEFT", self.Title, "RIGHT", 15, 0);
 		self.Swatch:Hide();
 	end
 end

--- a/totalRP3/UI/ColorSwatch.xml
+++ b/totalRP3/UI/ColorSwatch.xml
@@ -7,7 +7,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="ColorSwatch.lua"/>
 
 	<Frame name="TRP3_ColorSwatchTemplate" mixin="TRP3_ColorSwatchMixin" virtual="true">
-		<Size x="16" y="16"/>
+		<Size x="14" y="14"/>
 		<Layers>
 			<Layer level="BACKGROUND" textureSubLevel="-2">
 				<Texture parentKey="OuterBorder" texelSnappingBias="0.0" snapToPixelGrid="false">


### PR DESCRIPTION
Aligns the color swatch with the residence button rather than indenting the text, and also reduces its size very slightly in the characteristics page.

![image](https://github.com/user-attachments/assets/185f7ea5-ac1f-466e-a0d0-95896163dd03)
