### PR TITLE
Add local CVar cache

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -233,6 +233,7 @@ stds.wow = {
 
 		C_CVar = {
 			fields = {
+				"GetCVar",
 				"GetCVarBool",
 				"SetCVar",
 			},

--- a/totalRP3/Core/BindingUtil.lua
+++ b/totalRP3/Core/BindingUtil.lua
@@ -194,7 +194,7 @@ function TRP3_BindingUtil.FormatBinding(binding, options)
 	for index, key in ipairs(keys) do
 		local text;
 
-		if options.useMouseButtonAtlases and not C_CVar.GetCVarBool("colorblindMode") then
+		if options.useMouseButtonAtlases and not TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.ColorblindMode) then
 			local atlas = MouseButtonAtlases[key];
 
 			if atlas then

--- a/totalRP3/Core/CVarUtil.lua
+++ b/totalRP3/Core/CVarUtil.lua
@@ -1,0 +1,77 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+TRP3_CVarConstants = {
+	ChatClassColorOverride = "chatClassColorOverride",
+	ColorblindMode = "colorblindMode",
+	NamePlateShowFriendlyNPCs = "nameplateShowFriendlyNPCs",
+	NamePlateShowFriends = "nameplateShowFriends",
+	ProfanityFilter = "profanityFilter",
+};
+
+-- Copy/paste of Blizzard's CVarCallbackRegistry to improve performance for
+-- CVar value queries by caching state in Lua. We don't use the global
+-- registry provided by Blizzard as it has a few taint issues in certain
+-- clients.
+
+TRP3_CVarCacheMixin = {};
+
+function TRP3_CVarCacheMixin:OnLoad()
+	self.callbacks = TRP3_API.InitCallbackRegistry(self);
+	self.cachable = {};
+	self.cvarValueCache = {};
+
+	self:SetScript("OnEvent", self.OnEvent);
+	self:RegisterEvent("CVAR_UPDATE");
+end
+
+function TRP3_CVarCacheMixin:OnEvent(event, ...)
+	if event == "CVAR_UPDATE" then
+		local cvar, value = ...;
+
+		if self.cachable[cvar] then
+			self.cvarValueCache[cvar] = value;
+		end
+
+		self.callbacks:Fire(cvar, value);
+	end
+end
+
+function TRP3_CVarCacheMixin:GetCVarValue(cvar)
+	local value = self.cvarValueCache[cvar];
+
+	if value == nil then
+		value = C_CVar.GetCVar(cvar);
+
+		if self.cachable[cvar] then
+			self.cvarValueCache[cvar] = value;
+		end
+	end
+
+	return value;
+end
+
+function TRP3_CVarCacheMixin:GetCVarBool(cvar)
+	local value = self:GetCVarValue(cvar);
+	return (value ~= nil) and value ~= "0";
+end
+
+function TRP3_CVarCacheMixin:GetCVarNumber(cvar)
+	local value = self:GetCVarValue(cvar);
+	return (value ~= nil) and tonumber(cvar);
+end
+
+function TRP3_CVarCacheMixin:SetCVarCachable(cvar)
+	self.cachable[cvar] = true;
+end
+
+function TRP3_CVarCacheMixin:ClearCache(cvar)
+	self.cvarValueCache[cvar] = nil;
+end
+
+TRP3_CVarCache = CreateFrame("Frame");
+FrameUtil.SpecializeFrameWithMixins(TRP3_CVarCache, TRP3_CVarCacheMixin);
+
+for _, cvar in pairs(TRP3_CVarConstants) do
+	TRP3_CVarCache:SetCVarCachable(cvar);
+end

--- a/totalRP3/Core/Core.xml
+++ b/totalRP3/Core/Core.xml
@@ -19,6 +19,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Include file="Events.lua"/>
 	<Include file="Color.lua"/>
 	<Include file="ColorData.lua"/>
+	<Include file="CVarUtil.lua"/>
 	<Include file="FunctionUtil.lua"/>
 	<Include file="StringUtil.lua"/>
 	<Include file="EncodingUtil.lua"/>

--- a/totalRP3/Modules/Automation/Automation_Actions.lua
+++ b/totalRP3/Modules/Automation/Automation_Actions.lua
@@ -171,7 +171,7 @@ TRP3_AutomationUtil.RegisterAction({
 	end,
 
 	Apply = function(context, enabled)
-		if C_CVar.GetCVarBool("nameplateShowFriends") == enabled then
+		if TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.NamePlateShowFriends) == enabled then
 			return;  -- Already in the desired state.
 		end
 
@@ -183,7 +183,7 @@ TRP3_AutomationUtil.RegisterAction({
 			enabledText = L.AUTOMATION_ACTION_NAMEPLATES_SHOW_FRIENDS_DISABLED;
 		end
 
-		C_CVar.SetCVar("nameplateShowFriends", enabled and "1" or "0");
+		C_CVar.SetCVar(TRP3_CVarConstants.NamePlateShowFriends, enabled and "1" or "0");
 		context:Print(enabledText);
 	end,
 });
@@ -208,7 +208,7 @@ TRP3_AutomationUtil.RegisterAction({
 	end,
 
 	Apply = function(context, enabled)
-		if C_CVar.GetCVarBool("nameplateShowFriendlyNPCs") == enabled then
+		if TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.NamePlateShowFriendlyNPCs) == enabled then
 			return;  -- Already in the desired state.
 		end
 
@@ -220,7 +220,7 @@ TRP3_AutomationUtil.RegisterAction({
 			enabledText = L.AUTOMATION_ACTION_NAMEPLATES_SHOW_FRIENDLY_NPCS_DISABLED;
 		end
 
-		C_CVar.SetCVar("nameplateShowFriendlyNPCs", enabled and "1" or "0");
+		C_CVar.SetCVar(TRP3_CVarConstants.NamePlateShowFriendlyNPCs, enabled and "1" or "0");
 		context:Print(enabledText);
 	end,
 });

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -686,7 +686,7 @@ function Utils.customGetColoredName(event, _, _, unitID, _, _, _, _, _, _, _, _,
 		end
 	end
 
-	if GetCVar("chatClassColorOverride") ~= "1" then
+	if TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.ChatClassColorOverride) then
 		local _, englishClass = GetPlayerInfoByGUID(GUID);
 		characterColor = TRP3_API.GetClassDisplayColor(englishClass);
 	end

--- a/totalRP3/Modules/Launcher/Launcher_Settings.lua
+++ b/totalRP3/Modules/Launcher/Launcher_Settings.lua
@@ -225,7 +225,7 @@ function TRP3_LauncherClickBindingButtonMixin:OnLoad()
 	self.events = TRP3_API.CreateCallbackGroup();
 	self.events:RegisterCallback(TRP3_Launcher, "OnBindingsChanged", self.OnBindingsChanged, self);
 	self.events:RegisterCallback(LauncherClickBindingController, "OnSelectedActionChanged", self.OnSelectedActionChanged, self);
-	self.events:RegisterCallback(TRP3_API.GameEvents, "CVAR_UPDATE", self.OnCVarUpdate, self);
+	self.events:RegisterCallback(TRP3_CVarCache, TRP3_CVarConstants.ColorblindMode, self.OnColorblindModeChanged, self);
 
 	self:RegisterForClicks("AnyUp");
 
@@ -257,10 +257,8 @@ function TRP3_LauncherClickBindingButtonMixin:OnSelectedActionChanged(actionID)
 	self:SetSelected(self.actionID == actionID);
 end
 
-function TRP3_LauncherClickBindingButtonMixin:OnCVarUpdate(variableName)
-	if variableName == "colorblindMode" then
-		self:Refresh();
-	end
+function TRP3_LauncherClickBindingButtonMixin:OnColorblindModeChanged()
+	self:Refresh();
 end
 
 function TRP3_LauncherClickBindingButtonMixin:GetAction()

--- a/totalRP3/Modules/Register/Filter/RegisterMatureFilter.lua
+++ b/totalRP3/Modules/Register/Filter/RegisterMatureFilter.lua
@@ -449,7 +449,7 @@ local function onStart()
 	local matureFilterShouldBeEnabledByDefault = false;
 
 	-- Mature filter should be enabled by default if profanity filter is enabled
-	matureFilterShouldBeEnabledByDefault = GetCVar("profanityFilter") == "1" or matureFilterShouldBeEnabledByDefault;
+	matureFilterShouldBeEnabledByDefault = TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.ProfanityFilter) or matureFilterShouldBeEnabledByDefault;
 	-- Mature filter should be enabled by default if parental control is enabled
 	-- (As far as I know, there is not other way to know if parental control is enabled other that checking the store API…)
 	matureFilterShouldBeEnabledByDefault = C_StorePublic.IsDisabledByParentalControls() or matureFilterShouldBeEnabledByDefault;


### PR DESCRIPTION
Small performance optimization; calls to APIs that query CVars by-name have fairly expensive lookup costs. It's better where possible to mirror CVar values down in Lua for caching.

Blizzard helpfully have a CVarCallbackRegistry for this, but it has [an itsy little taint problem](https://github.com/Stanzilla/WoWUIBugs/issues/766) that mean we should avoid using it, lest we want to potentially taint anything querying the same CVars as ourselves. So - copy/paste their registry (and instead drive it with a less awful callback registry for change notifications), and redirect all our CVar reads through it.

I've not touched the CVars being read by nameplate code as that's all different in the Midnight branch.