### PR TITLE
Focus hex input field on color browser open

### DIFF
--- a/totalRP3/UI/Browsers/ColorBrowser.lua
+++ b/totalRP3/UI/Browsers/ColorBrowser.lua
@@ -286,6 +286,12 @@ function TRP3_ColorBrowserMixin:Open(initialColor, acceptCallback, cancelCallbac
 	self.initialColor = initialColor;
 	self.selectedColor = initialColor;
 	self:Update();
+
+	-- Focusing and highlighting the input field should occur after the
+	-- initial update which assigns the text contents.
+
+	self.Content.HexInput:SetFocus();
+	self.Content.HexInput:HighlightText();
 end
 
 function TRP3_ColorBrowserMixin:Accept()


### PR DESCRIPTION
As we already auto-focus the search field in the icon and background browsers, it makes sense to also autofocus the hex input field in the color browser to make it easier to paste in a new color without having to click the box first.