### PR TITLE
Hide toolbar and target frame when in pet battles

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -571,6 +571,7 @@ stds.wow = {
 		"PlaySoundFile",
 		"RaidNotice_AddMessage",
 		"RaidWarningFrame",
+		"RegisterStateDriver",
 		"ReloadUI",
 		"RemoveChatWindowChannel",
 		"ResetCursor",

--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -252,7 +252,9 @@ local function onStart()
 	end
 
 	local function shouldShowTargetFrame(config)
-		if currentTargetID == nil or (getConfigValue(config) ~= 1 and (getConfigValue(config) ~= 2 or not isPlayerIC())) then
+		if ui_TargetFrame:GetAttribute("state-forcehide") == 1 then
+			return false;
+		elseif currentTargetID == nil or (getConfigValue(config) ~= 1 and (getConfigValue(config) ~= 2 or not isPlayerIC())) then
 			return false;
 		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.CHARACTER and (currentTargetID == Globals.player_id or (not isIDIgnored(currentTargetID) and isUnitIDKnown(currentTargetID))) then
 			return true;
@@ -312,6 +314,16 @@ local function onStart()
 		-- Update tooltip anchors
 		for _,uiButton in pairs(uiButtons) do
 			updateTargetFrameButtonTooltip(uiButton);
+		end
+	end);
+
+	ui_TargetFrame:SetScript("OnAttributeChanged", function(self, attr)
+		if attr == "state-forcehide" then
+			if shouldShowTargetFrame(CONFIG_TARGET_USE) then
+				displayTargetFrame();
+			else
+				ui_TargetFrame:Hide();
+			end
 		end
 	end);
 
@@ -426,6 +438,8 @@ local function onStart()
 	end);
 
 	TRP3_API.RegisterCallback(TRP3_Addon, "ROLEPLAY_STATUS_CHANGED", function() onTargetChanged(); end);
+
+	RegisterStateDriver(ui_TargetFrame, "forcehide", "[petbattle] 1;0");
 end
 
 local MODULE_STRUCTURE = {

--- a/totalRP3/Modules/TargetFrame/TargetFrame.xml
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.xml
@@ -20,16 +20,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	</Button>
 
 	<!-- Target Frame -->
-	<Frame name="TRP3_TargetFrameTemplate" toplevel="true" enableMouse="true" hidden="true" inherits="TRP3_GroupBoxTemplate" virtual="true">
+	<Frame name="TRP3_TargetFrameTemplate" toplevel="true" enableMouse="true" hidden="true" inherits="TRP3_GroupBoxTemplate" clampedToScreen="true" virtual="true">
 		<Size x="200" y="50" />
 		<KeyValues>
 			<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
 		</KeyValues>
-		<Scripts>
-			<OnLoad inherit="prepend">
-				self:SetClampedToScreen(true);
-			</OnLoad>
-		</Scripts>
 	</Frame>
 
 	<Include file="TargetFrame.lua"/>

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.lua
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.lua
@@ -10,6 +10,8 @@ function TRP3_ToolbarFrameMixin:Init()
 	self:LoadPosition();
 	self:UpdateFrameVisibility();
 	self:UpdateTitleBar();
+
+	RegisterStateDriver(self, "forcehide", "[petbattle] 1;0");
 end
 
 function TRP3_ToolbarFrameMixin:OnLoad()
@@ -19,6 +21,12 @@ end
 
 function TRP3_ToolbarFrameMixin:OnShow()
 	self:MarkDirty();
+end
+
+function TRP3_ToolbarFrameMixin:OnAttributeChanged(attr)
+	if attr == "state-forcehide" then
+		self:UpdateFrameVisibility();
+	end
 end
 
 function TRP3_ToolbarFrameMixin:OnUpdate()
@@ -136,6 +144,8 @@ function TRP3_ToolbarFrameMixin:UpdateFrameVisibility(forcedVisibility)
 
 	if forcedVisibility ~= nil then
 		shouldShow = forcedVisibility;
+	elseif self:GetAttribute("state-forcehide") == 1 then
+		shouldShow = false;
 	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.AlwaysHidden then
 		shouldShow = false;
 	elseif configuredVisibility == TRP3_ToolbarVisibilityOption.OnlyShowInCharacter then

--- a/totalRP3/Modules/Toolbar/ToolbarFrame.xml
+++ b/totalRP3/Modules/Toolbar/ToolbarFrame.xml
@@ -45,6 +45,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Scripts>
 			<OnLoad method="OnLoad"/>
 			<OnShow method="OnShow"/>
+			<OnAttributeChanged method="OnAttributeChanged"/>
 			<OnDragStart method="OnDragStart"/>
 			<OnDragStop method="OnDragStop"/>
 		</Scripts>


### PR DESCRIPTION
When entering pet battles we have this annoying tendency to leave stuff like the toolbar and target frame open. Hook up a small integration into the state driver system that'll allow us to monitor changes to pet battle state, and update visibility of the frames accordingly.