### PR TITLE
Fix nil sender concat in ChatLink tooltips

### DIFF
--- a/totalRP3/Modules/ChatLinks/ChatLinks.lua
+++ b/totalRP3/Modules/ChatLinks/ChatLinks.lua
@@ -176,7 +176,9 @@ TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, func
 			if itemData.moduleName then
 				TRP3_RefTooltip:AddLine(loc.CL_TYPE:format("|cnWHITE_FONT_COLOR:" .. itemData.moduleName .. "|r"));
 			end
-			TRP3_RefTooltip:AddLine(loc.CL_SENT_BY:format("|cnWHITE_FONT_COLOR:" .. sender.. "|r"));
+			if sender then
+				TRP3_RefTooltip:AddLine(loc.CL_SENT_BY:format("|cnWHITE_FONT_COLOR:" .. sender.. "|r"));
+			end
 			if itemData.size then
 				TRP3_RefTooltip:AddLine(loc.CL_CONTENT_SIZE:format("|cnWHITE_FONT_COLOR:" .. Ellyb.Strings.formatBytes(itemData.size).. "|r"));
 			end


### PR DESCRIPTION
If you hold the alt key down while you've got an in-progress request for chat link data going on with the tooltip shown, we can sometimes attempt to concatenate a nil `sender` value into the expanded tooltip information. This explodes and looks silly.