### PR TITLE
Update Prat.lua

### DIFF
--- a/totalRP3/Modules/ChatFrame/Prat.lua
+++ b/totalRP3/Modules/ChatFrame/Prat.lua
@@ -25,8 +25,6 @@ Prat:AddModuleToLoad(function()
 			module_name = "Total RP 3",
 			module_desc = "Total RP 3 customizations for Prat",
 		});
-
-		if not pratModule:IsEnabled() then return; end
 	end
 
 


### PR DESCRIPTION
We shouldn't need to break out if the module isn't enabled.
This allows hot-reloading of the module state without a full reload.