### PR TITLE
Fix missing guild name on Blizz nameplates for units without profile

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -376,7 +376,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateSubText(nameplate)
 		end
 
 		if TRP3_NamePlatesUtil.IsGuildNameEnabled() then
-			displayGuild = displayInfo.guildName;
+			displayGuild = displayInfo.guildName or GetGuildInfo(unitToken);
 		end
 	end
 


### PR DESCRIPTION
Players without profiles have a displayInfo with mostly nil fields, which isn't an issue for any nameplate addon as we don't want to replace the existing fields, but is for the Blizz nameplates as we make the widget ourselves.