### PR TITLE
Add request indicator to main profile view

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -427,6 +427,12 @@ stds.wow = {
 			},
 		},
 
+		ResizeLayoutMixin = {
+			fields = {
+				"OnShow",
+			},
+		},
+
 		ScrollBoxConstants = {
 			fields = {
 				"DiscardScrollPosition",

--- a/totalRP3/Core/Objects/Callback.lua
+++ b/totalRP3/Core/Objects/Callback.lua
@@ -1,8 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local TRP3_API = select(2, ...);
-
 -- Callback objects are prebaked closures associated with a registry that can
 -- be toggled on-demand.
 --

--- a/totalRP3/Core/Objects/CallbackGroup.lua
+++ b/totalRP3/Core/Objects/CallbackGroup.lua
@@ -1,8 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local TRP3_API = select(2, ...);
-
 -- Callback groups provide a mechanism for toggling a collection of registrables
 -- on-demand. The concept of a "registrable" is anything that provides a pair
 -- of parameterless "Register" and "Unregister" methods.

--- a/totalRP3/Core/Objects/CallbackGroupCollection.lua
+++ b/totalRP3/Core/Objects/CallbackGroupCollection.lua
@@ -1,8 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local TRP3_API = select(2, ...);
-
 -- Callback group collections are a convenience wrapper for managing a keyed
 -- set of callback groups. Callbacks can be added to a child group with a
 -- user-defined group "key", and the groups later mass-toggled or individually

--- a/totalRP3/Core/Objects/CallbackRegistry.lua
+++ b/totalRP3/Core/Objects/CallbackRegistry.lua
@@ -1,8 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local TRP3_API = select(2, ...);
-
 local CallbackHandler = LibStub:GetLibrary("CallbackHandler-1.0");
 
 -- The below convenience utilities are for initializing callback callbacks

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -374,6 +374,7 @@ The formatting tools give you access to various |cnGREEN_FONT_COLOR:layout param
 
 |cnGREEN_FONT_COLOR:Companion description:|r
 The description doesn't have to be limited to |cnGREEN_FONT_COLOR:physical description|r. Feel free to indicate parts from their |cnGREEN_FONT_COLOR:background|r or details about their |cnGREEN_FONT_COLOR:personality|r.]],
+	REG_UPDATING_PROFILE = "Updating profile...",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- CONFIGURATION

--- a/totalRP3/Modules/Register/Characters/RegisterUIMain.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMain.xml
@@ -9,22 +9,13 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		<Size x="22" y="22"/>
 		<Layers>
 			<Layer level="OVERLAY">
-				<Texture parentKey="Icon" file="Interface\AddOns\totalRP3\Resources\UI\ui-refresh" texelSnappingBias="0.0" snapToPixelGrid="false">
-					<Size x="16" y="16"/>
+				<Texture parentKey="Icon" inherits="TRP3_RefreshSpinnerIcon">
 					<Anchors>
 						<Anchor point="CENTER"/>
 					</Anchors>
 				</Texture>
 			</Layer>
 		</Layers>
-		<Animations>
-			<AnimationGroup parentKey="SpinAnimation" looping="REPEAT">
-				<Rotation childKey="Icon" duration="1.5" degrees="-360" smoothing="OUT_IN"/>
-				<Scripts>
-					<OnLoad method="Play"/>
-				</Scripts>
-			</AnimationGroup>
-		</Animations>
 	</Frame>
 
 	<!-- Character tooltip -->
@@ -131,6 +122,11 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 				</Layers>
 				<HighlightTexture file="Interface\Minimap\UI-Minimap-ZoomButton-Highlight" alphaMode="ADD"/>
 			</Button>
+			<Frame parentKey="RequestIndicator" inherits="TRP3_RegisterRequestIndicatorTemplate" frameLevel="1000" fixedFrameLevel="true" hidden="true">
+				<Anchors>
+					<Anchor point="BOTTOMRIGHT" x="-5" y="5"/>
+				</Anchors>
+			</Frame>
 		</Frames>
 	</Frame>
 

--- a/totalRP3/Modules/Register/Main/RegisterRequestIndicator.lua
+++ b/totalRP3/Modules/Register/Main/RegisterRequestIndicator.lua
@@ -1,0 +1,110 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_RegisterRequestIndicatorMixin = {};
+
+local CallbackGroup = {
+	Dynamic = "dynamic",
+	Static = "static",
+};
+
+function TRP3_RegisterRequestIndicatorMixin:OnLoad()
+	self.callbacks = TRP3_API.CreateCallbackGroupCollection();
+	self.callbacks:AddCallback(CallbackGroup.Dynamic, TRP3_Addon, "REGISTER_REQUEST_STATE_CHANGED", "OnRegisterRequestStateChanged", self);
+	self.callbacks:AddCallback(CallbackGroup.Static, TRP3_Addon, "PAGE_OPENED", "OnPageOpened", self);
+	self.callbacks:RegisterGroup(CallbackGroup.Static);
+
+	-- Frame edge gradients have no XML integration.
+	-- Note that even if no fading is requested on an edge, both gradient
+	-- indices must be populated or we'll end up with a mostly invisible
+	-- frame. Also, this requires render layer flattening to be enabled or no
+	-- fade will occur.
+
+	local edgeFadeTop = 15;
+	local edgeFadeLeft = 15;
+	local edgeFadeRight = 0;
+	local edgeFadeBottom = 0;
+
+	self.Background:SetAlphaGradient(0, CreateVector2D(edgeFadeLeft, edgeFadeTop));
+	self.Background:SetAlphaGradient(1, CreateVector2D(edgeFadeRight, edgeFadeBottom));
+end
+
+function TRP3_RegisterRequestIndicatorMixin:OnEnabled()
+	self.callbacks:Register();
+end
+
+function TRP3_RegisterRequestIndicatorMixin:OnDisabled()
+	self.callbacks:Unregister();
+end
+
+function TRP3_RegisterRequestIndicatorMixin:OnRegisterRequestStateChanged()
+	self:UpdateShownState();
+end
+
+function TRP3_RegisterRequestIndicatorMixin:OnPageOpened()
+	self:UpdateDynamicCallbacks();
+	self:UpdateShownState();
+end
+
+function TRP3_RegisterRequestIndicatorMixin:BeginShow()
+	local progress = self.FadeAnimation:GetProgress();
+	local isFading = self.FadeAnimation:IsPlaying();
+	local isShown = self:IsShown();
+
+	self.FadeAnimation:SetScript("OnPlay", function() self:Show(); end);
+	self.FadeAnimation:SetScript("OnFinished", nil);
+
+	local reverse = false;
+	local offset = isFading and (1 - progress) or (isShown and 1 or 0);
+	self.FadeAnimation:Restart(reverse, offset);
+end
+
+function TRP3_RegisterRequestIndicatorMixin:BeginHide()
+	local progress = self.FadeAnimation:GetProgress();
+	local isFading = self.FadeAnimation:IsPlaying();
+	local isShown = self:IsShown();
+
+	self.FadeAnimation:SetScript("OnPlay", nil);
+	self.FadeAnimation:SetScript("OnFinished", function() self:Hide(); end);
+
+	local reverse = true;
+	local offset = isFading and (1 - progress) or (isShown and 0 or 1);
+	self.FadeAnimation:Restart(reverse, offset);
+end
+
+function TRP3_RegisterRequestIndicatorMixin:ApplyShownState(shouldShow)
+	local isShown = self:IsShown();
+
+	if shouldShow and not isShown then
+		self:BeginShow();
+	elseif not shouldShow and isShown then
+		self:BeginHide();
+	end
+end
+
+function TRP3_RegisterRequestIndicatorMixin:IsEnabledFromNavigationContext(pageID, context)
+	return pageID == "player_main" and context ~= nil and context.source == "directory" and context.unitID ~= nil;
+end
+
+function TRP3_RegisterRequestIndicatorMixin:UpdateShownState()
+	local pageID = TRP3_API.navigation.page.getCurrentPageID();
+	local context = TRP3_API.navigation.page.getCurrentContext();
+
+	if self:IsEnabledFromNavigationContext(pageID, context) then
+		local shouldShow = TRP3_API.register.HasActiveRequest(context.unitID);
+		self:ApplyShownState(shouldShow);
+	else
+		self:Hide();
+	end
+end
+
+function TRP3_RegisterRequestIndicatorMixin:UpdateDynamicCallbacks()
+	local pageID = TRP3_API.navigation.page.getCurrentPageID();
+	local context = TRP3_API.navigation.page.getCurrentContext();
+
+	if self:IsEnabledFromNavigationContext(pageID, context) then
+		self.callbacks:RegisterGroup(CallbackGroup.Dynamic);
+	else
+		self.callbacks:UnregisterGroup(CallbackGroup.Dynamic);
+	end
+end

--- a/totalRP3/Modules/Register/Main/RegisterRequestIndicator.lua
+++ b/totalRP3/Modules/Register/Main/RegisterRequestIndicator.lua
@@ -1,6 +1,8 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
+local L = TRP3_API.loc;
+
 TRP3_RegisterRequestIndicatorMixin = {};
 
 local CallbackGroup = {
@@ -19,14 +21,25 @@ function TRP3_RegisterRequestIndicatorMixin:OnLoad()
 	-- indices must be populated or we'll end up with a mostly invisible
 	-- frame. Also, this requires render layer flattening to be enabled or no
 	-- fade will occur.
+	--
+	-- As of writing - Classic Era (1.15.7) doesn't support this tech, so
+	-- it'll have no fading.
 
-	local edgeFadeTop = 15;
-	local edgeFadeLeft = 15;
-	local edgeFadeRight = 0;
-	local edgeFadeBottom = 0;
+	if self.Background.SetAlphaGradient then
+		local edgeFadeTop = 15;
+		local edgeFadeLeft = 15;
+		local edgeFadeRight = 0;
+		local edgeFadeBottom = 0;
 
-	self.Background:SetAlphaGradient(0, CreateVector2D(edgeFadeLeft, edgeFadeTop));
-	self.Background:SetAlphaGradient(1, CreateVector2D(edgeFadeRight, edgeFadeBottom));
+		self.Background:SetAlphaGradient(0, CreateVector2D(edgeFadeLeft, edgeFadeTop));
+		self.Background:SetAlphaGradient(1, CreateVector2D(edgeFadeRight, edgeFadeBottom));
+	end
+end
+
+function TRP3_RegisterRequestIndicatorMixin:OnShow()
+	-- Localize before triggering a layout update, or the size will be wrong.
+	self.Text:SetText(L.REG_UPDATING_PROFILE);
+	ResizeLayoutMixin.OnShow(self);
 end
 
 function TRP3_RegisterRequestIndicatorMixin:OnEnabled()

--- a/totalRP3/Modules/Register/Main/RegisterRequestIndicator.xml
+++ b/totalRP3/Modules/Register/Main/RegisterRequestIndicator.xml
@@ -1,0 +1,55 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="RegisterRequestIndicator.lua"/>
+
+	<Frame name="TRP3_RegisterRequestIndicatorTemplate" mixin="TRP3_RegisterRequestIndicatorMixin" inherits="ResizeLayoutFrame" virtual="true">
+		<Size x="1" y="1"/>
+		<Anchors>
+			<Anchor point="CENTER"/>
+		</Anchors>
+		<KeyValues>
+			<KeyValue key="heightPadding" value="15" type="number"/>
+			<KeyValue key="widthPadding" value="25" type="number"/>
+		</KeyValues>
+		<Layers>
+			<Layer level="OVERLAY">
+				<Texture parentKey="Icon" inherits="TRP3_RefreshSpinnerIcon">
+					<Anchors>
+						<Anchor point="LEFT" x="15" y="-5"/>
+					</Anchors>
+				</Texture>
+				<FontString parentKey="Text" inherits="GameFontHighlight" text="Updating profile...">
+					<Anchors>
+						<Anchor point="LEFT" relativeKey="$parent.Icon" relativePoint="RIGHT" x="5"/>
+					</Anchors>
+				</FontString>
+			</Layer>
+		</Layers>
+		<Frames>
+			<Frame parentKey="Background" flattenRenderLayers="true" setAllPoints="true" useParentLevel="true">
+				<KeyValues>
+					<KeyValue key="ignoreInLayout" value="true" type="boolean"/>
+				</KeyValues>
+				<Layers>
+					<Layer level="BACKGROUND">
+						<Texture parentKey="Background">
+							<Color a="0.6"/>
+						</Texture>
+					</Layer>
+				</Layers>
+			</Frame>
+		</Frames>
+		<Animations>
+			<AnimationGroup parentKey="FadeAnimation" setToFinalAlpha="true">
+				<Alpha toAlpha="1" duration="0.25" smoothing="IN" order="1"/>
+			</AnimationGroup>
+		</Animations>
+		<Scripts>
+			<OnLoad method="OnLoad"/>
+		</Scripts>
+	</Frame>
+</Ui>

--- a/totalRP3/Modules/Register/Main/RegisterRequestIndicator.xml
+++ b/totalRP3/Modules/Register/Main/RegisterRequestIndicator.xml
@@ -22,7 +22,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						<Anchor point="LEFT" x="15" y="-5"/>
 					</Anchors>
 				</Texture>
-				<FontString parentKey="Text" inherits="GameFontHighlight" text="Updating profile...">
+				<FontString parentKey="Text" inherits="GameFontHighlight">
 					<Anchors>
 						<Anchor point="LEFT" relativeKey="$parent.Icon" relativePoint="RIGHT" x="5"/>
 					</Anchors>
@@ -50,6 +50,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 		</Animations>
 		<Scripts>
 			<OnLoad method="OnLoad"/>
+			<OnShow method="OnShow"/>
 		</Scripts>
 	</Frame>
 </Ui>

--- a/totalRP3/Modules/Register/Register.xml
+++ b/totalRP3/Modules/Register/Register.xml
@@ -6,6 +6,7 @@
 https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Include file="Main\RegisterTemplates.xml"/>
+	<Include file="Main\RegisterRequestIndicator.xml"/>
 	<Include file="Characters\RegisterUICharacteristics.xml"/>
 	<Include file="Characters\RegisterUIAbout.xml"/>
 	<Include file="Characters\RegisterUIMisc.xml"/>

--- a/totalRP3/UI/RefreshSpinner.lua
+++ b/totalRP3/UI/RefreshSpinner.lua
@@ -1,0 +1,34 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_RefreshSpinnerMixin = {};
+
+function TRP3_RefreshSpinnerMixin:OnShow()
+	if self:ShouldPlayOnShow() then
+		self:Play();
+	end
+end
+
+function TRP3_RefreshSpinnerMixin:OnHide()
+	self:Stop();
+end
+
+function TRP3_RefreshSpinnerMixin:SetPlaying(playing)
+	self.SpinAnimation:SetPlaying(playing);
+end
+
+function TRP3_RefreshSpinnerMixin:Play()
+	self:SetPlaying(true);
+end
+
+function TRP3_RefreshSpinnerMixin:Stop()
+	self:SetPlaying(false);
+end
+
+function TRP3_RefreshSpinnerMixin:SetPlayOnShow(playOnShow)
+	self.playOnShow = playOnShow;
+end
+
+function TRP3_RefreshSpinnerMixin:ShouldPlayOnShow()
+	return self.playOnShow;
+end

--- a/totalRP3/UI/RefreshSpinner.xml
+++ b/totalRP3/UI/RefreshSpinner.xml
@@ -1,0 +1,23 @@
+<!--
+	Copyright The Total RP 3 Authors
+	SPDX-License-Identifier: Apache-2.0
+-->
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
+	<Include file="RefreshSpinner.lua"/>
+
+	<Texture name="TRP3_RefreshSpinnerIcon" mixin="TRP3_RefreshSpinnerMixin" file="Interface\AddOns\totalRP3\Resources\UI\ui-refresh" texelSnappingBias="0.0" snapToPixelGrid="false" virtual="true">
+		<Size x="16" y="16"/>
+		<KeyValues>
+			<KeyValue key="playOnShow" value="true" type="boolean"/>
+		</KeyValues>
+		<Animations>
+			<AnimationGroup parentKey="SpinAnimation" looping="REPEAT">
+				<Rotation duration="3" degrees="-1080" smoothing="OUT_IN"/>
+			</AnimationGroup>
+		</Animations>
+		<Scripts>
+			<OnShow method="OnShow"/>
+		</Scripts>
+	</Texture>
+</Ui>

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -15,6 +15,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="FontUtil.lua"/>
 	<Include file="TextUtil.lua"/>
 	<Include file="ColorSwatch.xml"/>
+	<Include file="RefreshSpinner.xml"/>
 	<Include file="Tooltip\Tooltip.xml"/>
 	<Include file="Widgets.lua"/>
 	<Include file="Menu\Menu.xml"/>


### PR DESCRIPTION
This implements a small overlay on our register profile view at the bottom right corner if you're looking at a profile that we're actively in the process of requesting new data from. This aims to make it a bit clearer that the addon is actually doing work that might change what you're reading, and to avoid the awkward state where we sometimes just hang with an "Unknown" character name if comms are being slow.

https://github.com/user-attachments/assets/de3a6377-bb7f-4adf-8f9d-52b0be8fb3be

The indicator shows generally if you're on a profile page irrespective of what tab you've got selected, and it'll show if there's _any_ outstanding data for the profile. We could technically make it only show on tabs actively being requested, but that might be a bit strange to look at - this is more stable a display at least, and matches how we show indicators on tooltips so has the benefit of being consistent.
