### PR TITLE
Change platynator ShouldShowName check

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Platynator.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Platynator.lua
@@ -52,7 +52,7 @@ function TRP3_Platynator:UpdateNamePlate(nameplate, unitToken)
 	if not unitToken then return; end;
 
 	local displayInfo = self:GetUnitDisplayInfo(unitToken);
-	local shouldShow = nameplate.UnitFrame and ShouldShowName(nameplate.UnitFrame);
+	local shouldShow = UnitShouldDisplayName(unitToken);
 
 	if displayInfo and displayInfo.shouldHide then
 		Platynator.API.SetUnitTextOverride(unitToken, "", "");


### PR DESCRIPTION
Heya! Platynator was only displaying RP names for me on the nameplates of my targets, not on nameplates in general, after peeking through the code of both addons, it seems like it is this specific ShouldShowName function that was causing the behaviour.

Not super familiar with these global blizzard functions, but I replaced it with what I assume is a more appropriate check, and it fixed the issue for me.