### PR TITLE
Use native compression APIs where available

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -28,7 +28,6 @@ externals:
   totalRP3/Libs/ChatThrottleLib: https://repos.curseforge.com/wow/chatthrottlelib/trunk
   totalRP3/Libs/Chomp: https://github.com/wow-rp-addons/Chomp
   totalRP3/Libs/LibChatAnims: https://repos.curseforge.com/wow/libchatanims/trunk/LibChatAnims
-  totalRP3/Libs/LibCompress: https://repos.curseforge.com/wow/libcompress/trunk
   totalRP3/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   totalRP3/Libs/LibDBCompartment: https://github.com/Meorawr/LibDBCompartment
   totalRP3/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0

--- a/totalRP3/Core/Compression.lua
+++ b/totalRP3/Core/Compression.lua
@@ -13,7 +13,7 @@ local Compression = {};
 function Compression.compress(data, willBeSentViaAddOnChannel)
 	Ellyb.Assertions.isType(data, "string", "data");
 
-	local compressedData = LibDeflate:CompressDeflate(data);
+	local compressedData = TRP3_EncodingUtil.CompressString(data);
 
 	if willBeSentViaAddOnChannel then
 		compressedData = LibDeflate:EncodeForWoWChatChannel(compressedData);
@@ -35,11 +35,7 @@ function Compression.decompress(compressedData, wasReceivedViaAddOnChannel)
 		end
 	end
 
-	local decompressedData, _ = LibDeflate:DecompressDeflate(compressedData);
-	if decompressedData == nil then
-		error(TRP3_API.Colors.Red("[AddOn_TotalRP3.Compression.decompress ERROR]:") .. "\nCould not decompress data \"" .. TRP3_API.Colors.Grey(tostring(compressedData)) .. "\"");
-	end
-
+	local decompressedData = TRP3_EncodingUtil.DecompressString(compressedData);
 	return decompressedData;
 end
 

--- a/totalRP3/Core/EncodingUtil.lua
+++ b/totalRP3/Core/EncodingUtil.lua
@@ -1,7 +1,25 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
+local LibDeflate = LibStub:GetLibrary("LibDeflate");
+
 TRP3_EncodingUtil = {};
+
+function TRP3_EncodingUtil.CompressString(data)
+	if C_EncodingUtil and C_EncodingUtil.CompressString then
+		return C_EncodingUtil.CompressString(data);
+	else
+		return LibDeflate:CompressDeflate(data);
+	end
+end
+
+function TRP3_EncodingUtil.DecompressString(data)
+	if C_EncodingUtil and C_EncodingUtil.DecompressString then
+		return C_EncodingUtil.DecompressString(data);
+	else
+		return assert(LibDeflate:DecompressDeflate(data));
+	end
+end
 
 --
 -- PEM Encoding and Decoding Utilities

--- a/totalRP3/Core/ProfileUtil.lua
+++ b/totalRP3/Core/ProfileUtil.lua
@@ -232,7 +232,7 @@ function TRP3_ProfileUtil.SerializeProfile(addonVersion, profileID, profileData)
 
 	if TRP3_EncodingUtil.IsPEMEncodingSupported() then
 		local label = "TRP3 PROFILE";
-		local data = C_EncodingUtil.CompressString(C_EncodingUtil.SerializeCBOR(packedData));
+		local data = TRP3_EncodingUtil.CompressString(C_EncodingUtil.SerializeCBOR(packedData));
 		local headers = {
 			{ key = "Name", value = profileData.profileName },
 			{ key = "Exported", value = date("%Y-%m-%d %H:%M:%S") },

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -708,8 +708,6 @@ end
 -- COMPRESSION / Serialization / HASH
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local libCompress = LibStub:GetLibrary("LibCompress");
-local libCompressEncoder = libCompress:GetAddonEncodeTable();
 local libSerializer = LibStub:GetLibrary("AceSerializer-3.0");
 
 local function serialize(structure)
@@ -734,18 +732,6 @@ local function safeDeserialize(structure, default)
 	return data;
 end
 Utils.serial.safeDeserialize = safeDeserialize;
-
-Utils.serial.decompressCodedStructure = function(message)
-	return deserialize(libCompress:Decompress(libCompressEncoder:Decode(message)));
-end
-
-Utils.serial.safeDecompressCodedStructure = function(message)
-	return safeDeserialize(libCompress:Decompress(libCompressEncoder:Decode(message)));
-end
-
-Utils.serial.encodeCompressStructure = function(structure)
-	return libCompressEncoder:Encode(libCompress:Compress(serialize(structure)));
-end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- MUSIC / SOUNDS

--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -479,15 +479,9 @@ local function incomingInformationTypeSent(structure, senderID, channel)
 	QueryCooldowns[informationType][senderID] = nil;
 	TRP3_Addon:TriggerEvent("REGISTER_DATA_RECEIVED", senderID, informationType);
 
-	local decodedData = data;
-	-- If the data is a string, we assume that it was compressed.
-	if type(data) == "string" then
-		decodedData = Utils.serial.safeDecompressCodedStructure(decodedData, {});
-	end
-
 	if informationType == registerInfoTypes.CHARACTERISTICS or informationType == registerInfoTypes.ABOUT
 	or informationType == registerInfoTypes.MISC or informationType == registerInfoTypes.CHARACTER then
-		saveInformation(senderID, informationType, decodedData);
+		saveInformation(senderID, informationType, data);
 	elseif informationType:sub(1, COMPANION_PREFIX:len()) == COMPANION_PREFIX then
 		local v = informationType:sub(COMPANION_PREFIX:len() + 1, COMPANION_PREFIX:len() + 1);
 		local profileID = informationType:sub(COMPANION_PREFIX:len() + 2);

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -40,7 +40,6 @@ Libs\TaintLess\TaintLess.xml
 Libs\Chomp\Chomp.xml
 Libs\Ellyb\Ellyb.xml
 Libs\LibChatAnims\LibChatAnims.xml
-Libs\LibCompress\lib.xml
 Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
 Libs\LibDBCompartment\lib.xml
 Libs\LibDBIcon-1.0\lib.xml


### PR DESCRIPTION
Smaller version of what's in #1208 that just enables the use of native compression APIs on clients that support them, and kills the unused LibCompress dependency.