### PR TITLE
Add warning when chat is disabled

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -312,6 +312,12 @@ stds.wow = {
 			},
 		},
 
+		C_SocialRestrictions = {
+			fields = {
+				"IsChatDisabled",
+			},
+		},
+
 		C_Spell = {
 			fields = {
 				"DoesSpellExist",

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -10,7 +10,7 @@ L = {
 
 	GEN_WELCOME_MESSAGE = "Thank you for using Total RP 3 (v %s)! Have fun!",
 	GEN_VERSION = "Version: %s (Build %s)",
-	GEN_WARNING_CHAT_DISABLED = "Warning: Chat is disabled. Profiles cannot be exchanged with other players until it is enabled again.",
+	GEN_WARNING_CHAT_DISABLED = "Chat is disabled. Profiles cannot be exchanged with other players until it is enabled again.",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- REGISTER

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -10,6 +10,7 @@ L = {
 
 	GEN_WELCOME_MESSAGE = "Thank you for using Total RP 3 (v %s)! Have fun!",
 	GEN_VERSION = "Version: %s (Build %s)",
+	GEN_WARNING_CHAT_DISABLED = "Warning: Chat is disabled. Profiles cannot be exchanged with other players until it is enabled again.",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- REGISTER

--- a/totalRP3/totalRP3.lua
+++ b/totalRP3/totalRP3.lua
@@ -86,14 +86,16 @@ local function loadingSequence()
 		TRP3_API.utils.message.displayMessage(loc.GEN_WELCOME_MESSAGE:format(Globals.version_display));
 	end
 
+	local CHAT_DISABLED_WARNING = "|cnWARNING_FONT_COLOR:" .. loc.GEN_WARNING_CHAT_DISABLED .. "|r";
+
 	TRP3_API.RegisterCallback(TRP3_API.GameEvents, "CHAT_DISABLED_CHANGED", function(_, disabled)
 		if disabled then
-			TRP3_API.utils.message.displayMessage(TRP3_API.Colors.Red(loc.GEN_WARNING_CHAT_DISABLED));
+			TRP3_API.utils.message.displayMessage(CHAT_DISABLED_WARNING);
 		end
 	end);
 
 	if C_SocialRestrictions.IsChatDisabled() then
-		TRP3_API.utils.message.displayMessage(TRP3_API.Colors.Red(loc.GEN_WARNING_CHAT_DISABLED));
+		TRP3_API.utils.message.displayMessage(CHAT_DISABLED_WARNING);
 	end
 
 	TRP3_API.Log("OnEnable() DONE");

--- a/totalRP3/totalRP3.lua
+++ b/totalRP3/totalRP3.lua
@@ -86,6 +86,16 @@ local function loadingSequence()
 		TRP3_API.utils.message.displayMessage(loc.GEN_WELCOME_MESSAGE:format(Globals.version_display));
 	end
 
+	TRP3_API.RegisterCallback(TRP3_API.GameEvents, "CHAT_DISABLED_CHANGED", function(_, disabled)
+		if disabled then
+			TRP3_API.utils.message.displayMessage(TRP3_API.Colors.Red(loc.GEN_WARNING_CHAT_DISABLED));
+		end
+	end);
+
+	if C_SocialRestrictions.IsChatDisabled() then
+		TRP3_API.utils.message.displayMessage(TRP3_API.Colors.Red(loc.GEN_WARNING_CHAT_DISABLED));
+	end
+
 	TRP3_API.Log("OnEnable() DONE");
 end
 


### PR DESCRIPTION
Fixes #1152.

A warning appears in chat when logging in or changing the "Disable chat" setting if chat is disabled.

![image](https://github.com/user-attachments/assets/a1b52aaa-ec40-413e-9bed-ec2455617b33)
