### PR TITLE
Add secret check to GUID in name color function

### DIFF
--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -640,7 +640,7 @@ function Utils.customGetColoredName(event, _, _, unitID, _, _, _, _, _, _, _, _,
 	end
 
 	-- Do not change stuff if the customizations are disabled for this channel or the GUID is invalid (WIM…), use the default function
-	if not isChannelHandled(event) or not configIsChannelUsed(event) or not GUID or not Utils.guid.isAPlayerGUID(GUID) then
+	if not isChannelHandled(event) or not configIsChannelUsed(event) or not GUID or not canaccessvalue(GUID) or not Utils.guid.isAPlayerGUID(GUID) then
 		return;
 	end ;
 


### PR DESCRIPTION
Fixes #1287

Because we're replacing ElvUI's GetColoredName function which gets called in secret situations, we're getting into issues when we check the GUID. This doesn't happen in the default UI since we're using the filters which don't get run natively in secret situations.