### PR TITLE
Fix error on opening walkup/proficiency/automation action dropdowns

### DIFF
--- a/totalRP3/Modules/Automation/Automation_Settings.lua
+++ b/totalRP3/Modules/Automation/Automation_Settings.lua
@@ -107,7 +107,7 @@ function TRP3_AutomationSettingsMixin:SetupActionDropdownMenu(menuDescription)
 		end
 
 		local displayText = action.name;
-		local displayIcon;
+		local displayIcon = "";
 		local tooltipText = string.join("|n|n", action.description, action.help);
 
 		if action.expression and action.expression ~= "" then

--- a/totalRP3/Modules/Dashboard/StatusPanel.lua
+++ b/totalRP3/Modules/Dashboard/StatusPanel.lua
@@ -115,7 +115,7 @@ local function GenerateXPStatusMenu(_, rootDescription)
 
 	for _, level in ipairs(levels) do
 		local text = TRP3_API.GetRoleplayExperienceText(level);
-		local icon = TRP3_API.GetRoleplayExperienceIcon(level);
+		local icon = TRP3_API.GetRoleplayExperienceIcon(level) or "";
 		local tooltipText = TRP3_API.GetRoleplayExperienceTooltipText(level);
 
 		local elementDescription = rootDescription:CreateRadio(text, IsRoleplayExperienceLevel, SetRoleplayExperienceLevel, level);

--- a/totalRP3/Modules/Dashboard/StatusPanel.lua
+++ b/totalRP3/Modules/Dashboard/StatusPanel.lua
@@ -94,7 +94,7 @@ end
 local function GenerateWalkupMenu(_, rootDescription)
 	do  -- Walkup No
 		local walkup = AddOn_TotalRP3.Enums.WALKUP.NO;
-		local elementDescription = rootDescription:CreateRadio(L.CM_DO_NOT_SHOW, IsWalkupFriendly, SetWalkup, walkup);
+		rootDescription:CreateRadio(L.CM_DO_NOT_SHOW, IsWalkupFriendly, SetWalkup, walkup);
 	end
 
 	do  -- Walkup Yes

--- a/totalRP3/Modules/Dashboard/StatusPanel.lua
+++ b/totalRP3/Modules/Dashboard/StatusPanel.lua
@@ -95,7 +95,6 @@ local function GenerateWalkupMenu(_, rootDescription)
 	do  -- Walkup No
 		local walkup = AddOn_TotalRP3.Enums.WALKUP.NO;
 		local elementDescription = rootDescription:CreateRadio(L.CM_DO_NOT_SHOW, IsWalkupFriendly, SetWalkup, walkup);
-		TRP3_MenuUtil.AttachTexture(elementDescription);
 	end
 
 	do  -- Walkup Yes

--- a/totalRP3/UI/Menu/MenuUtil.lua
+++ b/totalRP3/UI/Menu/MenuUtil.lua
@@ -15,6 +15,8 @@ function TRP3_MenuUtil.SetElementTooltip(elementDescription, tooltipText)
 end
 
 function TRP3_MenuUtil.AttachTexture(elementDescription, icon)
+	if not icon then return end
+
 	local function Initializer(button)
 		local iconTexture = button:AttachTexture();
 		iconTexture:SetPoint("RIGHT");

--- a/totalRP3/UI/Menu/MenuUtil.lua
+++ b/totalRP3/UI/Menu/MenuUtil.lua
@@ -15,8 +15,6 @@ function TRP3_MenuUtil.SetElementTooltip(elementDescription, tooltipText)
 end
 
 function TRP3_MenuUtil.AttachTexture(elementDescription, icon)
-	if not icon then return end
-
 	local function Initializer(button)
 		local iconTexture = button:AttachTexture();
 		iconTexture:SetPoint("RIGHT");


### PR DESCRIPTION
In dropdowns where we have some options with an attached texture and some without, we decided to pass nil, which doesn't work anymore due to GetAtlasInfo throwing a tantrum with nil.

Since we used that trick a couple times, I'd rather add the safety check at the start of the AttachTexture function than add empty strings around. However, that one call that explicitly had a nil passed and nothing else can go.