### PR TITLE
Add monochromatic contrast level

### DIFF
--- a/totalRP3/Core/Color.lua
+++ b/totalRP3/Core/Color.lua
@@ -475,6 +475,7 @@ TRP3_ColorContrastOption =
 	MediumHigh = 5,
 	High = 6,
 	VeryHigh = 7,
+	Monochromatic = 8,
 
 	-- Aliases and other magical values.
 	Default = 3,
@@ -489,6 +490,7 @@ local ColorContrastLevels =
 	[TRP3_ColorContrastOption.MediumHigh] = 60,
 	[TRP3_ColorContrastOption.High] = 75,
 	[TRP3_ColorContrastOption.VeryHigh] = 90,
+	[TRP3_ColorContrastOption.Monochromatic] = math.huge,
 };
 
 local function CalculateLuminance(r, g, b)
@@ -604,7 +606,7 @@ function TRP3_API.GenerateReadableColor(foregroundColor, backgroundColor, target
 	local FgYs = CalculateLuminance(FgR, FgG, FgB);
 	local FgLc = CalculateLightnessContrast(FgYs, BgYs);
 
-	if math.abs(FgLc) < targetContrast then
+	if math.abs(FgLc) < targetContrast and targetContrast ~= math.huge then
 		local MiCd = math.huge;
 		local L = 0;
 		local R = 100;

--- a/totalRP3/Core/Configuration.lua
+++ b/totalRP3/Core/Configuration.lua
@@ -434,6 +434,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOAD, functi
 					{ loc.CO_GENERAL_CONTRAST_LEVEL_MEDIUM_HIGH, TRP3_ColorContrastOption.MediumHigh },
 					{ loc.CO_GENERAL_CONTRAST_LEVEL_HIGH, TRP3_ColorContrastOption.High },
 					{ loc.CO_GENERAL_CONTRAST_LEVEL_VERY_HIGH, TRP3_ColorContrastOption.VeryHigh },
+					{ loc.CO_GENERAL_CONTRAST_LEVEL_MONOCHROMATIC, TRP3_ColorContrastOption.Monochromatic },
 				},
 				listCancel = true,
 			},

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -403,6 +403,7 @@ The description doesn't have to be limited to |cnGREEN_FONT_COLOR:physical descr
 	CO_GENERAL_CONTRAST_LEVEL_MEDIUM_HIGH = "Medium high",
 	CO_GENERAL_CONTRAST_LEVEL_HIGH = "High",
 	CO_GENERAL_CONTRAST_LEVEL_VERY_HIGH = "Very high",
+	CO_GENERAL_CONTRAST_LEVEL_MONOCHROMATIC = "Monochrome",
 	CO_GENERAL_HIDE_MAXIMIZE_BUTTON = "Hide maximize button",
 	CO_GENERAL_HIDE_MAXIMIZE_BUTTON_HELP = "Hides the minimize and maximize buttons on the Total RP 3 window.",
 	CO_TOOLTIP = "Tooltip",


### PR DESCRIPTION
Had intended to add this with the characteristics changes but forgot. This adds a new color contrast level ("Monochrome") that if selected will force text to either use pure white or black depending upon the background color.

In our actual use cases, this is currently always white.