### PR TITLE
Fix link conversion on MSP

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -63,8 +63,10 @@ local function onStart()
 
 	local function removeTextTags(text)
 		if text then
+			text =  text:gsub("%{link%*([^*]+)%*({icon:[^}]+})}","[%2]( %1 )"); --cleanup links instead of outright removing the tag
+			text =  text:gsub("%{link%*(.-)%*(.-)%}","[%2]( %1 )"); --cleanup links instead of outright removing the tag
 			text = Utils.str.convertTextTags(text);
-			return text:gsub("%{link%*(.-)%*(.-)%}","[%2]( %1 )"); --cleanup links instead of outright removing the tag
+			return text;
 		end
 	end
 


### PR DESCRIPTION
I received an anonymous hint that icon links were busted on MRP. After investigating both sides, I found out we were sending invalid data over on MRP when converting {link*...} tags into the \[...](...) version MRP is used to.

![image](https://github.com/user-attachments/assets/9fb17b56-a646-4346-8d0c-bacf333b9274)

Doing the link tag conversion prior to converting the rest of the tags fixes the issue, as there is no nested brackets anymore.