### PR TITLE
Don't customize nameplates for ignored characters

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -170,7 +170,6 @@ local function GetCharacterUnitDisplayInfo(unitToken, characterID)
 	end
 
 	local player = GetOrCreatePlayerFromCharacterID(characterID);
-	local classToken = UnitClassBase(unitToken);
 
 	-- Don't customize default profile nameplates
 	if TRP3_API.profile.isDefaultProfile(player:GetProfileID()) then
@@ -216,6 +215,7 @@ local function GetCharacterUnitDisplayInfo(unitToken, characterID)
 		end
 
 		if displayInfo.shouldColorHealth or displayInfo.shouldColorName then
+			local classToken = UnitClassBase(unitToken);
 			displayInfo.color = GetCharacterColorForDisplay(player, classToken);
 
 			if not displayInfo.color then


### PR DESCRIPTION
When a character is on the TRP3 ignore list, their nameplate still gets customized with RP data (name, title, icon, colors). Other systems like tooltips, chat, and the target frame already skip customization for ignored characters, but nameplates didn't.

This adds an `isIDIgnored` check in `GetCharacterUnitDisplayInfo` and `GetCompanionUnitDisplayInfo` in the nameplate core. Since all nameplate decorators (Blizzard, Plater, Platynator, etc.) receive their data through this single code path, one check covers all of them.

Companion nameplates are also skipped when their owner is ignored, matching the existing tooltip behavior.