### PR TITLE
Delete missing phrases on all locales when Exporting All

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,9 @@ translations-export-all: $(addprefix translations-export-,$(LOCALES))
 translations-import: $(addprefix translations-import-,$(IMPORT_LOCALES))
 translations-import-all: $(addprefix translations-import-,$(LOCALES))
 
-translations-export-enUS: EXPORT_OPTIONS := --delete-missing-phrases
-
 .PHONY: $(addprefix translations-export-,$(LOCALES))
 $(addprefix translations-export-,$(LOCALES)): translations-export-%:
-	$(LOCALES_SCRIPT) upload --locale $* --project-id $(CF_PROJECT_ID) $(EXPORT_OPTIONS) <$(LOCALES_DIR)/$*.lua
+	$(LOCALES_SCRIPT) upload --locale $* --project-id $(CF_PROJECT_ID) --delete-missing-phrases $(EXPORT_OPTIONS) <$(LOCALES_DIR)/$*.lua
 
 .PHONY: $(addprefix translations-import-,$(LOCALES))
 $(addprefix translations-import-,$(LOCALES)): translations-import-%:


### PR DESCRIPTION
We sometimes reset loc keys from other languages when the original key has been modified, but the script to export all locales does not handle deleting missing keys other than the English ones, leading to Curseforge trying to put the keys back. Feels like we should apply this on all languages, unless I'm missing something and this would delete the English ones too?