### PR TITLE
Fix Enter/Escape calls on input popups

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -606,6 +606,7 @@ stds.wow = {
 		"ShowingCloak",
 		"ShowingHelm",
 		"ShowUIPanel",
+		"StaticPopup_OnClick",
 		"StaticPopup_Show",
 		"StopMusic",
 		"StopSound",

--- a/totalRP3/Core/Popup.lua
+++ b/totalRP3/Core/Popup.lua
@@ -111,10 +111,10 @@ StaticPopupDialogs["TRP3_INPUT_TEXT"] = {
 		end
 	end,
 	EditBoxOnEnterPressed = function(self)
-		GetDialogButton1(self:GetParent()):GetScript("OnClick")(GetDialogButton1(self:GetParent()));
+		StaticPopup_OnClick(self:GetParent(), GetDialogButton1(self:GetParent()):GetID());
 	end,
 	EditBoxOnEscapePressed = function(self)
-		GetDialogButton2(self:GetParent()):GetScript("OnClick")(GetDialogButton2(self:GetParent()));
+		StaticPopup_OnClick(self:GetParent(), GetDialogButton2(self:GetParent()):GetID());
 	end,
 	timeout = false,
 	whileDead = true,
@@ -142,10 +142,10 @@ StaticPopupDialogs["TRP3_INPUT_NUMBER"] = {
 		end
 	end,
 	EditBoxOnEnterPressed = function(self)
-		self:GetParent().button1:GetScript("OnClick")(self:GetParent().button1);
+		StaticPopup_OnClick(self:GetParent(), GetDialogButton1(self:GetParent()):GetID());
 	end,
 	EditBoxOnEscapePressed = function(self)
-		self:GetParent().button2:GetScript("OnClick")(self:GetParent().button2);
+		StaticPopup_OnClick(self:GetParent(), GetDialogButton2(self:GetParent()):GetID());
 	end,
 	timeout = false,
 	whileDead = true,


### PR DESCRIPTION
Text input popup was throwing an assertsafe error when trying to press Enter/Escape while editing the editbox.
Number input popup was straight up not working (because still using .button1 and .button2).

Instead of using the "OnClick" script, I just call the StaticPopup_OnClick which doesn't go through the assertsafe.
*However*, I could just copy the OnAccept/OnCancel functions (with minot adjustments as self is EditBox). Depends what's preferred.