### PR TITLE
Resolve error when clicking 'No scan available'

### DIFF
--- a/totalRP3/Modules/Map/WorldMapButton.lua
+++ b/totalRP3/Modules/Map/WorldMapButton.lua
@@ -174,7 +174,13 @@ WorldMapButton:SetScript("OnMouseDown", function(self)
 
 	TRP3_MenuUtil.CreateContextMenu(self, function(_, description)
 		for _, scan in pairs(structure) do
-			description:CreateButton(scan[1], TRP3_API.MapScannersManager.launch, scan[2]);
+			local responder;
+
+			if scan[2] ~= nil then
+				responder = TRP3_API.MapScannersManager.launch;
+			end
+
+			description:CreateButton(scan[1], responder, scan[2]);
 		end
 	end);
 end);


### PR DESCRIPTION
The responder for launching map scans asserts that there's a valid scan ID. The placeholder entry we place into the table when there's no scans has no scan ID, so clicking it explodes.