### PR TITLE
Allow copying/saving colors from register swatches

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -963,6 +963,7 @@ Total RP is not responsible for links leading to harmful content.|r]],
 	CM_OPTIONS_ADDITIONAL = "Additional options",
 	CM_ACTIVATE = "Activate",
 	CM_DO_NOT_SHOW = "Do not show",
+	CM_COPY_TO_CLIPBOARD = "Copy to clipboard",
 
 	CM_ORANGE = "Orange",
 	CM_WHITE = "White",
@@ -1004,6 +1005,7 @@ Total RP is not responsible for links leading to harmful content.|r]],
 	BW_COLOR_UNREADABLE = "Readability Warning",
 	BW_COLOR_UNREADABLE_TT = "This color may be |cnWARNING_FONT_COLOR:automatically adjusted|r when displayed as it can be difficult to read against dark backgrounds, such as in tooltips.|n|nAn |cnGREEN_FONT_COLOR:alternative recommended color|r is displayed at the bottom-right of the preview.",
 	BW_COLOR_UNREADABLE_CLICK = "Use recommended color",
+	BW_COLOR_PRESET_SAVE_AS_CUSTOM = "Save as custom color preset",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Databroker

--- a/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUICharacteristics.xml
@@ -447,7 +447,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Layer>
 		</Layers>
 		<Frames>
-			<Frame parentKey="Swatch" mixin="TRP3_RegisterColorSwatchMixin" inherits="TRP3_ColorSwatchTemplate, TRP3_TooltipScriptTemplate">
+			<Frame parentKey="Swatch" inherits="TRP3_RegisterColorSwatchTemplate">
 				<Anchors>
 					<Anchor point="RIGHT" relativeKey="$parent.Value" relativePoint="LEFT" x="-5"/>
 				</Anchors>

--- a/totalRP3/Modules/Register/Main/RegisterTemplates.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTemplates.lua
@@ -55,6 +55,39 @@ end
 
 TRP3_RegisterColorSwatchMixin = {};
 
+function TRP3_RegisterColorSwatchMixin:OnMouseDown(mouseButtonName)
+	if mouseButtonName ~= "RightButton" then
+		return;
+	end
+
+	local color = self:GetColor();
+
+	local function OnCopyColorClicked()
+		local code = "#" .. color:GenerateHexColorOpaque();
+		TRP3_API.popup.showCopyDropdownPopup({ code });
+	end
+
+	local function OnSaveColorClicked()
+		local function OnPopupResponse(name)
+			if name == "" then
+				name = TRP3_ColorPresetManager.GenerateDefaultPresetName(color);
+			end
+
+			TRP3_ColorPresetManager.SaveCustomPreset(name, color);
+		end
+
+		local prompt = string.join("|n|n", L.BW_CUSTOM_NAME, L.BW_CUSTOM_NAME_TT);
+		TRP3_API.popup.showTextInputPopup(prompt, OnPopupResponse);
+	end
+
+	local function GenerateMenu(_, rootDescription)
+		rootDescription:CreateButton(L.CM_COPY_TO_CLIPBOARD, OnCopyColorClicked);
+		rootDescription:CreateButton(L.BW_COLOR_PRESET_SAVE_AS_CUSTOM, OnSaveColorClicked);
+	end
+
+	TRP3_MenuUtil.CreateContextMenu(self, GenerateMenu);
+end
+
 function TRP3_RegisterColorSwatchMixin:OnTooltipShow(description)
 	if self.showContrastTooltip then
 		description:AddNormalLine(L.REG_COLOR_SWATCH_WARNING);

--- a/totalRP3/Modules/Register/Main/RegisterTemplates.xml
+++ b/totalRP3/Modules/Register/Main/RegisterTemplates.xml
@@ -27,4 +27,10 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Layer>
 		</Layers>
 	</Frame>
+
+	<Frame name="TRP3_RegisterColorSwatchTemplate" mixin="TRP3_RegisterColorSwatchMixin" inherits="TRP3_ColorSwatchTemplate, TRP3_TooltipScriptTemplate" virtual="true">
+		<Scripts>
+			<OnMouseDown method="OnMouseDown"/>
+		</Scripts>
+	</Frame>
 </Ui>

--- a/totalRP3/UI/Browsers/ColorBrowser.lua
+++ b/totalRP3/UI/Browsers/ColorBrowser.lua
@@ -131,6 +131,10 @@ function TRP3_ColorPresetManager.DeleteCustomPreset(name)
 	end
 end
 
+function TRP3_ColorPresetManager.GenerateDefaultPresetName(color)
+	return "#" .. color:GenerateHexColorOpaque();
+end
+
 TRP3_ColorBrowserMixin = {};
 
 function TRP3_ColorBrowserMixin:OnLoad()
@@ -190,14 +194,10 @@ function TRP3_ColorBrowserMixin:OnPresetButtonClick()
 		self:SetSelectedColor(color);
 	end
 
-	local function GenerateDefaultPresetName(color)
-		return "#" .. color:GenerateHexColorOpaque();
-	end
-
 	local function OnPresetSaveClicked(color)
 		local function OnPopupResponse(name)
 			if name == "" then
-				name = GenerateDefaultPresetName(color);
+				name = TRP3_ColorPresetManager.GenerateDefaultPresetName(color);
 			end
 
 			TRP3_ColorPresetManager.SaveCustomPreset(name, color);
@@ -210,7 +210,7 @@ function TRP3_ColorBrowserMixin:OnPresetButtonClick()
 	local function OnPresetRenameClicked(preset)
 		local function OnPopupResponse(name)
 			if name == "" then
-				name = GenerateDefaultPresetName(preset.CO);
+				name = TRP3_ColorPresetManager.GenerateDefaultPresetName(preset.CO);
 			end
 
 			TRP3_ColorPresetManager.RenameCustomPreset(preset.TX, name);

--- a/totalRP3/UI/ColorSwatch.lua
+++ b/totalRP3/UI/ColorSwatch.lua
@@ -12,6 +12,14 @@ function TRP3_ColorSwatchMixin:OnShow()
 	PixelUtil.SetPoint(self.Color, "BOTTOMRIGHT", self, "BOTTOMRIGHT", -2, 2);
 end
 
+function TRP3_ColorSwatchMixin:GetColor()
+	return TRP3_API.CreateColor(self.Color:GetVertexColor());
+end
+
+function TRP3_ColorSwatchMixin:GetColorRGB()
+	return self.Color:GetVertexColor();
+end
+
 function TRP3_ColorSwatchMixin:SetColor(color)
 	self.Color:SetVertexColor(color:GetRGB());
 end


### PR DESCRIPTION
Per user request; this adds the ability to right-click a color swatch in the view of another persons profile to either open a copy dialog with the hex code of the displayed color, or to save it directly as a custom preset.

![image](https://github.com/user-attachments/assets/f5d9b298-2ff9-4991-a736-96bb07b341bf)
