### PR TITLE
Allow partial offscreen frame dragging

### DIFF
--- a/totalRP3/UI/Main.lua
+++ b/totalRP3/UI/Main.lua
@@ -43,6 +43,7 @@ function TRP3_MainFrameMixin:OnShow()
 end
 
 function TRP3_MainFrameMixin:OnSizeChanged()
+	self:UpdateClampRectInsets();
 	TRP3_Addon:TriggerEvent(TRP3_Addon.Events.NAVIGATION_RESIZED, TRP3_MainFramePageContainer:GetSize());
 end
 
@@ -101,6 +102,19 @@ function TRP3_MainFrameMixin:UpdateWindowStateButtons()
 
 	self.Minimize:SetShown(state == WindowState.Maximized and ShouldShowWindowStateButtons());
 	self.Maximize:SetShown(state == WindowState.Normal and ShouldShowWindowStateButtons());
+end
+
+function TRP3_MainFrameMixin:UpdateClampRectInsets()
+	local width, height = self:GetSize();
+	local ratio = width / height;
+	local padding = 300;
+
+	local left = width - padding;
+	local right = -left;
+	local bottom = height - (padding / ratio);
+	local top = -bottom;
+
+	self:SetClampRectInsets(left, right, top, bottom);
 end
 
 TRP3_MainFrameLayoutMixin = CreateFromMixins(TRP3_MainFrameMixin);


### PR DESCRIPTION
Sometimes it's convenient to have our main window open alongside an existing game panel, like when you have this dark urge to update your CO field while scanning the auction house.

Unfortunately with the size of our window and the fact that it clamps to the screen, we make this a bit tricky - depending upon the panels and other junk you've got shown, you can't actually move our window out of the way enough because it clamps at the edges of the screen.

To resolve this, we now allow the user to drag the window *partially* off-screen, clamping only if the position of the window would fall within ~around 300 units of it being completely off-screen. That way you can move about 70% of the window completely out of the way if you want to look at that Draenei's transmog or whatever.