### PR TITLE
Fix tooltips for party units on other maps

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1446,9 +1446,15 @@ end
 local function GetCurrentTooltipUnit()
 	local unitToken;
 
-	if UnitExists("mouseover") then
+	if GameTooltip:IsShown() then
+		unitToken = (select(2, GameTooltip:GetUnit())) or "none";
+	end
+
+	if not unitToken and UnitExists("mouseover") then
 		unitToken = "mouseover";
-	elseif showWorldCursor() and getAnchoredPosition() ~= "ANCHOR_CURSOR" then
+	end
+
+	if not unitToken and showWorldCursor() and getAnchoredPosition() ~= "ANCHOR_CURSOR" then
 		-- World cursor units are not consulted if the tooltip is set to
 		-- anchor to the cursor itself, as it looks a bit silly.
 		unitToken = GetWorldCursorUnit();


### PR DESCRIPTION
The tooltip logic when the mouseover unit changes explicitly consults the "mouseover" unit or falls back to the world cursor support in mainline when enabled.

For units on different maps to the current player, the client never associates the "mouseover" unit to them - it'll instead display the tooltip with their party/raid unit token which we've never checked.

The current tooltip unit logic has been adjusted to consult the default GTT if shown and use its unit if set, before then falling back to the "mouseover" token and world cursor support.

**Note:** This may in fact break things. Extensive testing required because this logic is garbage.