### PR TITLE
Restore target frame buttons settings + add settings title for them

### DIFF
--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -568,7 +568,7 @@ Possible status:
 	CO_TARGETFRAME_USE_2 = "Only when IC",
 	CO_TARGETFRAME_USE_3 = "Never (Disabled)",
 	CO_TARGETFRAME_ICON_SIZE = "Icons size",
-	CO_BARFRAME_BUTTONSVISIBILITY = "Buttons visibility",
+	CO_BARFRAME_BUTTONSVISIBILITY = "Button visibility",
 	CO_MINIMAP_BUTTON = "Minimap button",
 	CO_MINIMAP_BUTTON_SHOW_TITLE = "Show minimap button",
 	CO_MINIMAP_BUTTON_SHOW_HELP = [[If you are using another add-on to display Total RP 3's minimap button (FuBar, Titan, Bazooka) you can remove the button from the minimap.

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -568,6 +568,7 @@ Possible status:
 	CO_TARGETFRAME_USE_2 = "Only when IC",
 	CO_TARGETFRAME_USE_3 = "Never (Disabled)",
 	CO_TARGETFRAME_ICON_SIZE = "Icons size",
+	CO_BARFRAME_BUTTONSVISIBILITY = "Buttons visibility",
 	CO_MINIMAP_BUTTON = "Minimap button",
 	CO_MINIMAP_BUTTON_SHOW_TITLE = "Show minimap button",
 	CO_MINIMAP_BUTTON_SHOW_HELP = [[If you are using another add-on to display Total RP 3's minimap button (FuBar, Titan, Bazooka) you can remove the button from the minimap.

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -403,7 +403,7 @@ local function onStart()
 				configKey = configKey,
 			});
 		end
-		
+	
 		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
 	end);
 

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -403,7 +403,7 @@ local function onStart()
 				configKey = configKey,
 			});
 		end
-	
+
 		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
 	end);
 

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -378,7 +378,6 @@ local function onStart()
 			end,
 		});
 
-		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
 
 		local ids = {};
 		for buttonID, _ in pairs(targetButtons) do
@@ -400,6 +399,8 @@ local function onStart()
 				configKey = configKey,
 			});
 		end
+		
+		TRP3_API.configuration.registerConfigurationPage(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE);
 	end);
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -378,6 +378,10 @@ local function onStart()
 			end,
 		});
 
+		tinsert(TRP3_API.configuration.CONFIG_TARGETFRAME_PAGE.elements, {
+			inherit = "TRP3_ConfigH1",
+			title = loc.CO_BARFRAME_BUTTONSVISIBILITY,
+		});
 
 		local ids = {};
 		for buttonID, _ in pairs(targetButtons) do

--- a/totalRP3/Modules/Toolbar/Toolbar.lua
+++ b/totalRP3/Modules/Toolbar/Toolbar.lua
@@ -217,6 +217,11 @@ local function onStart()
 			configKey = TRP3_ToolbarConfigKeys.HideTitle,
 		});
 
+		tinsert(TRP3_API.configuration.CONFIG_TOOLBAR_PAGE.elements, {
+			inherit = "TRP3_ConfigH1",
+			title = loc.CO_BARFRAME_BUTTONSVISIBILITY,
+		});
+
 		local ids = {};
 		for buttonID, _ in pairs(buttonStructures) do
 			tinsert(ids, buttonID);


### PR DESCRIPTION
During some big modernization pass last summer (#1108), the toolbar and target frame settings registration got moved to be properly registered only when those were enabled, but the target frame one was moved a bit too early and excluded the buttons visibility options.

It is now back in its proper place, and as an added bonus, I split those settings (and the toolbar ones) with a title, didn't like how they were all bunched up with the rest of the settings.

<img width="957" height="478" alt="image" src="https://github.com/user-attachments/assets/977590f9-6f51-4799-9b35-22cb1241bad2" />
<img width="954" height="717" alt="image" src="https://github.com/user-attachments/assets/cbf1ff21-b2b9-42d9-bbeb-b70b606c2b2b" />
