### PR TITLE
Improve accuracy of large export warning

### DIFF
--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -349,7 +349,7 @@ local function onActionSelected(value, button)
 		local serial = Utils.serial.serialize({Globals.version, profileID, profile });
 		if serial:len() < 20000 then
 			TRP3_ProfileExport.content.scroll.text:SetText(serial);
-			TRP3_ProfileExport.content.title:SetText(loc.PR_EXPORT_NAME:format(profile.profileName, serial:len() / 1024));
+			TRP3_ProfileExport.content.title:SetText(loc.PR_EXPORT_NAME:format(profile.profileName, serial:len() / 1000));
 			TRP3_ProfileExport:Show();
 			TRP3_ProfileExport.content.scroll.text:SetFocus();
 		else

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -353,7 +353,7 @@ local function onActionSelected(value, button)
 			TRP3_ProfileExport:Show();
 			TRP3_ProfileExport.content.scroll.text:SetFocus();
 		else
-			Utils.message.displayMessage(loc.PR_EXPORT_TOO_LARGE:format(serial:len() / 1024), 2);
+			Utils.message.displayMessage(loc.PR_EXPORT_TOO_LARGE:format(serial:len() / 1000), 2);
 		end
 	elseif value == PROFILEMANAGER_ACTIONS.IMPORT then
 		TRP3_ProfileImport.profileID = profileID;


### PR DESCRIPTION
The surrounding code checks for a limit of exactly 20,000 bytes and then hardcodes the limit as being "20 kB" in the locale string. When formatting, we were dividing by 1024 rather than 1000 and so when breaching the limit we could end up showing values that were smaller than 20 kB.