### PR TITLE
Fix bug when trying to right-click a wild battle pet

### DIFF
--- a/totalRP3/Modules/UnitPopups/UnitPopups.lua
+++ b/totalRP3/Modules/UnitPopups/UnitPopups.lua
@@ -36,6 +36,12 @@ end
 local function GetUnitCompanionProfileInfo(unitToken)
 	local unitType = TRP3_API.ui.misc.getTargetType(unitToken);
 	local companionFullID = TRP3_API.ui.misc.getCompanionFullID(unitToken, unitType);
+
+	if not companionFullID then
+		-- Wild battle pet
+		return nil;
+	end
+
 	local owner, companionID = TRP3_API.utils.str.companionIDToInfo(companionFullID);
 	local profileType, profileID;
 


### PR DESCRIPTION
Right-clicking a wild battle pet would error out as they don't have an owner. Now it won't.

```lua
Message: Interface/AddOns/totalRP3/Core/Utils.lua:134: attempt to index local 'companionID' (a nil value)
Time: Thu Mar 19 20:10:04 2026
Count: 4
Stack:
[Interface/AddOns/totalRP3/Core/Utils.lua]:134: in function 'companionIDToInfo'
[Interface/AddOns/totalRP3/Modules/UnitPopups/UnitPopups.lua]:39: in function <...ce/AddOns/totalRP3/Modules/UnitPopups/UnitPopups.lua:36>
```

