### PR TITLE
Add framebuffer attribute to main frame

### DIFF
--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -205,7 +205,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Frames>
 	</Frame>
 
-	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameLayoutMixin" hidden="true" movable="true" dontSavePosition="true">
+	<Frame name="TRP3_MainFrame" inherits="TRP3_MainFrameTemplate" mixin="TRP3_MainFrameLayoutMixin" hidden="true" movable="true" dontSavePosition="true" frameBuffer="true">
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>
 		</Anchors>
@@ -248,6 +248,10 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Layer level="BACKGROUND">
 						<Texture parentKey="Background" file="Interface\AddOns\totalRP3\Resources\UI\ui-frame-neutral-background" horizTile="true" vertTile="true">
 							<Color r="0.6" g="0.6" b="0.6"/>
+							<Anchors>
+								<Anchor point="TOPLEFT" x="-8" y="8"/>
+								<Anchor point="BOTTOMRIGHT" x="8" y="-8"/>
+							</Anchors>
 						</Texture>
 					</Layer>
 					<Layer level="BORDER" textureSubLevel="-3">


### PR DESCRIPTION
Mostly for Rae's benefit and whoever else is now deciding to alpha-ify our main frame when moving.

As our main frame is a composition of various texture regions, adjusting the alpha of the frame has a few ugly side effects where individual textures representing the borders and sidebar divider end up blending together. This can be seen below - note the top and bottom of the dividing bar between the sidebar and the main content area.

![Before](https://github.com/user-attachments/assets/2d60eb8d-9884-44d3-81ab-db316f800e98)

This can be resolved by just enabling the framebuffer attribute on the frame which will force the frame to be rendered to a target at full opacity before being composited into the final UI scene with transparency applied.

Net result - none of the borders end up blending together. As an extra add, as Keyboard pointed out our sidebar texture was smaller than its actual space so the anchors have been adjusted slightly to compensate. See below for the after.

![After](https://github.com/user-attachments/assets/cdae51d5-053d-4da7-ba1e-f260b23d6b7d)
