### PR TITLE
Remove ClearAllPoints call after we show the tooltip

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1374,8 +1374,6 @@ local function show(targetType, targetID, targetMode)
 					end
 				end
 			end
-
-			TRP3_CharacterTooltip:ClearAllPoints(); -- Prevent to break parent frame fade out if parent is a tooltip.
 		end
 	end
 end


### PR DESCRIPTION
Blizzard are changing ClearAllPoints in 11.2.0 to invalidate frame rects. To accommodate, we need to remove this post-Show ClearAllPoints call or we'll end up with an invisible tooltip.

```lua
-- NOTE FOR ADDON DEVELOPERS:
-- Starting this patch, region:ClearAllPoints() will immediately invalidate the rect.
-- This means you cannot rely on calling GetWidth, GetHeight, GetTop/Left/Bottom/Right, or GetRect after ClearAllPoints.
-- Any measurement calculations relying on the previous rect should occur before calling ClearAllPoints.
```

God knows why the code was doing this all along. Will probably break something like fading, but that's better than literally _not having a tooltip whatsoever_.