### PR TITLE
Fix relative key issue in PetBrowser

### DIFF
--- a/totalRP3/UI/Browsers/PetBrowser.xml
+++ b/totalRP3/UI/Browsers/PetBrowser.xml
@@ -94,8 +94,8 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Layer level="OVERLAY">
 						<FontString parentKey="Text" inherits="QuestTitleFontBlackShadow" justifyH="CENTER" justifyV="MIDDLE">
 							<Anchors>
-								<Anchor point="TOPLEFT" relativeKey="$parent.Header"/>
-								<Anchor point="BOTTOMRIGHT" relativeKey="$parent.Header" y="8"/>
+								<Anchor point="TOPLEFT"/>
+								<Anchor point="BOTTOMRIGHT" y="8"/>
 							</Anchors>
 						</FontString>
 					</Layer>


### PR DESCRIPTION
This usage of `relativeKey` is technically invalid. As the key being specified is in fact its parent, resolution of its key won't work until _after_ the parent has been fully parsed.

Conveniently, the result of such behaviour though is that it just anchors to the parent anyway - so it's looked correct, but only by chance.