### PR TITLE
Prefer native C_ColorUtil functions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -206,6 +206,16 @@ stds.wow = {
 			},
 		},
 
+		C_ColorUtil = {
+			fields = {
+				"ConvertHSLToHSV",
+				"ConvertHSVToHSL",
+				"ConvertHSVToRGB",
+				"ConvertRGBToHSV",
+				"WrapTextInColor",
+			},
+		},
+
 		C_CVar = {
 			fields = {
 				"GetCVarBool",

--- a/totalRP3/Core/ColorData.lua
+++ b/totalRP3/Core/ColorData.lua
@@ -1,8 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local TRP3_API = select(2, ...);
-
 local function TryCreateColorFromTable(table)
 	if table then
 		return TRP3_API.CreateColorFromTable(table);
@@ -74,7 +72,7 @@ TRP3_API.RelationColors =
 	Love = TRP3_API.CreateColorFromBytes(255, 192, 203),
 	Family = TRP3_API.CreateColorFromBytes(255, 192, 0),
 	Friend = TRP3_API.CreateColorFromBytes(25, 255, 25),
-}
+};
 
 -- Power colors (See: https://warcraft.wiki.gg/wiki/Power_colors)
 TRP3_API.PowerTypeColors =

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -36,16 +36,17 @@ end
 
 local DEFAULT_RELATIONS = {
 	NONE = { id = "NONE", order = 0, texture = TRP3_InterfaceIcons.RelationNone },
-	UNFRIENDLY = { id = "UNFRIENDLY", order = 1, texture = TRP3_InterfaceIcons.RelationUnfriendly, color = TRP3_API.Colors.Red:GenerateHexColorOpaque() },
-	NEUTRAL = { id = "NEUTRAL", order = 2, texture = TRP3_InterfaceIcons.RelationNeutral, color = TRP3_API.CreateColor(0.5, 0.5, 1):GenerateHexColorOpaque() },
-	BUSINESS = { id = "BUSINESS", order = 3, texture = TRP3_InterfaceIcons.RelationBusiness, color = TRP3_API.CreateColor(1, 1, 0):GenerateHexColorOpaque() },
-	FRIEND = { id = "FRIEND", order = 4, texture = TRP3_InterfaceIcons.RelationFriend, color = TRP3_API.Colors.Green:GenerateHexColorOpaque() },
-	LOVE = { id = "LOVE", order = 5, texture = TRP3_InterfaceIcons.RelationLove, color = TRP3_API.Colors.Pink:GenerateHexColorOpaque() },
-	FAMILY = { id = "FAMILY", order = 6, texture = TRP3_InterfaceIcons.RelationFamily, color = TRP3_API.CreateColor(1, 0.75, 0):GenerateHexColorOpaque() },
+	UNFRIENDLY = { id = "UNFRIENDLY", order = 1, texture = TRP3_InterfaceIcons.RelationUnfriendly, color = TRP3_API.RelationColors.Unfriendly:GenerateHexColorOpaque() },
+	NEUTRAL = { id = "NEUTRAL", order = 2, texture = TRP3_InterfaceIcons.RelationNeutral, color = TRP3_API.RelationColors.Neutral:GenerateHexColorOpaque() },
+	BUSINESS = { id = "BUSINESS", order = 3, texture = TRP3_InterfaceIcons.RelationBusiness, color = TRP3_API.RelationColors.Business:GenerateHexColorOpaque() },
+	FRIEND = { id = "FRIEND", order = 4, texture = TRP3_InterfaceIcons.RelationFriend, color = TRP3_API.RelationColors.Friend:GenerateHexColorOpaque() },
+	LOVE = { id = "LOVE", order = 5, texture = TRP3_InterfaceIcons.RelationLove, color = TRP3_API.RelationColors.Love:GenerateHexColorOpaque() },
+	FAMILY = { id = "FAMILY", order = 6, texture = TRP3_InterfaceIcons.RelationFamily, color = TRP3_API.RelationColors.Family:GenerateHexColorOpaque() },
 };
+
 local ACTIONS = {
-	DELETE= "DEL",
-	EDIT= "EDT",
+	DELETE = "DEL",
+	EDIT = "EDT",
 };
 
 --getRelationList function should get relations stored in config, or default relations if none are stored


### PR DESCRIPTION
Some absolute chad exposed native APIs for HSV <=> RGB and HSV <=> HSL conversions; update existing code to use those instead. Also resolve an issue where for some reason the relationship presets weren't using the proper color constants.