### PR TITLE
The great default profile purge

### DIFF
--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -158,7 +158,16 @@ end
 TRP3_API.profile.getPlayerCurrentProfile = getPlayerCurrentProfile;
 
 local function updateDefaultProfile()
-	local profileDefault = profiles[getConfigValue("default_profile_id")];
+	-- We replace the profile ID every login session so multiple characters don't get linked to the same profile ID
+	-- The new profileID will automatically get selected during the init process
+	local oldProfileID = getConfigValue("default_profile_id");
+	local newProfileID = Utils.str.id();
+	profiles[newProfileID] = profiles[oldProfileID];
+	profiles[oldProfileID] = nil;
+	TRP3_API.configuration.setValue("default_profile_id", newProfileID);
+
+	local profileDefault = profiles[newProfileID];
+
 	-- Updating profile name in case of addon locale change
 	profileDefault.profileName = loc.PR_DEFAULT_PROFILE_NAME;
 

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -528,6 +528,8 @@ local function GenerateLinkFormatter(line, defaultLinkColor, includeBraces, isMa
 			text = "[" .. text .. "]";
 		end
 
+		url = Utils.str.sanitize(url, false);
+
 		if linkType then
 			url = TRP3_LinkUtil.CreateLinkString(linkType, url);
 		end

--- a/totalRP3/Modules/Dashboard/Dashboard.lua
+++ b/totalRP3/Modules/Dashboard/Dashboard.lua
@@ -64,10 +64,23 @@ end
 local FIELDS_TO_SANITIZE = {
 	"CO", "CU"
 }
+local VALID_DEFAULT_FIELDS = {
+	"v", "RP", "WU"
+};
+
 ---@param structure table
 ---@return boolean
-function TRP3_API.dashboard.sanitizeCharacter(structure)
+function TRP3_API.dashboard.sanitizeCharacter(profileID, structure)
 	local somethingWasSanitized = false;
+
+	if TRP3_API.profile.isDefaultProfile(profileID) then
+		for fieldID, _ in pairs(structure) do
+			if not tContains(VALID_DEFAULT_FIELDS, fieldID) then
+				structure[fieldID] = nil;
+			end
+		end
+	end
+	
 	if structure then
 		for _, field in pairs(FIELDS_TO_SANITIZE) do
 			if structure[field] then
@@ -79,6 +92,7 @@ function TRP3_API.dashboard.sanitizeCharacter(structure)
 			end
 		end
 	end
+
 	return somethingWasSanitized;
 end
 

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -41,8 +41,8 @@ TRP3_API.flyway.patches["5"] = function()
 	-- Sanitize existing profiles
 	TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_FINISH, function()
 		local sanitizeFullProfile = TRP3_API.register.sanitizeFullProfile;
-		for _, profile in pairs(TRP3_Register.profiles) do
-			sanitizeFullProfile(profile);
+		for profileID, profile in pairs(TRP3_Register.profiles) do
+			sanitizeFullProfile(profileID, profile);
 		end
 	end)
 end

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -57,54 +57,67 @@ getDefaultProfile().player.characteristics = {
 
 local FIELDS_TO_SANITIZE = {
 	"RA", "CL", "FN", "LN", "FT", "TI", "EC", "AG", "HE", "RE", "BP"
-}
+};
+local VALID_DEFAULT_FIELDS = {
+	"v", "RA", "CL", "FN", "IC"
+};
 
 ---@param structure table
 ---@return boolean
-local function sanitizeCharacteristics(structure)
+local function sanitizeCharacteristics(profileID, structure)
 	local somethingWasSanitized = false;
 
-	if structure then
-		for _, field in pairs(FIELDS_TO_SANITIZE) do
-			if structure[field] then
-				local sanitizedValue = Utils.str.sanitize(structure[field]);
-				if sanitizedValue ~= structure[field] then
-					structure[field] = sanitizedValue;
+	if not structure then return somethingWasSanitized end
+
+	if TRP3_API.profile.isDefaultProfile(profileID) then
+		for fieldID, _ in pairs(structure) do
+			if fieldID == "MI" or fieldID == "PS" then
+				structure[fieldID] = {};
+			elseif not tContains(VALID_DEFAULT_FIELDS, fieldID) then
+				structure[fieldID] = nil;
+			end
+		end
+	end
+	
+	for _, field in pairs(FIELDS_TO_SANITIZE) do
+		if structure[field] then
+			local sanitizedValue = Utils.str.sanitize(structure[field]);
+			if sanitizedValue ~= structure[field] then
+				structure[field] = sanitizedValue;
+				somethingWasSanitized = true;
+			end
+		end
+		-- Sanitizing misc traits
+		if structure.MI then
+			for _, trait in pairs(structure.MI) do
+				-- Sanitizing value
+				local sanitizedValue = Utils.str.sanitize(trait.VA);
+				if sanitizedValue ~= trait.VA then
+					trait.VA = sanitizedValue;
+					somethingWasSanitized = true;
+				end
+				-- Sanitizing name
+				sanitizedValue = Utils.str.sanitize(trait.NA);
+				if sanitizedValue ~= trait.NA then
+					trait.NA = sanitizedValue;
 					somethingWasSanitized = true;
 				end
 			end
-			-- Sanitizing misc traits
-			if structure.MI then
-				for _, trait in pairs(structure.MI) do
-					-- Sanitizing value
-					local sanitizedValue = Utils.str.sanitize(trait.VA);
-					if sanitizedValue ~= trait.VA then
-						trait.VA = sanitizedValue;
-						somethingWasSanitized = true;
-					end
-					-- Sanitizing name
-					sanitizedValue = Utils.str.sanitize(trait.NA);
-					if sanitizedValue ~= trait.NA then
-						trait.NA = sanitizedValue;
-						somethingWasSanitized = true;
-					end
+		end
+		-- Sanitizing personality traits
+		if structure.PS then
+			for _, trait in pairs(structure.PS) do
+				-- Sanitizing value
+				local sanitizedValue = Utils.str.sanitize(trait.RT);
+				if sanitizedValue ~= trait.RT then
+					trait.RT = sanitizedValue;
+					somethingWasSanitized = true;
 				end
-			end
-			-- Sanitizing personality traits
-			if structure.PS then
-				for _, trait in pairs(structure.PS) do
-					-- Sanitizing value
-					local sanitizedValue = Utils.str.sanitize(trait.RT);
-					if sanitizedValue ~= trait.RT then
-						trait.RT = sanitizedValue;
-						somethingWasSanitized = true;
-					end
-					-- Sanitizing name
-					sanitizedValue = Utils.str.sanitize(trait.LT);
-					if sanitizedValue ~= trait.LT then
-						trait.LT = sanitizedValue;
-						somethingWasSanitized = true;
-					end
+				-- Sanitizing name
+				sanitizedValue = Utils.str.sanitize(trait.LT);
+				if sanitizedValue ~= trait.LT then
+					trait.LT = sanitizedValue;
+					somethingWasSanitized = true;
 				end
 			end
 		end

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -682,7 +682,7 @@ local function cleanupProfiles()
 	TRP3_API.Log("Protected profiles: " .. CountTable(protectedProfileIDs));
 	local profilesToPurge = {};
 	for profileID, profile in pairs(profiles) do
-		if not protectedProfileIDs[profileID] and (not profile.time or time() - profile.time > getConfigValue("register_auto_purge_mode")) then
+		if not protectedProfileIDs[profileID] and (TRP3_API.profile.isDefaultProfile(profileID) or not profile.time or time() - profile.time > getConfigValue("register_auto_purge_mode")) then
 			tinsert(profilesToPurge, profileID);
 		end
 	end

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -285,34 +285,34 @@ local function saveCharacterInformation(unitID, race, class, gender, faction, ti
 end
 TRP3_API.register.saveCharacterInformation = saveCharacterInformation;
 
-local function sanitizeFullProfile(data)
+local function sanitizeFullProfile(profileID, data)
 	if not data or not data.player then return false end
 	local somethingWasSanitizedInsideProfile = false;
-	if data.player.characteristics and TRP3_API.register.sanitizeProfile(registerInfoTypes.CHARACTERISTICS, data.player.characteristics) then
+	if data.player.characteristics and TRP3_API.register.sanitizeProfile(registerInfoTypes.CHARACTERISTICS, profileID, data.player.characteristics) then
 		somethingWasSanitizedInsideProfile = true;
 	end
-	if data.player.character and TRP3_API.register.sanitizeProfile(registerInfoTypes.CHARACTER, data.player.character) then
+	if data.player.character and TRP3_API.register.sanitizeProfile(registerInfoTypes.CHARACTER, profileID, data.player.character) then
 		somethingWasSanitizedInsideProfile = true;
 	end
-	if data.player.misc and TRP3_API.register.sanitizeProfile(registerInfoTypes.MISC, data.player.misc) then
+	if data.player.misc and TRP3_API.register.sanitizeProfile(registerInfoTypes.MISC, profileID, data.player.misc) then
 		somethingWasSanitizedInsideProfile = true;
 	end
 	return somethingWasSanitizedInsideProfile;
 end
 TRP3_API.register.sanitizeFullProfile = sanitizeFullProfile;
 
-function TRP3_API.register.sanitizeProfile(informationType, data)
+function TRP3_API.register.sanitizeProfile(informationType, profileID, data)
 	local somethingWasSanitizedInsideProfile = false;
 	if informationType == registerInfoTypes.CHARACTERISTICS then
-		if TRP3_API.register.ui.sanitizeCharacteristics(data) then
+		if TRP3_API.register.ui.sanitizeCharacteristics(profileID, data) then
 			somethingWasSanitizedInsideProfile = true;
 		end
 	elseif informationType == registerInfoTypes.CHARACTER then
-		if TRP3_API.dashboard.sanitizeCharacter(data) then
+		if TRP3_API.dashboard.sanitizeCharacter(profileID, data) then
 			somethingWasSanitizedInsideProfile = true;
 		end
 	elseif informationType == registerInfoTypes.MISC then
-		if TRP3_API.register.ui.sanitizeMisc(data) then
+		if TRP3_API.register.ui.sanitizeMisc(profileID, data) then
 			somethingWasSanitizedInsideProfile = true;
 		end
 	end
@@ -321,12 +321,13 @@ end
 
 --- Raises error if unknown unitID or unit hasn't profile ID
 function TRP3_API.register.saveInformation(unitID, informationType, data)
+	local profileID = getUnitIDProfileID(unitID);
 	local profile = getUnitIDProfile(unitID);
 	if profile[informationType] then
 		wipe(profile[informationType]);
 	end
 
-	TRP3_API.register.sanitizeProfile(informationType, data);
+	TRP3_API.register.sanitizeProfile(informationType, profileID, data);
 	profile[informationType] = data;
 	TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), informationType);
 end
@@ -665,7 +666,7 @@ local function cleanupProfiles()
 	end
 
 	if type(getConfigValue("register_auto_purge_mode")) ~= "number" then
-		return ;
+		return;
 	end
 	TRP3_API.Log(("Purging profiles older than %s day(s)"):format(getConfigValue("register_auto_purge_mode") / 86400));
 	-- First, get a tab with all profileID with which we have a relation or on which we have notes
@@ -693,8 +694,8 @@ end
 
 local function cleanupMyProfiles()
 	-- Get the player's profiles and sanitize them, removing all invalid codes manually inserted
-	for _, profile in pairs(TRP3_API.profile.getProfiles()) do
-		sanitizeFullProfile(profile);
+	for profileID, profile in pairs(TRP3_API.profile.getProfiles()) do
+		sanitizeFullProfile(profileID, profile);
 	end
 end
 

--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -288,6 +288,17 @@ end
 
 local function sanitizeMisc(structure)
 	local somethingWasSanitized = false;
+
+	if TRP3_API.profile.isDefaultProfile(profileID) then
+		for fieldID, _ in pairs(structure) do
+			if fieldID == "PE" or fieldID == "ST" then
+				structure[fieldID] = {};
+			elseif fieldID ~= "v" then
+				structure[fieldID] = nil;
+			end
+		end
+	end
+	
 	if structure and structure.PE then
 		for i=1, 5 do
 			local index = tostring(i);
@@ -305,6 +316,7 @@ local function sanitizeMisc(structure)
 			end
 		end
 	end
+
 	return somethingWasSanitized;
 end
 TRP3_API.register.ui.sanitizeMisc = sanitizeMisc;

--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -518,9 +518,9 @@ local function onStart()
 				profile.characteristics["CH"] = color;
 			end
 
-			TRP3_API.register.ui.sanitizeCharacteristics(profile.characteristics);
-			TRP3_API.dashboard.sanitizeCharacter(profile.character)
-			TRP3_API.register.ui.sanitizeMisc(profile.misc);
+			TRP3_API.register.ui.sanitizeCharacteristics(character.profileID, profile.characteristics);
+			TRP3_API.dashboard.sanitizeCharacter(character.profileID, profile.character);
+			TRP3_API.register.ui.sanitizeMisc(character.profileID, profile.misc);
 
 			TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, senderID, hasProfile(senderID), nil);
 		end


### PR DESCRIPTION
There has been some weird profile ID manipulation noticed last month which messed with how profiles are shown in the directory. As default profiles are not meant to be editable, we now enforce deletion of any invalid fields for a default profile.

I'm also regenerating the default profile ID every login session in order to clean up lingering identifying data, and clearing up default profiles in the auto-purge (since those aren't displayed in the directory anyway).

Also I'm sanitizing the content of the URL tag. I've had that change waiting for a while and I forgot what exact use prompted it. Might have been some multiline shenanigans.