### PR TITLE
Add race, class, faction, and sex conditions nyaa~

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -243,6 +243,14 @@ stds.wow = {
 			},
 		},
 
+		C_CreatureInfo = {
+			fields = {
+				"GetClassInfo",
+				"GetFactionInfo",
+				"GetRaceInfo",
+			},
+		},
+
 		C_CVar = {
 			fields = {
 				"GetCVar",
@@ -346,6 +354,9 @@ stds.wow = {
 		C_PlayerInfo = {
 			fields = {
 				"GetAlternateFormInfo",
+				"GetClass",
+				"GetRace",
+				"GetSex",
 				"GUIDIsPlayer",
 			},
 		},
@@ -449,6 +460,19 @@ stds.wow = {
 						"LeftCenter",
 					},
 				},
+
+				UnitSex = {
+					fields = {
+						"Male",
+						"Female",
+					},
+				}
+			},
+		},
+
+		EnumUtil = {
+			fields = {
+				"GenerateNameTranslation",
 			},
 		},
 
@@ -503,6 +527,12 @@ stds.wow = {
 			fields = {
 				"SetPoint",
 				"SetSize",
+			},
+		},
+
+		PlayerLocation = {
+			fields = {
+				"CreateFromUnit",
 			},
 		},
 

--- a/totalRP3/Core/CVarUtil.lua
+++ b/totalRP3/Core/CVarUtil.lua
@@ -4,8 +4,8 @@
 TRP3_CVarConstants = {
 	ChatClassColorOverride = "chatClassColorOverride",
 	ColorblindMode = "colorblindMode",
-	NamePlateShowFriendlyNPCs = "nameplateShowFriendlyNPCs",
-	NamePlateShowFriends = "nameplateShowFriends",
+	NamePlateShowFriendlyNPCs = "nameplateShowFriendlyNpcs",
+	NamePlateShowFriendlyPlayers = "nameplateShowFriendlyPlayers",
 	NamePlateShowOnlyNameForFriendlyPlayerUnits = "nameplateShowOnlyNameForFriendlyPlayerUnits",
 	ProfanityFilter = "profanityFilter",
 };

--- a/totalRP3/Modules/Automation/Automation_Actions.lua
+++ b/totalRP3/Modules/Automation/Automation_Actions.lua
@@ -171,7 +171,7 @@ TRP3_AutomationUtil.RegisterAction({
 	end,
 
 	Apply = function(context, enabled)
-		if TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.NamePlateShowFriends) == enabled then
+		if TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.NamePlateShowFriendlyPlayers) == enabled then
 			return;  -- Already in the desired state.
 		end
 
@@ -183,7 +183,7 @@ TRP3_AutomationUtil.RegisterAction({
 			enabledText = L.AUTOMATION_ACTION_NAMEPLATES_SHOW_FRIENDS_DISABLED;
 		end
 
-		C_CVar.SetCVar(TRP3_CVarConstants.NamePlateShowFriends, enabled and "1" or "0");
+		C_CVar.SetCVar(TRP3_CVarConstants.NamePlateShowFriendlyPlayers, enabled and "1" or "0");
 		context:Print(enabledText);
 	end,
 });

--- a/totalRP3/Modules/Automation/Automation_Conditions.lua
+++ b/totalRP3/Modules/Automation/Automation_Conditions.lua
@@ -156,3 +156,88 @@ TRP3_AutomationUtil.RegisterCondition({
 		return inAlternateForm;
 	end,
 });
+
+local function GetActivePlayerLocation()
+	return PlayerLocation:CreateFromUnit("player");
+end
+
+TRP3_AutomationUtil.RegisterCondition({
+	id = "trp3:race",
+	tokens = { "race" },
+
+	Evaluate = function(context)
+		local currentRaceID = C_PlayerInfo.GetRace(GetActivePlayerLocation());
+		local desiredRaceID = tonumber(context.option);
+
+		if desiredRaceID then
+			return currentRaceID == desiredRaceID;
+		end
+
+		local currentRaceInfo = C_CreatureInfo.GetRaceInfo(currentRaceID);
+		local desiredRaceName = context.option;
+
+		if currentRaceInfo then
+			return TRP3_StringUtil.IsExactOrSubstringMatch(currentRaceInfo.raceName, desiredRaceName)
+				or TRP3_StringUtil.IsExactOrSubstringMatch(currentRaceInfo.clientFileString, desiredRaceName);
+		end
+
+		return false;
+	end,
+});
+
+TRP3_AutomationUtil.RegisterCondition({
+	id = "trp3:class",
+	tokens = { "class" },
+
+	Evaluate = function(context)
+		local currentClassName, currentClassFile, currentClassID = C_PlayerInfo.GetClass(GetActivePlayerLocation());
+		local desiredClassID = tonumber(context.option);
+
+		if desiredClassID then
+			return currentClassID == desiredClassID;
+		end
+
+		local desiredClassName = context.option;
+
+		return TRP3_StringUtil.IsExactOrSubstringMatch(currentClassName, desiredClassName)
+			or TRP3_StringUtil.IsExactOrSubstringMatch(currentClassFile, desiredClassName);
+	end,
+});
+
+TRP3_AutomationUtil.RegisterCondition({
+	id = "trp3:faction",
+	tokens = { "faction" },
+
+	Evaluate = function(context)
+		local currentFactionInfo = C_CreatureInfo.GetFactionInfo(C_PlayerInfo.GetRace(GetActivePlayerLocation()));
+		local desiredFactionName = context.option;
+
+		if currentFactionInfo then
+			return TRP3_StringUtil.IsExactOrSubstringMatch(currentFactionInfo.name, desiredFactionName)
+				or TRP3_StringUtil.IsExactOrSubstringMatch(currentFactionInfo.groupTag, desiredFactionName);
+		end
+
+		return false;
+	end,
+});
+
+local GetLocaleInvariantSex = EnumUtil.GenerateNameTranslation(Enum.UnitSex);
+
+TRP3_AutomationUtil.RegisterCondition({
+	id = "trp3:sex",
+	tokens = { "bodytype", "gender", "sex" },
+
+	Evaluate = function(context)
+		local currentSexID = C_PlayerInfo.GetSex(GetActivePlayerLocation());
+		local desiredSexID = tonumber(context.option);
+
+		if desiredSexID then
+			return currentSexID == desiredSexID;
+		end
+
+		local currentSexName = GetLocaleInvariantSex(currentSexID);
+		local desiredSexName = context.option;
+
+		return TRP3_StringUtil.IsExactOrSubstringMatch(currentSexName, desiredSexName);
+	end,
+});


### PR DESCRIPTION
Adds the following conditions to automation:

- `[class:<id or name>]` - Name matching uses both localized and english tokens.
- `[race:<id or name>]` - Name matching uses both localized and english tokens.
- `[faction:<name>]` - There's no integral faction IDs. Name matching uses both localized and english tokens.
- `[sex:<id or name>]` - Implemented in terms of [C_PlayerInfo.GetSex](https://warcraft.wiki.gg/wiki/API_C_PlayerInfo.GetSex) which returns an `Enum.UnitSex` value (which is different from regular UnitSex returns because reasons). Name matching only supports locale-invariant tokens based on the keys in the enum. Alternatively can be used as `[gender:...]` or `[bodytype:...]`.

Also fixed a couple of bugs;

- Our constants for some nameplate CVars had improper casing which would cause automation to spam when using the "Toggle friendly NPC nameplates" action.
- Similarly, our CVar constant for friendly player nameplates was entirely wrong - probably renamed in 12.0, so "Toggle friendly player nameplates" was entirely non-functional.

:purr: