### PR TITLE
Add Group and Category TOC directives

### DIFF
--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -9,8 +9,8 @@
 ## Category-esES: Juego de rol
 ## Category-esMX: Juego de rol
 ## Category-frFR: Jeu de rôle
-## Category-itIT: Gioco di ruolo
-## Category-koKR: 롤플레이
+## Category-itIT: Gioco di Ruolo
+## Category-koKR: 롤플레잉
 ## Category-ptBR: Interpretação de Papel
 ## Category-ruRU: Ролевая игра
 ## Category-zhCN: 角色扮演

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -12,7 +12,7 @@
 ## Category-itIT: Gioco di ruolo
 ## Category-koKR: 롤플레이
 ## Category-ptBR: Jogo de papéis
-## Category-ruRU: Ролевой процесс
+## Category-ruRU: Ролевая игра
 ## Category-zhCN: 角色扮演
 ## Category-zhTW: 角色扮演
 ## Group: totalRP3

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -11,7 +11,7 @@
 ## Category-frFR: Jeu de rôle
 ## Category-itIT: Gioco di ruolo
 ## Category-koKR: 롤플레이
-## Category-ptBR: Jogo de papéis
+## Category-ptBR: Interpretação de Papel
 ## Category-ruRU: Ролевая игра
 ## Category-zhCN: 角色扮演
 ## Category-zhTW: 角色扮演

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -4,6 +4,19 @@
 ## Version: @project-version@
 ## Notes: The best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
 ## IconTexture: Interface\AddOns\totalRP3\Resources\trp3minimap
+## Category-enUS: Roleplay
+## Category-deDE: Rollenspiel
+## Category-esES: Juego de rol
+## Category-esMX: Juego de rol
+## Category-frFR: Jeu de rôle
+## Category-itIT: Gioco di ruolo
+## Category-koKR: 롤플레이
+## Category-ptBR: Jogo de papéis
+## Category-ruRU: Ролевой процесс
+## Category-zhCN: 角色扮演
+## Category-zhTW: 角色扮演
+## Group: totalRP3
+
 ## OptionalDeps: !ClassColors, _DebugLog, Kui_Nameplates, Kui_Nameplates_Core, Prat-3.0, WagoAnalytics
 ## RequiredDeps: totalRP3_Data
 ## SavedVariables: TRP3_Profiles, TRP3_Characters, TRP3_Configuration, TRP3_Flyway, TRP3_Presets, TRP3_Companions, TRP3_MatureFilter, TRP3_Colors, TRP3_Notes, TRP3_SavedAutomation

--- a/totalRP3_Data/totalRP3_Data.toc
+++ b/totalRP3_Data/totalRP3_Data.toc
@@ -4,6 +4,7 @@
 ## Version: @project-version@
 ## Notes: The best data storage for the best roleplaying addon for World of Warcraft.|n|n|cffffd200Version:|r @project-version@
 ## IconTexture: 982414
+## Group: totalRP3
 ## SavedVariables: TRP3_AddonLocale, TRP3_Register
 ## LoadOnDemand: 1
 


### PR DESCRIPTION
Initial translations for these categories are machine-translated, but they look consistent with Blizzard's own strings as used for realm category names with the exception of ptBR; however the ptBR translation is much longer so it might be the case that Blizzard specifically chose a much shorter string so as to avoid UI issues.

Explicit Groups have been defined on both TOCs to prevent any cases where the auto-grouping might for some reason decide to break our addons apart, eg. if someone made an addon called "tot" and made it depend upon "totalRP3".

![image](https://github.com/user-attachments/assets/994b94a3-1763-4108-b6c9-5942f0ea5b71)

I'd like some native speakers to confirm these strings before we use them ideally, and for us to remain consistent with (read: edit and replace) [this list here](https://warcraft.wiki.gg/wiki/Addon_Categories#Roleplay) so that we're the authoritative source of all things RP.