### PR TITLE
Fix error when targeting player without profile

### DIFF
--- a/totalRP3/Modules/TargetFrame/TargetFrame.lua
+++ b/totalRP3/Modules/TargetFrame/TargetFrame.lua
@@ -256,7 +256,7 @@ local function onStart()
 			return false;
 		elseif currentTargetID == nil or (getConfigValue(config) ~= 1 and (getConfigValue(config) ~= 2 or not isPlayerIC())) then
 			return false;
-		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.CHARACTER and (currentTargetID == Globals.player_id or (not isIDIgnored(currentTargetID) and hasProfile(currentTargetID))) then
+		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.CHARACTER and (currentTargetID == Globals.player_id or (not isIDIgnored(currentTargetID) and isUnitIDKnown(currentTargetID) and hasProfile(currentTargetID))) then
 			return true;
 		elseif currentTargetType == TRP3_Enums.UNIT_TYPE.PET or currentTargetType == TRP3_Enums.UNIT_TYPE.BATTLE_PET then
 			local owner = companionIDToInfo(currentTargetID);


### PR DESCRIPTION
Unsure if this is the correct fix overall for what we were intending to accomplish with this change, but for stupid reasons hasProfile has the assert that fires unless you manually check if we have a character entry first - so any hasProfile needs a stupid, pointless isUnitIDKnown because wisdom once decided that simply returning false was too obvious.