### PR TITLE
Fix Plater optional friendly nameplates handling

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -95,7 +95,6 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 
 	local addons = {
 		"Kui_Nameplates",
-		"Plater",
 		"TidyPlates",
 	};
 
@@ -111,6 +110,13 @@ function TRP3_BlizzardNamePlates:OnModuleInitialize()
 	if ElvUI then
 		local E = ElvUI[1];
 		if E and E.NamePlates and E.NamePlates.Initialized then
+			return TRP3_API.module.status.CONFLICTED, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
+		end
+	end
+
+	-- Plater also has optional friendly nameplates - if they're enabled, we bail
+	if Plater then
+		if Plater.db.profile.plate_config.friendlyplayer.module_enabled then
 			return TRP3_API.module.status.CONFLICTED, L.NAMEPLATES_MODULE_DISABLED_BY_EXTERNAL;
 		end
 	end

--- a/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
@@ -65,7 +65,7 @@ function TRP3_PlaterNamePlates:CustomizeNameplate(nameplate, unitToken, displayI
 	-- Add the icon widget if it doesn't exist, if it does, update it
 	if displayInfo.icon and not plateFrame.TRP3Icon and not displayInfo.shouldHide then
 		do
-			local iconWidget = plateFrame:CreateTexture(nil, "ARTWORK")
+			local iconWidget = plateFrame:CreateTexture(nil, "ARTWORK");
 			iconWidget:ClearAllPoints();
 			iconWidget:SetPoint("RIGHT", plateFrame.CurrentUnitNameString, "LEFT", -4, 0);
 			iconWidget:Hide();
@@ -159,6 +159,11 @@ function TRP3_PlaterNamePlates:OnModuleEnable()
 	end
 
 	Plater = _G.Plater;
+
+	-- Check if the friendly nameplates module is enabled within Plater
+	if not Plater.db.profile.plate_config.friendlyplayer.module_enabled then
+		return TRP3_API.module.status.CONFLICTED, L.NAMEPLATES_MODULE_DISABLED_BY_DEPENDENCY;
+	end
 
 	-- Check if the script exists and has the same revision before importing it, to avoid flooding the recycle bin
 	local scriptObject;


### PR DESCRIPTION
Friendly nameplates are an optional module in Plater, like with ElvUI - this PR ensures that if friendly nameplates are disabled in the Plater config, that the base Blizzard nameplates module can still come in and save the day. This fix feels icky to me since it's a hack on top of a hack but it can't really be fixed otherwise without wider changes to the module system or the two modules themselves. Might be nice to have a system to allow modules to negotiate with each other to see who gets to load. Fixes #1157 