### PR TITLE
Stop the addon from touching languages in instances

### DIFF
--- a/totalRP3/Modules/Languages/Languages.lua
+++ b/totalRP3/Modules/Languages/Languages.lua
@@ -60,7 +60,7 @@ function Languages.setLanguage(language)
 		-- Touching languages while in an instance risks locking down chat during encounters
 		return;
 	end
-	
+
 	Ellyb.Assertions.isInstanceOf(language, AddOn_TotalRP3.Language, "language")
 	TRP3_API.Log("Setting language " .. language:GetName());
 


### PR DESCRIPTION
cf #1273

As far as my understanding is concerned, if we have touched the language fields, chat is locked in encounters (maybe only say/yell since those are the only ones applying the language).

The game helpfully reset languages to the default one during loading screens, which we worked around a while back. In theory, if we disable the ability for the addon to set a language in combat instances, we should no longer have tainted fields in encounters, at the expense of the language button doing anything in instances.