### PR TITLE
Set the target type accordingly when creating a mount profile

### DIFF
--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -386,6 +386,7 @@ local function companionProfileSelectionList(characterID, targetType, buttonClic
 		ownerID = characterID;
 		if ownerID == Globals.player_id then
 			companionID = tostring(getCurrentMountSpellID());
+			targetType = TRP3_Enums.UNIT_TYPE.MOUNT;
 		else
 			companionFullID = TRP3_API.companions.register.getUnitMount(characterID, "target");
 		end


### PR DESCRIPTION
Previously, mount profiles would be created/linked from the target frame with no profile/link type. This corrects the injustice and fixes #1201.