### PR TITLE
Implement MSP dataload callback

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -339,7 +339,6 @@ local function onStart()
 	end
 
 	local function LoadRegisterProfile(characterID, char)
-		print(characterID, char)
 		if not TRP3_API.register.isUnitIDKnown(characterID) then
 			return;
 		elseif not TRP3_API.register.profileExists(characterID) then


### PR DESCRIPTION
Implement stripped down support for LibMSP's dataload callback to pre-fill `msp.char` records from our registry data. This may give a slight improvement to comms performance if MSP is able to detect that the `TT` data from our registry is the same as the person being requested.

This is limited to just initializing basic character and characteristics fields. I've skipped implementing about and misc data because we don't need them at this stage and because it's more effort than it's worth.