### PR TITLE
Resolve taint issues with context menus

### DIFF
--- a/totalRP3/Modules/Dashboard/Dashboard.xml
+++ b/totalRP3/Modules/Dashboard/Dashboard.xml
@@ -161,7 +161,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 					<Anchor point="RIGHT" relativePoint="CENTER" relativeKey="$parent" x="-20"/>
 				</Anchors>
 			</EditBox>
-			<Frame parentKey="ChannelDropdown" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
+			<Frame parentKey="ChannelDropdown" inherits="TRP3_DropdownButtonTemplate" enableMouse="true">
 				<Anchors>
 					<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.Title" y="-5"/>
 					<Anchor point="RIGHT" relativePoint="RIGHT" x="-25"/>

--- a/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIAbout.xml
@@ -233,7 +233,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 							<Anchor point="TOPLEFT" x="13" y="-35"/>
 						</Anchors>
 					</Button>
-					<Frame name="TRP3_RegisterAbout_Edit_TemplateField" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
+					<Frame name="TRP3_RegisterAbout_Edit_TemplateField" inherits="TRP3_DropdownButtonTemplate" enableMouse="true">
 						<Anchors>
 							<Anchor point="LEFT" relativePoint="RIGHT" x="10" y="-1" relativeTo="TRP3_RegisterAbout_Edit_BckField"/>
 						</Anchors>

--- a/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
+++ b/totalRP3/Modules/Register/Characters/RegisterUIMisc.xml
@@ -29,7 +29,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 	<Frame name="TRP3_RegisterRPStyleMain_Edit_Line" inherits="TRP3_RegisterRPStyleMain_Basic_Line" virtual="true">
 		<Size x="465" y="30"/>
 		<Frames>
-			<Frame parentKey="Values" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
+			<Frame parentKey="Values" inherits="TRP3_DropdownButtonTemplate" enableMouse="true">
 				<Size x="225" y="32"/>
 				<Anchors>
 					<Anchor point="LEFT" relativePoint="RIGHT" relativeKey="$parent.FieldName"/>

--- a/totalRP3/UI/Configuration.xml
+++ b/totalRP3/UI/Configuration.xml
@@ -95,7 +95,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Frame name="TRP3_ConfigDropDown" inherits="TRP3_ConfigNote" virtual="true">
 		<Frames>
-			<Frame parentKey="Dropdown" inherits="TRP3_DropDownButtonTemplate" enableMouse="true">
+			<Frame parentKey="Dropdown" inherits="TRP3_DropdownButtonTemplate" enableMouse="true">
 				<Size x="150" y="32"/>
 				<Anchors>
 					<Anchor point="RIGHT" x="-10"/>

--- a/totalRP3/UI/Menu/DropdownButton.lua
+++ b/totalRP3/UI/Menu/DropdownButton.lua
@@ -81,7 +81,12 @@ function TRP3_DropdownButtonMixin:GenerateMenu()
 end
 
 function TRP3_DropdownButtonMixin:SetupMenu(menuGenerator)
-	self.Button:SetupMenu(menuGenerator);
+	local function WrappedMenuGenerator(ownerRegion, rootDescription)
+		TRP3_MenuUtil.PrepareRootMenuDescription(rootDescription);
+		return menuGenerator(ownerRegion, rootDescription);
+	end
+
+	self.Button:SetupMenu(WrappedMenuGenerator);
 end
 
 function TRP3_DropdownButtonMixin:Update()

--- a/totalRP3/UI/Menu/MenuUtil.lua
+++ b/totalRP3/UI/Menu/MenuUtil.lua
@@ -32,5 +32,23 @@ function TRP3_MenuUtil.AttachTexture(elementDescription, icon)
 end
 
 function TRP3_MenuUtil.CreateContextMenu(ownerRegion, menuGenerator)
-	return MenuUtil.CreateContextMenu(ownerRegion, menuGenerator);
+	local function WrappedMenuGenerator(ownerRegion, rootDescription)  -- luacheck: no redefined (ownerRegion)
+		TRP3_MenuUtil.PrepareRootMenuDescription(rootDescription);
+		return menuGenerator(ownerRegion, rootDescription);
+	end
+
+	return MenuUtil.CreateContextMenu(ownerRegion, WrappedMenuGenerator);
+end
+
+function TRP3_MenuUtil.PrepareRootMenuDescription(rootDescription)
+	-- Resolving taint issues with dropdowns - if no minimum width is defined
+	-- then if tainted code is the first thing to open a custom menu the
+	-- 'minimumWidth' field on menu frames is assigned a tainted nil value.
+	--
+	-- This then taints menus open by secure code later on if they themselves
+	-- don't set a minimum width due to metatable bullshit in the compositor.
+	--
+	-- Can remove when WowUIBugs#783 is fixed.
+
+	rootDescription:SetMinimumWidth(1);
 end

--- a/totalRP3/UI/Widgets.xml
+++ b/totalRP3/UI/Widgets.xml
@@ -872,7 +872,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 			</Layer>
 		</Layers>
 	</Frame>
-	<Frame name="TRP3_TitledDropdown" inherits="TRP3_DropDownButtonTemplate" enableMouse="true" virtual="true">
+	<Frame name="TRP3_TitledDropdown" inherits="TRP3_DropdownButtonTemplate" enableMouse="true" virtual="true">
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString name="$parentTitle" parentKey="title" text="" inherits="GameFontNormalSmall" justifyH="LEFT" justifyV="TOP">


### PR DESCRIPTION
Resolve an issue wherein if we're the first addon to open a context menu then we can set up a landmine of a tainted `minimumWidth` field on the menu frame itself, which taints execution when later a securely-driven menu is opened.

Also, while I'm here, fix the fact that apparently XML template inheritance is case-insensitive and a shitload of usages of our dropdown template are using the wrong casing.

Note that this doesn't fix all menu issues - the other one I noticed about the raid target submenu is still a problem even with these changes.

This primarily just affects 12.0 where the following sequence of actions is a script error involving secrets:

1. Enter any instanced map
2. Open the TRP3 window and open a context menu (eg. the hamburgers in Character > Profiles). Don't use a regular dropdown like the ones on the dashboard.
3. Close the menu and the TRP3 window.
4. Right-click a unit frame for any neutral or hostile unit.
5. Collect bacon.

```
Message: Interface/AddOns/Blizzard_SharedXMLBase/MathUtil.lua:28: attempt to compare local 'max' (a secret value)
Time: Sat Jan 17 15:58:55 2026
Count: 5
Stack:
[Interface/AddOns/Blizzard_SharedXMLBase/MathUtil.lua]:28: in function <Interface/AddOns/Blizzard_SharedXMLBase/MathUtil.lua:27>
[Interface/AddOns/Blizzard_SharedXML/LayoutFrame.lua]:225: in function <Interface/AddOns/Blizzard_SharedXML/LayoutFrame.lua:224>
[Interface/AddOns/Blizzard_SharedXML/LayoutFrame.lua]:511: in function 'Layout'
[Interface/AddOns/Blizzard_Menu/Menu.lua]:1467: in function 'PerformLayout'
[Interface/AddOns/Blizzard_Menu/Menu.lua]:1191: in function 'SetMenuDescription'
[Interface/AddOns/Blizzard_Menu/Menu.lua]:1200: in function <Interface/AddOns/Blizzard_Menu/Menu.lua:1194>
[C]: in function 'securecallfunction'
[Interface/AddOns/Blizzard_Menu/Menu.lua]:2344: in function <Interface/AddOns/Blizzard_Menu/Menu.lua:2298>
[tail call]: ?
[tail call]: ?
[Interface/AddOns/Blizzard_Menu/Menu.lua]:2514: in function 'OpenContextMenu'
[Interface/AddOns/Blizzard_Menu/MenuUtil.lua]:163: in function 'CreateContextMenu'
[Interface/AddOns/Blizzard_UnitPopupShared/UnitPopupShared.lua]:97: in function 'OpenMenu'
[Interface/AddOns/Blizzard_UnitPopupShared/UnitPopupShared.lua]:132: in function 'UnitPopup_OpenMenu'
[Interface/AddOns/Blizzard_UnitFrame/Mainline/TargetFrame.lua]:942: in function <...e/AddOns/Blizzard_UnitFrame/Mainline/TargetFrame.lua:894>
[C]: in function 'ExecuteAttribute'
[Interface/AddOns/Blizzard_FrameXML/SecureTemplates.lua]:258: in function 'handler'
[Interface/AddOns/Blizzard_FrameXML/SecureTemplates.lua]:732: in function <...terface/AddOns/Blizzard_FrameXML/SecureTemplates.lua:710>
[Interface/AddOns/Blizzard_FrameXML/SecureTemplates.lua]:746: in function <...terface/AddOns/Blizzard_FrameXML/SecureTemplates.lua:739>
[Interface/AddOns/Blizzard_FrameXML/SecureTemplates.lua]:837: in function <...terface/AddOns/Blizzard_FrameXML/SecureTemplates.lua:821>

Locals:
value = <no value>
min = <no value>
max = <no value>
(*temporary) = "attempt to compare local 'max' (a secret value)"
```