### PR TITLE
Improve toolbar object addon compatibility

### DIFF
--- a/totalRP3/Modules/Dashboard/Currently.lua
+++ b/totalRP3/Modules/Dashboard/Currently.lua
@@ -51,6 +51,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		TRP3_API.toolbar.toolbarAddButton({
 			id = "bb_trp3_currently",
 			icon = TRP3_InterfaceIcons.ToolbarCurrently,
+			text = loc.CURRENTLY_TITLE,
 			configText = loc.CURRENTLY_TITLE,
 			tooltip = loc.CURRENTLY_TITLE,
 			tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.CURRENTLY_BUTTON_TT),

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -202,7 +202,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
 				buttonStructure.text = buttonStructure.tooltip;
-				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 			end,
 			onClick = function(_, _, button)
 				if UnitIsAFK("player") then
@@ -244,7 +243,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = OOC_ICON;
 				end
 				buttonStructure.text = buttonStructure.tooltip;
-				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 			end,
 			onClick = function(Uibutton, _, button)
 

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -202,7 +202,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
 				buttonStructure.text = buttonStructure.tooltip;
-				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
+				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 			end,
 			onClick = function(_, _, button)
 				if UnitIsAFK("player") then
@@ -244,7 +244,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.icon = OOC_ICON;
 				end
 				buttonStructure.text = buttonStructure.tooltip;
-				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
+				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 			end,
 			onClick = function(Uibutton, _, button)
 

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -185,6 +185,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		local Button_Status = {
 			id = "aa_trp3_d",
 			icon = TRP3_InterfaceIcons.ModeNormal,
+			text = status3Text,
 			configText = loc.CO_TOOLBAR_CONTENT_STATUS,
 			onModelUpdate = function(buttonStructure)
 				if UnitIsDND("player") then
@@ -200,6 +201,8 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.tooltipSub  = status3SubText;
 					buttonStructure.icon = TRP3_InterfaceIcons.ModeNormal;
 				end
+				buttonStructure.text = buttonStructure.tooltip;
+				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
 			end,
 			onClick = function(_, _, button)
 				if UnitIsAFK("player") then
@@ -228,6 +231,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 		local Button_RPStatus = {
 			id = "aa_trp3_rpstatus",
 			icon = OOC_ICON,
+			text = rpTextOn,
 			configText = loc.CO_TOOLBAR_CONTENT_RPSTATUS,
 			onModelUpdate = function(buttonStructure)
 				if AddOn_TotalRP3.Player.GetCurrentUser():IsInCharacter() then
@@ -239,6 +243,8 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 					buttonStructure.tooltipSub  = rpText2;
 					buttonStructure.icon = OOC_ICON;
 				end
+				buttonStructure.text = buttonStructure.tooltip;
+				TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
 			end,
 			onClick = function(Uibutton, _, button)
 

--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -96,16 +96,19 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 	local languagesButton = {
 		id = "ww_trp3_languages",
 		icon = TRP3_InterfaceIcons.ToolbarLanguage,
+		text = loc.TB_LANGUAGE,
 		configText = loc.TB_LANGUAGE,
 		onModelUpdate = function(buttonStructure)
 			if buttonStructure.currentLanguageID ~= ChatFrame1EditBox.languageID then
-				buttonStructure.currentLanguageID = ChatFrame1EditBox.languageID
-				local currentLanguage = Languages.getCurrentLanguage()
+				buttonStructure.currentLanguageID = ChatFrame1EditBox.languageID;
+				local currentLanguage = Languages.getCurrentLanguage();
 				buttonStructure.currentLanguageID = currentLanguage:GetID();
 				buttonStructure.tooltip = loc.TB_LANGUAGE .. ": " .. currentLanguage:GetName();
 				buttonStructure.tooltipSub = TRP3_API.FormatShortcutWithInstruction("CLICK", loc.TB_LANGUAGES_TT);
 				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
+			buttonStructure.text = buttonStructure.tooltip;
+			TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
 		end,
 		onClick = function(Uibutton)
 			TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)

--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -108,7 +108,6 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
 			buttonStructure.text = buttonStructure.tooltip;
-			TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 		end,
 		onClick = function(Uibutton)
 			TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)

--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -108,7 +108,7 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 				buttonStructure.icon = currentLanguage:GetIcon():GetFileName() or TRP3_InterfaceIcons.ToolbarLanguage;
 			end
 			buttonStructure.text = buttonStructure.tooltip;
-			TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure);
+			TRP3_API.toolbar.SignalLDBObjectUpdate(buttonStructure, "text");
 		end,
 		onClick = function(Uibutton)
 			TRP3_MenuUtil.CreateContextMenu(Uibutton, function(_, description)

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -47,16 +47,32 @@ local function onStart()
 
 	local LDB = LibStub:GetLibrary("LibDataBroker-1.1");
 
+	-- in order to turn a toolbar object into an LDBObject that can be used by other addons (ElvUI) to display information:
+	-- 	modify the object's 'text' attribute to the desired display text
+	-- 	call TRP3_API.toolbar.SignalLDBObjectUpdate, passing the object as the only arg
+	-- 	ensure the default 'text' attribute is a suitable placeholder, as it will be shown temporarily when the object is updated (at least in the case of ElvUI)
+
+	local OBJECT_NAME_FORMAT = TRP3_API.globals.addon_name_short .. " — %s"; -- what is this dash character??
+
+	local function SignalLDBObjectUpdate(object)
+		local name = OBJECT_NAME_FORMAT:format(object.configText);
+		local callbackName = "LibDataBroker_AttributeChanged_" .. name;
+		LDB.callbacks:Fire(callbackName, name, nil, object.text, object);
+	end
+	TRP3_API.toolbar.SignalLDBObjectUpdate = SignalLDBObjectUpdate;
+
 	---
 	-- Register a Databroker plugin using a button structure
 	-- @param buttonStructure
 	--
 	local function registerDatabrokerButton(buttonStructure)
+		local objectName = OBJECT_NAME_FORMAT:format(buttonStructure.configText);
 		local LDBObject = LDB:NewDataObject(
-			TRP3_API.globals.addon_name_short .. " — " .. buttonStructure.configText,
+			objectName,
 			{
-				type= "data source",
+				type = "data source",
 				icon = Utils.getIconTexture(buttonStructure.icon),
+				text = buttonStructure.text,
 				OnClick = function(Uibutton, button)
 					if buttonStructure.onClick then
 						buttonStructure.onClick(Uibutton, buttonStructure, button);

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -46,27 +46,7 @@ local function onStart()
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	local LDB = LibStub:GetLibrary("LibDataBroker-1.1");
-
-	-- in order to turn a toolbar object into an LDBObject that can be used by other addons (ElvUI) to display information:
-	-- 	modify the object's 'text' attribute to the desired display text
-	-- 	call TRP3_API.toolbar.SignalLDBObjectUpdate, passing the object as the only arg
-	-- 	ensure the default 'text' attribute is a suitable placeholder, as it will be shown temporarily when the object is updated (at least in the case of ElvUI)
-
 	local OBJECT_NAME_FORMAT = TRP3_API.globals.addon_name_short .. " — %s"; -- what is this dash character??
-
-	local function SignalLDBObjectUpdate(object, attr)
-		local name = OBJECT_NAME_FORMAT:format(object.configText);
-
-		-- have to fire both of these events because some addons only listen to one or the other - peak design
-		local callbackNames = {
-			"LibDataBroker_AttributeChanged_" .. name,
-			"LibDataBroker_AttributeChanged_" .. name .. "_" .. attr,
-		};
-		for _, callback in ipairs(callbackNames) do
-			LDB.callbacks:Fire(callback, name, attr, object[attr], object);
-		end
-	end
-	TRP3_API.toolbar.SignalLDBObjectUpdate = SignalLDBObjectUpdate;
 
 	---
 	-- Register a Databroker plugin using a button structure
@@ -114,6 +94,7 @@ local function onStart()
 		assert(LDBButton, "Could not find a registered LDB object for id " .. buttonStructure.id)
 
 		LDBButton.icon = Utils.getIconTexture(buttonStructure.icon);
+		LDBButton.text = buttonStructure.text; -- need to manually update each attribute here in order to correctly propagate object changes
 
 		LDBButton.tooltipTitle = TRP3_ToolbarUtil.GetFormattedTooltipTitle(buttonStructure);
 		LDBButton.tooltipSub = buttonStructure.tooltipSub;

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -46,7 +46,7 @@ local function onStart()
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	local LDB = LibStub:GetLibrary("LibDataBroker-1.1");
-	local OBJECT_NAME_FORMAT = TRP3_API.globals.addon_name_short .. " — %s"; -- what is this dash character??
+	local OBJECT_NAME_FORMAT = TRP3_API.globals.addon_name_short .. " — %s";
 
 	---
 	-- Register a Databroker plugin using a button structure
@@ -94,7 +94,7 @@ local function onStart()
 		assert(LDBButton, "Could not find a registered LDB object for id " .. buttonStructure.id)
 
 		LDBButton.icon = Utils.getIconTexture(buttonStructure.icon);
-		LDBButton.text = buttonStructure.text; -- need to manually update each attribute here in order to correctly propagate object changes
+		LDBButton.text = buttonStructure.text;
 
 		LDBButton.tooltipTitle = TRP3_ToolbarUtil.GetFormattedTooltipTitle(buttonStructure);
 		LDBButton.tooltipSub = buttonStructure.tooltipSub;

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -54,10 +54,17 @@ local function onStart()
 
 	local OBJECT_NAME_FORMAT = TRP3_API.globals.addon_name_short .. " — %s"; -- what is this dash character??
 
-	local function SignalLDBObjectUpdate(object)
+	local function SignalLDBObjectUpdate(object, attr)
 		local name = OBJECT_NAME_FORMAT:format(object.configText);
-		local callbackName = "LibDataBroker_AttributeChanged_" .. name;
-		LDB.callbacks:Fire(callbackName, name, nil, object.text, object);
+
+		-- have to fire both of these events because some addons only listen to one or the other - peak design
+		local callbackNames = {
+			"LibDataBroker_AttributeChanged_" .. name,
+			"LibDataBroker_AttributeChanged_" .. name .. "_" .. attr,
+		};
+		for _, callback in ipairs(callbackNames) do
+			LDB.callbacks:Fire(callback, name, attr, object[attr], object);
+		end
 	end
 	TRP3_API.toolbar.SignalLDBObjectUpdate = SignalLDBObjectUpdate;
 
@@ -96,7 +103,6 @@ local function onStart()
 				end
 			});
 		LDBObjects[buttonStructure.id] = LDBObject;
-
 	end
 
 	--- Refresh the UI of an databroker object corresponding to the given buttonStructure


### PR DESCRIPTION
Addons like ElvUI, praise be to their name, use the `text` field on LDB objects when creating displays for those objects. Our toolbar objects were missing this field, so they'd show up in the DataText selection but would be completely blank.

I've added a function that allows objects to signal when they're updated, as well as added `text` attributes to some of the buttons people might want to use as DataTexts. Maybe it's worth going through and standardizing the way these LDB objects are handled but until then, this makes the objects functional for LDB displayer addons.