### PR TITLE
Fix target frame character test

### DIFF
--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -256,7 +256,7 @@ local function onStart()
 			return false;
 		elseif currentTargetID == nil or (getConfigValue(config) ~= 1 and (getConfigValue(config) ~= 2 or not isPlayerIC())) then
 			return false;
-		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.CHARACTER and (currentTargetID == Globals.player_id or (not isIDIgnored(currentTargetID) and isUnitIDKnown(currentTargetID))) then
+		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.CHARACTER and (currentTargetID == Globals.player_id or (not isIDIgnored(currentTargetID) and hasProfile(currentTargetID))) then
 			return true;
 		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.PET or currentTargetType == TRP3_Enums.UNIT_TYPE.BATTLE_PET then
 			local owner = companionIDToInfo(currentTargetID);


### PR DESCRIPTION
When deleting a profile tied to a character and clicking on them again, if you cannot get their profile, you're stuck with a target frame with 2 buttons, ignore and report to Blizzard (last one erroring since there is no profile to report).

I fixed the test which should check that the target actually has a profile rather than is just known.