### PR TITLE
Fix broken realm name normalization pattern

### DIFF
--- a/totalRP3/Core/Globals.lua
+++ b/totalRP3/Core/Globals.lua
@@ -95,7 +95,7 @@ setmetatable(TRP3_API.globals.empty, emptyMeta);
 
 TRP3_API.globals.build = function()
 	local fullName = UnitNameUnmodified("player");
-	local realm = GetRealmName():gsub("[%s*%-%.]*", "");
+	local realm = GetRealmName():gsub("[%s%-%.]*", "");
 	TRP3_API.globals.player_realm_id = realm;
 	TRP3_API.globals.player_id = fullName .. "-" .. realm;
 	TRP3_API.globals.player_icon = TRP3_API.ui.misc.getUnitTexture(race, UnitSex("player"));


### PR DESCRIPTION
Realm name normalization needs to skip period characters, but also our pattern here was broken - it'd only replace _one_ invalid character because the repeat specifier was inside the character set block.