### PR TITLE
Fix error when /trp3 open in instances

### DIFF
--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -601,7 +601,7 @@ function TRP3_API.slash.openProfile(...)
 		end
 
 		-- If no realm has been entered, we use the player's realm automatically
-		if not characterToOpen:find("-") then
+		if characterToOpen and not characterToOpen:find("-") then
 			characterToOpen = characterToOpen .. "-" .. TRP3_API.globals.player_realm_id;
 		end
 	else
@@ -612,6 +612,11 @@ function TRP3_API.slash.openProfile(...)
 			displayMessage(loc.PR_SLASH_OPEN_EXAMPLE);
 			return
 		end
+	end
+
+	if not characterToOpen then
+		-- Probably tried to use a unit token in a secret environment, nothing we can do.
+		return;
 	end
 
 	sendQuery(characterToOpen);


### PR DESCRIPTION
This error first came from TRP3 Unit Frames, but technically could still happen with us alone. If `/trp3 open` is called with a unit token (or nothing at all, which uses `"target"` as default), we cannot retrieve the name of the character to open. We just won't do anything when that happens.

```lua
Message: .../totalRP3/Modules/Register/Main/RegisterExchange.lua:604: attempt to index upvalue 'characterToOpen' (a nil value)
Time: Fri Mar 20 21:14:07 2026
Count: 1
Stack:
[C]: ?
[Interface/AddOns/totalRP3/Modules/Register/Main/RegisterExchange.lua]:604: in function 'openProfile'
[Interface/AddOns/totalRP3_UnitFrames/Buttons.lua]:58: in function <Interface/AddOns/totalRP3_UnitFrames/Buttons.lua:57>
```