### PR TITLE
Strictly validate interface icons on load

### DIFF
--- a/totalRP3/Resources/InterfaceIcons.lua
+++ b/totalRP3/Resources/InterfaceIcons.lua
@@ -221,18 +221,18 @@ TRP3_InterfaceIcons = {
 --
 
 do
-	local function GetFirstValidTexturePath(candidates, root)
-		root = root or "";
+	local LRPM12 = LibStub:GetLibrary("LibRPMedia-1.2");
 
-		for _, path in ipairs(candidates) do
-			if GetFileIDFromPath(root .. path) then
-				return path;
+	local function GetFirstValidIcon(candidates)
+		for _, name in ipairs(candidates) do
+			if LRPM12:ResolveIcon(name) then
+				return name;
 			end
 		end
 	end
 
 	for id, candidates in pairs(TRP3_InterfaceIcons) do
-		local name = GetFirstValidTexturePath(candidates, [[interface\icons\]]);
+		local name = GetFirstValidIcon(candidates);
 
 		if not name and TRP3_API.globals.DEBUG_MODE then
 			securecallfunction(error, string.format("Invalid interface icon %q: No valid texture file found", id));


### PR DESCRIPTION
If someone installs a Mainline icon pack in Classic then the interface icon selector can get a bit confused.

What'll happen is it'll see that the preferred mainline icons for each part of the interface exist, but use of them will fail in conjunction with our fancy new BorderedIconTemplate system because that uses LRPM to strictly validate icons against a defined set that we're actually expecting to find in Classic.

As the use of Mainline icons in Classic is wholly unsupported, let's just apply this same stricter LRPM-based check earlier and completely remove the possibility that Mainline icons can be picked up from custom icon packs.