### PR TITLE
Fix error when right-clicking a unit

### DIFF
--- a/totalRP3/Libs/Ellyb/Tools/Unit.lua
+++ b/totalRP3/Libs/Ellyb/Tools/Unit.lua
@@ -47,7 +47,7 @@ end
 ---@return string unitID @ Returns the unit ID in the format PlayerName-ServerName
 function Unit:GetUnitID()
 	local playerName, realm = UnitNameUnmodified(_private[self].rawUnitID);
-	if not playerName or playerName:len() == 0 or playerName == UNKNOWNOBJECT then
+	if not canaccessvalue(playerName) or not playerName or playerName:len() == 0 or playerName == UNKNOWNOBJECT then
 		return nil;
 	end
 	if not realm then


### PR DESCRIPTION
Cursor interactions in Ellyb are retrieving the unit right-clicked/on mouseover, so adding a quick check in that function to make sure it's not a secret.