### PR TITLE
Prat integration updates

### DIFF
--- a/totalRP3/Modules/ChatFrame/Prat.lua
+++ b/totalRP3/Modules/ChatFrame/Prat.lua
@@ -9,7 +9,7 @@ end
 local _, TRP3_API = ...;
 
 Prat:AddModuleToLoad(function()
-	local pratModule
+	local pratModule;
 	-- Legacy Prat API
 	if Prat.RequestModuleName then
 		local PRAT_MODULE = Prat:RequestModuleName("Total RP 3");


### PR DESCRIPTION
- Add support for the new module syntax (we no longer call RequestModuleName)
- Update syntax for AddLocale for new modules
- Pass `pratModule` rather than `pratModule.name` (this is now deprecated)
- Utilise self on module enable/disable
- Utilise Prat enums for chat events