### PR TITLE
Fix companion name coloring & exclude from name-only

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -264,7 +264,8 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateName(nameplate)
 
 		-- Process color overrides.
 		-- Do not color name when unit name is within the health bar, except when name-only mode is on.
-		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameInsideHealthBar and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
+		-- Companion nameplates don't have a name-only option, so exclude them from the name-only check.
+		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameInsideHealthBar and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() or not displayInfo.isPlayerUnit;
 
 		if displayInfo.shouldColorName and not hasHealthBarOverlap then
 			local color = displayInfo.color;
@@ -343,10 +344,10 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateFullTitle(nameplate)
 	local shouldHide = displayInfo and displayInfo.shouldHide or false;
 
 	-- Hide the full title widget if no title is to be displayed, or if the
-	-- nameplate isn't in name-only mode.
+	-- nameplate isn't in name-only mode (companions are excluded).
 	--
 
-	local isNameOnly = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled();
+	local isNameOnly = TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() and displayInfo.isPlayerUnit;
 
 	if shouldHide or not ShouldShowName(unitframe) or not isNameOnly then
 		displayText = nil;

--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -23,6 +23,7 @@ local function GetOrCreateDisplayInfo(unitToken)
 	displayInfo.guildRank = nil;
 	displayInfo.guildIsCustom = nil;
 	displayInfo.icon = nil;
+	displayInfo.isPlayerUnit = false;
 	displayInfo.isRoleplayUnit = false;
 	displayInfo.name = nil;
 	displayInfo.nameUncropped = nil;
@@ -161,6 +162,7 @@ end
 
 local function GetCharacterUnitDisplayInfo(unitToken, characterID)
 	local displayInfo = GetOrCreateDisplayInfo(unitToken);
+	displayInfo.isPlayerUnit = true;
 
 	if characterID and TRP3_API.register.isUnitIDKnown(characterID) then
 		local player = GetOrCreatePlayerFromCharacterID(characterID);


### PR DESCRIPTION
Creating and assigning `displayInfo.isPlayerUnit` once felt like a better idea than doing these sort of `unitType` checks:
```lua
local unitType = TRP3_API.ui.misc.getTargetType(unitToken);

if unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.CHARACTER then
...
elseif unitType == AddOn_TotalRP3.Enums.UNIT_TYPE.PET then
...
```
| Before  | After |
| ------------- | ------------- |
| <img width="286" height="90" alt="image" src="https://github.com/user-attachments/assets/6e608f98-68d0-4285-b661-522019a60d08" />  | <img width="267" height="55" alt="image" src="https://github.com/user-attachments/assets/8df90515-c1a3-46c2-a909-b96c3d4e40ff" /> |


