### PR TITLE
Flyway Log counting is hard

### DIFF
--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -10,18 +10,18 @@ if not TRP3_Flyway then
 end
 
 local function applyPatches(fromBuild, toBuild)
-	for i = fromBuild + 1, toBuild do
+	for i = fromBuild, toBuild do
 		if type(TRP3_API.flyway.patches[tostring(i)]) == "function" then
 			TRP3_API.Logf("Applying patch %s", i);
 			TRP3_API.flyway.patches[tostring(i)]();
 		end
 	end
-	TRP3_Flyway.log = ("Patch applied from %s to %s on %s"):format(fromBuild, toBuild, date("%d/%m/%y %H:%M:%S"));
+	TRP3_Flyway.log = ("Patch applied from %s to %s on %s"):format(fromBuild - 1, toBuild, date("%d/%m/%y %H:%M:%S"));
 end
 
 function TRP3_API.flyway.applyPatches()
 	if not TRP3_Flyway.currentBuild or TRP3_Flyway.currentBuild < SCHEMA_VERSION then
-		applyPatches((TRP3_Flyway.currentBuild or 0), SCHEMA_VERSION);
+		applyPatches((TRP3_Flyway.currentBuild or 0) + 1, SCHEMA_VERSION);
 	end
 	TRP3_Flyway.currentBuild = SCHEMA_VERSION;
 end


### PR DESCRIPTION
Saving Total RP 3 once again (I wish).
If from build is +1, it will always be the same as the following build log-wise, so that's silly.

Before:
```lua
TRP3_Flyway = {
  ["currentBuild"] = 22,
  ["log"] = "Patch applied from 22 to 22 on 15/08/24 05:41:37",
}
```

After
```lua
TRP3_Flyway = {
  ["currentBuild"] = 22,
  ["log"] = "Patch applied from 21 to 22 on 05/08/25 05:40:56",
}
```

PS: Extended also needs this fix, given it stol-- uses the same Flyway idea.