### PR TITLE
Improve error display logic for modules

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -527,6 +527,7 @@ The description doesn't have to be limited to |cnGREEN_FONT_COLOR:physical descr
 	CO_MODULES_STATUS_3 = "Total RP 3 update required",
 	CO_MODULES_STATUS_4 = "Error on initialization",
 	CO_MODULES_STATUS_5 = "Error on startup",
+	CO_MODULES_STATUS_6 = "Disabled due to conflict",
 	CO_MODULES_TT_NONE = "No dependencies";
 	CO_MODULES_TT_DEPS = "Dependencies";
 	CO_MODULES_TT_TRP = "%sFor Total RP 3 build %s minimum.|r",

--- a/totalRP3/Modules/ChatFrame/ElvUI.lua
+++ b/totalRP3/Modules/ChatFrame/ElvUI.lua
@@ -9,18 +9,18 @@ local loc = TRP3_API.loc;
 local function onStart()
 	-- Stop right here if ElvUI is not installed
 	if not ElvUI then
-		return false, loc.MO_ADDON_NOT_INSTALLED:format("ElvUI");
+		return TRP3_API.module.status.MISSING_DEPENDENCY, loc.MO_ADDON_NOT_INSTALLED:format("ElvUI");
 	end
 
 	local ElvUI = ElvUI[1];
 	local ElvUIChatModule = ElvUI:GetModule("Chat", true);
 	if not ElvUIChatModule then
-		return false, "Your version of ElvUI doesn't need this module to function.";
+		return TRP3_API.module.status.MISSING_DEPENDENCY, "Your version of ElvUI doesn't need this module to function.";
 	end
 	local ElvUIGetColoredName = ElvUIChatModule.GetColoredName;
 
 	if not ElvUIGetColoredName then
-		return false, "Your version of ElvUI doesn't need this module to function.";
+		return TRP3_API.module.status.MISSING_DEPENDENCY, "Your version of ElvUI doesn't need this module to function.";
 	end
 
 	-- Build the fallback, using ElvUI's function
@@ -36,7 +36,7 @@ end
 
 -- Register a Total RP 3 module that can be disabled in the settings
 TRP3_API.module.registerModule({
-	["name"] = "ElvUI",
+	["name"] = "ElvUI Chat",
 	["description"] = loc.MO_CHAT_CUSTOMIZATIONS_DESCRIPTION:format("ElvUI"),
 	["version"] = 1.0,
 	["id"] = "trp3_elvui_chat",

--- a/totalRP3/Modules/ChatFrame/WIM.lua
+++ b/totalRP3/Modules/ChatFrame/WIM.lua
@@ -9,7 +9,7 @@ local loc = TRP3_API.loc;
 local function onStart()
 	-- Stop right here if WIM is not installed
 	if not WIM then
-		return false, loc.MO_ADDON_NOT_INSTALLED:format("WIM");
+		return TRP3_API.module.status.MISSING_DEPENDENCY, loc.MO_ADDON_NOT_INSTALLED:format("WIM");
 	end
 
 	-- Import Total RP 3 functions

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -85,7 +85,7 @@ local TRP3_BlizzardNamePlates = {};
 
 function TRP3_BlizzardNamePlates:OnModuleInitialize()
 	if not C_AddOns.IsAddOnLoaded("Blizzard_NamePlates") then
-		return false, L.NAMEPLATES_MODULE_DISABLED_BY_DEPENDENCY;
+		return TRP3_API.module.status.MISSING_DEPENDENCY, L.NAMEPLATES_MODULE_DISABLED_BY_DEPENDENCY;
 	end
 
 	-- Quick hack to make these nameplates "cowardly"; if any of the below
@@ -101,7 +101,7 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 
 	for _, addon in ipairs(addons) do
 		if TRP3_API.utils.IsAddOnEnabled(addon) then
-			return false, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
+			return TRP3_API.module.status.CONFLICTED, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
 		end
 	end
 
@@ -111,7 +111,7 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 	if ElvUI then
 		local E = ElvUI[1];
 		if E and E.NamePlates and E.NamePlates.Initialized then
-			return false, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
+			return TRP3_API.module.status.CONFLICTED, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
 		end
 	end
 end
@@ -454,6 +454,7 @@ TRP3_API.module.registerModule({
 	description = L.BLIZZARD_NAMEPLATES_MODULE_DESCRIPTION,
 	version = 1,
 	minVersion = 92,
+	requiredDeps = { {"Blizzard_NamePlates", "external"} },
 	onInit = function() return TRP3_BlizzardNamePlates:OnModuleInitialize(); end,
 	onStart = function() return TRP3_BlizzardNamePlates:OnModuleEnable(); end,
 });

--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -16,7 +16,7 @@ local function ResolveFrame(tbl, name, ...)
 end
 
 TRP3_API.module.registerModule({
-	["name"] = "ElvUI",
+	["name"] = "ElvUI Tooltips",
 	["id"] = "trp3_elvui",
 	["description"] = loc.MO_TOOLTIP_CUSTOMIZATIONS_DESCRIPTION:format("ElvUI"),
 	["requiredDeps"] = {
@@ -28,7 +28,7 @@ TRP3_API.module.registerModule({
 
 		-- Stop right here if ElvUI is not installed
 		if not ElvUI then
-			return false, loc.MO_ADDON_NOT_INSTALLED:format("ElvUI");
+			return TRP3_API.module.status.MISSING_DEPENDENCY, loc.MO_ADDON_NOT_INSTALLED:format("ElvUI");
 		end
 
 		local skinFrame, skinTooltips;

--- a/totalRP3/Modules/TooltipSkins/TinyTooltip.lua
+++ b/totalRP3/Modules/TooltipSkins/TinyTooltip.lua
@@ -13,7 +13,7 @@ TRP3_API.module.registerModule({
 
 		-- Check if the add-on TinyTooltip is installed
 		if not TinyTooltip then
-			return false,  loc.MO_ADDON_NOT_INSTALLED:format("TinyTooltip");
+			return TRP3_API.module.status.MISSING_DEPENDENCY,  loc.MO_ADDON_NOT_INSTALLED:format("TinyTooltip");
 		end
 
 		-- List of the tooltips we want to be customized by TinyTooltips

--- a/totalRP3/Modules/TooltipSkins/Tiptac.lua
+++ b/totalRP3/Modules/TooltipSkins/Tiptac.lua
@@ -13,7 +13,7 @@ TRP3_API.module.registerModule({
 
 		-- Stop right here if TipTac is not installed
 		if not TipTac then
-			return false, loc.MO_ADDON_NOT_INSTALLED:format("TipTac");
+			return TRP3_API.module.status.MISSING_DEPENDENCY, loc.MO_ADDON_NOT_INSTALLED:format("TipTac");
 		end
 
 		-- List of the tooltips we want to be customized by TipTac


### PR DESCRIPTION
Module functions like onInit, onStart, or onDisable can return a (bool, string) pair that act similarly to the returns of a pcall to trigger a "soft error" for the module and display it as failed in the module listing.

Some of our modules use this when gracefully disabling themselves, but confusingly end up being displayed as errored in the module listing - chief among them are the Blizzard nameplates when they've been disabled due to the presence of other known nameplate addons.

We now support returning a module status enum code from the module functions in-place of the leading boolean, which will force the status of the module to appear as returned.

Additionally to better support the use case by Blizzard nameplates, a new status code has been added for conflicted modules. These will display as grey in the list rather than appearing as errors.