### PR TITLE
Protect profiles from auto-purge again

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -682,7 +682,7 @@ local function cleanupProfiles()
 	TRP3_API.Log("Protected profiles: " .. CountTable(protectedProfileIDs));
 	local profilesToPurge = {};
 	for profileID, profile in pairs(profiles) do
-		if TRP3_API.profile.isDefaultProfile(profileID) or (not protectedProfileIDs[profileID] and not profile.time or time() - profile.time > getConfigValue("register_auto_purge_mode")) then
+		if TRP3_API.profile.isDefaultProfile(profileID) or (not protectedProfileIDs[profileID] and (not profile.time or time() - profile.time > getConfigValue("register_auto_purge_mode"))) then
 			tinsert(profilesToPurge, profileID);
 		end
 	end


### PR DESCRIPTION
I moved the default profile before checking protected profiles but moved the parentheses out of it as well which is pretty bad. x_x