### PR TITLE
Fix inverted check for class color override CVar

### DIFF
--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -686,7 +686,7 @@ function Utils.customGetColoredName(event, _, _, unitID, _, _, _, _, _, _, _, _,
 		end
 	end
 
-	if not TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.ChatClassColorOverride) then
+	if TRP3_CVarCache:GetCVarNumber(TRP3_CVarConstants.ChatClassColorOverride) ~= 1 then
 		local _, englishClass = GetPlayerInfoByGUID(GUID);
 		characterColor = TRP3_API.GetClassDisplayColor(englishClass);
 	end


### PR DESCRIPTION
Original code was checking if this CVar was inactive (`~= "1"`) rather than active. It's actually intended to be a tristate looking at the help text, so treat it as a number and restore the original test.