### PR TITLE
Update workflows to versions supporting node24

### DIFF
--- a/.github/workflows/export-all-translations.yml
+++ b/.github/workflows/export-all-translations.yml
@@ -8,8 +8,8 @@ jobs:
     if: github.repository_owner == 'Total-RP'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/export-translations.yml
+++ b/.github/workflows/export-translations.yml
@@ -11,8 +11,8 @@ jobs:
     if: github.repository_owner == 'Total-RP'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/import-translations.yml
+++ b/.github/workflows/import-translations.yml
@@ -10,8 +10,8 @@ jobs:
     if: github.repository_owner == 'Total-RP'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -25,7 +25,7 @@ jobs:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Import External Translations
           branch: actions/import-external-translations

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
-      - uses: actions/setup-ruby@v1
-      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -30,10 +32,11 @@ jobs:
         with:
           args: -dz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: totalRP3-PR-${{ github.event.number }}
           path: .release/
+          archive: true
           include-hidden-files: true
 
       - name: Send Webhook Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'Total-RP'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'Total-RP'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 


### PR DESCRIPTION
With the following in mind: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I've tested and started updating some workflows to versions that are already updated to node24.
All the node24 actions require GitHub's runner v2.327.1 (mostly relevant for custom runners), but ours is GitHub-ran and is already on v2.332.0 as of writing.

**Extra Notes**
`actions/setup-ruby` was moved over to `ruby/setup-ruby` which is now the official maintained version, we do have to explicitly define a version though (set as `ruby-version: '3.4'` for now).

---
There's a few actions we use that might still be running on Node 20 internally, but some seem unmaintained or are something we seem to maintain (e.g. wow-rp-addons/actions-editorconfig-check).

Whether these will break or not when GitHub forces the change, is to be seen.

---
[upload-artifact v7](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) added support for [uploading single files directly](https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/).
We don't ever do this to my knowledge, but by adding `archive: true` we make sure that one file is still zipped as it did previously (to avoid confusion on our part as we've come to expect this for now).