### PR TITLE
Fix Prat realm removal setting

### DIFF
--- a/totalRP3/Modules/ChatFrame/Prat.lua
+++ b/totalRP3/Modules/ChatFrame/Prat.lua
@@ -65,7 +65,7 @@ Prat:AddModuleToLoad(function()
 		-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 		if realm == TRP3_API.globals.player_realm_id or TRP3_API.configuration.getValue("remove_realm") then
 			characterName = name;
-			
+
 			message.sS = ""
 			message.SERVER = ""
 			message.Ss = ""

--- a/totalRP3/Modules/ChatFrame/Prat.lua
+++ b/totalRP3/Modules/ChatFrame/Prat.lua
@@ -65,6 +65,10 @@ Prat:AddModuleToLoad(function()
 		-- Character name is without the server name is they are from the same realm or if the option to remove realm info is enabled
 		if realm == TRP3_API.globals.player_realm_id or TRP3_API.configuration.getValue("remove_realm") then
 			characterName = name;
+			
+			message.sS = ""
+			message.SERVER = ""
+			message.Ss = ""
 		end
 
 		-- Get the unit color and name
@@ -105,9 +109,6 @@ Prat:AddModuleToLoad(function()
 
 		-- Replace the message player name with the colored character name
 		message.PLAYER = characterName
-		message.sS = nil
-		message.SERVER = nil
-		message.Ss = nil
 	end
 
 	function pratModule:OnModuleEnable()


### PR DESCRIPTION
Realm removal setting wasn't working in either Prat or TRP when using both addons. Dug a little bit, seems it gets added by Prat when giving it `nil` for the additional fields.

If changing the fields to be an empty string instead when the TRP setting is enabled (or player on the same realm), the realm now appears hidden whether the setting is enabled in Prat or in TRP.