### PR TITLE
ElvUI tooltip skin update

### DIFF
--- a/totalRP3/Modules/TooltipSkins/ElvUI.lua
+++ b/totalRP3/Modules/TooltipSkins/ElvUI.lua
@@ -128,15 +128,15 @@ TRP3_API.module.registerModule({
 
 		-- Wait for the add-on to be fully loaded so all the tooltips are available
 		TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_FINISH, function()
-			local E = ElvUI[1]
-			local TT = E:GetModule('Tooltip')
+			local E = ElvUI[1];
+			local TT = E:GetModule('Tooltip');
 
 			function skinTooltips()
 				-- Go through each tooltips from our table
 				for _, tooltip in pairs(TOOLTIPS) do
-					local tt = _G[tooltip]
+					local tt = _G[tooltip];
 					if tt and not tt.template then
-						TT:SetStyle(tt)
+						TT:SetStyle(tt);
 					end
 				end
 			end

--- a/totalRP3/UI/Widgets.lua
+++ b/totalRP3/UI/Widgets.lua
@@ -9,7 +9,7 @@ function TRP3_TooltipMixin:SetCenterColor(r, g, b, a)
 	self.NineSlice:SetCenterColor(r, g, b, a or 1);
 
 	if self.Center and self.Center.SetVertexColor then -- used by ElvUI skin
-		self.Center:SetVertexColor(r, g, b, a or 1)
+		self.Center:SetVertexColor(r, g, b, a or 1);
 	end
 end
 
@@ -17,7 +17,7 @@ function TRP3_TooltipMixin:SetBorderColor(r, g, b, a)
 	self.NineSlice:SetBorderColor(r, g, b, a or 1);
 
 	if self.SetBackdropBorderColor then -- used by ElvUI skin
-		self:SetBackdropBorderColor(r, g, b, a or 1)
+		self:SetBackdropBorderColor(r, g, b, a or 1);
 	end
 end
 


### PR DESCRIPTION
we currently not using NineSlice because of restrictions.
image below to fix relation border + it removes hooks which makes the code more optimal.