### PR TITLE
Increase default tertiary tooltip font size to 12

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterTooltip.lua
+++ b/totalRP3/Modules/Register/Main/RegisterTooltip.lua
@@ -1591,7 +1591,7 @@ local function onModuleInit()
 	registerConfigKey(ConfigKeys.HIDE_ON_MODIFIER, "ALT");
 	registerConfigKey(ConfigKeys.CHARACT_MAIN_SIZE, 16);
 	registerConfigKey(ConfigKeys.CHARACT_SUB_SIZE, 12);
-	registerConfigKey(ConfigKeys.CHARACT_TER_SIZE, 10);
+	registerConfigKey(ConfigKeys.CHARACT_TER_SIZE, 12);
 	registerConfigKey(ConfigKeys.CHARACT_ICONS, true);
 	registerConfigKey(ConfigKeys.CHARACT_FT, true);
 	registerConfigKey(ConfigKeys.CHARACT_RACECLASS, true);


### PR DESCRIPTION
Our default font size for OOC/Currently text in tooltips is a terribly small default. For accessibility, let's increase this to 12 which matches the default size of all tooltips in the game.

We _couuld_ for consistency also reduce the main tooltip font size from 16 to 14 (which would match default tooltip headers) but that's less important than just having readable CU/CO by default.