### PR TITLE
Fix MSP conflicts further

### DIFF
--- a/totalRP3/Modules/Register/Characters/RegisterAbout.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterAbout.lua
@@ -605,7 +605,7 @@ local function refreshConsultDisplay(context)
 		if context.profile and context.profile.link then
 			TRP3_ProfileReportButton:Show();
 		end
-	elseif msp_RPAddOn ~= "Total RP 3" then
+	elseif msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
 		TRP3_MSPWarningButton:Show();
 	end
 

--- a/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterCharacteristics.lua
@@ -1367,7 +1367,7 @@ local function refreshDisplay()
 	TRP3_MSPWarningButton:Hide();
 	if context.isPlayer then
 		TRP3_RegisterCharact_NamePanel_EditButton:Show();
-		if msp_RPAddOn ~= "Total RP 3" then
+		if msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
 			TRP3_MSPWarningButton:Show();
 		end
 	else

--- a/totalRP3/Modules/Register/Characters/RegisterMain.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMain.lua
@@ -558,7 +558,7 @@ local function showDefaultTab()
 	TRP3_RegisterMisc:Hide();
 	TRP3_RegisterNotes:Hide();
 	TRP3_ProfileReportButton:Hide();
-	TRP3_MSPWarningButton:SetShown(msp_RPAddOn ~= "Total RP 3");
+	TRP3_MSPWarningButton:SetShown(msp_RPAddOn and msp_RPAddOn ~= "Total RP 3");
 
 	tabGroup:SetAllTabsVisible(false);
 

--- a/totalRP3/Modules/Register/Characters/RegisterMisc.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterMisc.lua
@@ -443,7 +443,7 @@ local function showMiscTab()
 		if context.profile and context.profile.link then
 			TRP3_ProfileReportButton:Show();
 		end
-	elseif msp_RPAddOn ~= "Total RP 3" then
+	elseif msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
 		TRP3_MSPWarningButton:Show();
 	end
 end

--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -675,7 +675,7 @@ local function onStart()
 end
 
 function TRP3_API.r.sendMSPQuery(name, targetMode)
-	if msp_RPAddOn ~= "Total RP 3" then
+	if msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
 		return;
 	elseif not name or name == TRP3_API.globals.player_id or TRP3_API.register.isIDIgnored(name) then
 		return;

--- a/totalRP3/Modules/Register/Main/RegisterExchange.lua
+++ b/totalRP3/Modules/Register/Main/RegisterExchange.lua
@@ -298,6 +298,11 @@ end
 
 --- Send vernum request to the player
 local function sendQuery(unitID)
+	if msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
+		-- To avoid issues with profiles flickering between TRP and another MSP profile, we disable sending queries if using a different MSP addon
+		return;
+	end
+
 	if unitID and unitID ~= Globals.player_id and not isIDIgnored(unitID) and checkCooldown(unitID, LAST_QUERY) then
 		LAST_QUERY[unitID] = GetTime();
 		LAST_QUERY_STAT[unitID] = LAST_QUERY[unitID];
@@ -318,9 +323,8 @@ end
 -- This is received when another player has "mouseovered" you.
 -- His main query is to receive your vernum tab. But you can already read his tab to query information.
 local function incomingVernumQuery(structure, senderID, sendBack)
-	if msp_RPAddOn ~= "Total RP 3" then
+	if msp_RPAddOn and msp_RPAddOn ~= "Total RP 3" then
 		-- To avoid issues with profiles flickering between TRP and another MSP profile, we disable replying to vernum queries if using a different MSP addon
-		-- This will still allow people to query others' profiles (which can be useful for companion profiles)
 		return;
 	end
 


### PR DESCRIPTION
Silly me forgot you could disable the MSP module and therefore not have any msp_RPAddOn. We won't display the warning icon or block comms if that's the case.

However, in the process of figuring out why transfers don't work, I realized my comms fix was incorrect. I don't think there is a way to allow you to query other players profiles while refusing queries yourself without leaving some issues, since the very first comms message includes things like client/version numbers/info fields versions which then get saved and displayed on the tooltip. So no profile comms at all if you misbehave.