### PR TITLE
Improve resizing behavior

### DIFF
--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1075,8 +1075,6 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	local parentFrame = resizeButton.resizableFrame;
 	resizeButton:SetScript("OnMouseDown", function(self)
 		if not self.onResizeStart or not self.onResizeStart() then
-			TRP3_ResizeShadowFrame.minWidth = self.minWidth;
-			TRP3_ResizeShadowFrame.minHeight = self.minHeight;
 			TRP3_ResizeShadowFrame:ClearAllPoints();
 			TRP3_ResizeShadowFrame:SetPoint("CENTER", self.resizableFrame, "CENTER", 0, 0);
 			TRP3_ResizeShadowFrame:SetWidth(parentFrame:GetWidth());

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1075,20 +1075,7 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	assert(resizeButton.minWidth, "minWidth key is not set.");
 	assert(resizeButton.minHeight, "minHeight key is not set.");
 	local parentFrame = resizeButton.resizableFrame;
-	resizeButton:RegisterForDrag("LeftButton");
 	resizeButton:SetScript("OnMouseDown", function(self)
-		if self.CursorFrame then
-			self.CursorFrame:Show();
-		end
-		SetCursor("Interface\\CURSOR\\UI-Cursor-Size");
-	end);
-	resizeButton:SetScript("OnMouseUp", function(self)
-		if self.CursorFrame then
-			self.CursorFrame:Hide();
-		end
-		ResetCursor();
-	end);
-	resizeButton:SetScript("OnDragStart", function(self)
 		if not self.onResizeStart or not self.onResizeStart() then
 			resizeShadowFrame.minWidth = self.minWidth;
 			resizeShadowFrame.minHeight = self.minHeight;
@@ -1099,9 +1086,10 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 			resizeShadowFrame:Show();
 			resizeShadowFrame:StartSizing();
 			parentFrame.isSizing = true;
+			SetCursor("Interface\\CURSOR\\UI-Cursor-Size");
 		end
 	end);
-	resizeButton:SetScript("OnDragStop", function(self)
+	resizeButton:SetScript("OnMouseUp", function(self)
 		if parentFrame.isSizing then
 			if self.CursorFrame then
 				self.CursorFrame:Hide();
@@ -1123,6 +1111,7 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 					self.onResizeStop(width, height);
 				end);
 			end
+			ResetCursor();
 		end
 	end);
 end

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -1068,8 +1068,6 @@ end
 -- Resize button
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local resizeShadowFrame = TRP3_ResizeShadowFrame;
-
 function TRP3_API.ui.frame.initResize(resizeButton)
 	resizeButton.resizableFrame = resizeButton.resizableFrame or resizeButton:GetParent();
 	assert(resizeButton.minWidth, "minWidth key is not set.");
@@ -1077,34 +1075,28 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	local parentFrame = resizeButton.resizableFrame;
 	resizeButton:SetScript("OnMouseDown", function(self)
 		if not self.onResizeStart or not self.onResizeStart() then
-			resizeShadowFrame.minWidth = self.minWidth;
-			resizeShadowFrame.minHeight = self.minHeight;
-			resizeShadowFrame:ClearAllPoints();
-			resizeShadowFrame:SetPoint("CENTER", self.resizableFrame, "CENTER", 0, 0);
-			resizeShadowFrame:SetWidth(parentFrame:GetWidth());
-			resizeShadowFrame:SetHeight(parentFrame:GetHeight());
-			resizeShadowFrame:Show();
-			resizeShadowFrame:StartSizing();
+			TRP3_ResizeShadowFrame.minWidth = self.minWidth;
+			TRP3_ResizeShadowFrame.minHeight = self.minHeight;
+			TRP3_ResizeShadowFrame:ClearAllPoints();
+			TRP3_ResizeShadowFrame:SetPoint("CENTER", self.resizableFrame, "CENTER", 0, 0);
+			TRP3_ResizeShadowFrame:SetWidth(parentFrame:GetWidth());
+			TRP3_ResizeShadowFrame:SetHeight(parentFrame:GetHeight());
+			TRP3_ResizeShadowFrame:SetResizeBounds(resizeButton.minWidth, resizeButton.minHeight, resizeButton.maxWidth, resizeButton.maxHeight);
+			TRP3_ResizeShadowFrame:Show();
+			TRP3_ResizeShadowFrame:StartSizing();
 			parentFrame.isSizing = true;
 			SetCursor("Interface\\CURSOR\\UI-Cursor-Size");
 		end
 	end);
 	resizeButton:SetScript("OnMouseUp", function(self)
 		if parentFrame.isSizing then
-			if self.CursorFrame then
-				self.CursorFrame:Hide();
-			end
 			ResetCursor();
-			resizeShadowFrame:StopMovingOrSizing();
+			TRP3_ResizeShadowFrame:StopMovingOrSizing();
 			parentFrame.isSizing = false;
-			local height, width = resizeShadowFrame:GetHeight(), resizeShadowFrame:GetWidth()
-			resizeShadowFrame:Hide();
-			if height < self.minHeight then
-				height = self.minHeight;
-			end
-			if width < self.minWidth then
-				width = self.minWidth;
-			end
+			local height, width = TRP3_ResizeShadowFrame:GetHeight(), TRP3_ResizeShadowFrame:GetWidth();
+			width = Clamp(width, self.minWidth, self.maxWidth or math.huge);
+			height = Clamp(height, self.minHeight, self.maxHeight or math.huge);
+			TRP3_ResizeShadowFrame:Hide();
 			parentFrame:SetSize(width, height);
 			if self.onResizeStop then
 				C_Timer.After(0.1, function()
@@ -1116,18 +1108,8 @@ function TRP3_API.ui.frame.initResize(resizeButton)
 	end);
 end
 
-local VALID_SIZE_COLOR = TRP3_API.Colors.Green;
-local INVALID_SIZE_COLOR = TRP3_API.Colors.Red;
-resizeShadowFrame:SetScript("OnUpdate", function(self)
-	local height, width = math.ceil(self:GetHeight()), math.ceil(self:GetWidth());
-	local heightColor, widthColor = VALID_SIZE_COLOR, VALID_SIZE_COLOR;
-	if height < self.minHeight then
-		heightColor = INVALID_SIZE_COLOR;
-	end
-	if width < self.minWidth then
-		widthColor = INVALID_SIZE_COLOR;
-	end
-	resizeShadowFrame.text:SetText(widthColor(width) .. " x " .. heightColor(height));
+TRP3_ResizeShadowFrame:SetScript("OnUpdate", function(self)
+	TRP3_ResizeShadowFrame.text:SetText(string.format("|cnGREEN_FONT_COLOR:%d x %d|r", self:GetSize()));
 end);
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -57,6 +57,7 @@ end
 function TRP3_MainFrameMixin:ResizeWindow(width, height)
 	ResetWindowPoint(self);
 	self:SetSize(width, height);
+	self:SetWindowState(WindowState.Normal);
 end
 
 function TRP3_MainFrameMixin:OnWindowStateChanged(oldState, newState)  -- luacheck: no unused
@@ -70,11 +71,6 @@ end
 
 function TRP3_MainFrameMixin:RestoreWindow()
 	self:SetSize(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
-	self:SetWindowState(WindowState.Normal);
-end
-
-function TRP3_MainFrameMixin:ResizeWindow(width, height)
-	self:SetSize(width, height);
 	self:SetWindowState(WindowState.Normal);
 end
 

--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -11,6 +11,15 @@ local WindowState = {
 	Maximized = 2,
 };
 
+local function ResetWindowPoint(frame)
+	local parent = frame:GetParent() or UIParent;
+	local offsetX = frame:GetLeft();
+	local offsetY = -(parent:GetTop() - frame:GetTop());
+
+	frame:ClearAllPoints();
+	frame:SetPoint("TOPLEFT", offsetX, offsetY);
+end
+
 TRP3_MainFrameMixin = {};
 
 function TRP3_MainFrameMixin:OnLoad()
@@ -18,6 +27,8 @@ function TRP3_MainFrameMixin:OnLoad()
 
 	tinsert(UISpecialFrames, self:GetName());
 	TRP3_Addon.RegisterCallback(self, "CONFIGURATION_CHANGED", "OnConfigurationChanged");
+	self.Resize.onResizeStart = function() self:OnResizeStart(); end;
+	self.Resize.onResizeStop = function(width, height) self:OnResizeStop(width, height); end;
 	TRP3_API.ui.frame.initResize(self.Resize);
 end
 
@@ -33,6 +44,19 @@ end
 
 function TRP3_MainFrameMixin:OnSizeChanged()
 	TRP3_Addon:TriggerEvent(TRP3_Addon.Events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetSize());
+end
+
+function TRP3_MainFrameMixin:OnResizeStart()
+	ResetWindowPoint(self);
+end
+
+function TRP3_MainFrameMixin:OnResizeStop(width, height)
+	self:ResizeWindow(width, height);
+end
+
+function TRP3_MainFrameMixin:ResizeWindow(width, height)
+	ResetWindowPoint(self);
+	self:SetSize(width, height);
 end
 
 function TRP3_MainFrameMixin:OnWindowStateChanged(oldState, newState)  -- luacheck: no unused
@@ -117,6 +141,7 @@ function TRP3_MainFrameLayoutMixin:RestoreLayout()
 	local height = math.max(self.windowLayout.h or DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_HEIGHT);
 	self:SetSize(width, height);
 	LibWindow.RestorePosition(self);
+	ResetWindowPoint(self);
 end
 
 function TRP3_MainFrameLayoutMixin:SaveLayout()

--- a/totalRP3/UI/Main.xml
+++ b/totalRP3/UI/Main.xml
@@ -193,14 +193,6 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				<Anchors>
 					<Anchor point="BOTTOMRIGHT" x="-1" y="1"/>
 				</Anchors>
-				<Frames>
-					<Frame parentKey="CursorFrame" hidden="true" enableMouse="true">
-						<Size x="50" y="50"/>
-						<Anchors>
-							<Anchor point="CENTER" relativePoint="BOTTOMRIGHT" />
-						</Anchors>
-					</Frame>
-				</Frames>
 			</Button>
 		</Frames>
 	</Frame>


### PR DESCRIPTION
The resize button utility no longer uses the OnDragStart/Stop handlers but instead just activates the resize shadow immediately upon OnMouseDown/Up. This means you don't need hacks like the cursor frame child, and makes it easier to adjust frame sizes in smaller increments. Additionally, we now set proper resize bounds on the shadow frame which resolves issues where shrinking the resize shadow to a negative size would comically shoot it offscreen.

As an extra change, when resizing the main frame we now also reset its point to be relative to the topleft corner of the screen. This means that resizing the main window when it's positioned in the center doesn't awkwardly reposition itself each time and matches what the resize shadow actually shows.

Long term, I'm killing the shadow - but that requires us to first remove all the stupid navigation change handlers that result in enormous slowdowns whenever we resize the frame dynamically. This is just a first step.