### PR TITLE
Request MSP profile even if TT field is missing

### DIFF
--- a/totalRP3/Modules/Register/MSP/RegisterMSP.lua
+++ b/totalRP3/Modules/Register/MSP/RegisterMSP.lua
@@ -472,7 +472,7 @@ local function onStart()
 			local color = false;
 			for _, field in ipairs(SUPPORTED_FIELDS) do
 				if profile.mspver[field] ~= msp.char[senderID].ver[field]
-				or msp.ttAll[field] and profile.mspver.TT ~= msp.char[senderID].ver.TT
+				or msp.ttAll[field] and (not msp.char[senderID].ver.TT or profile.mspver.TT ~= msp.char[senderID].ver.TT)
 				then
 					-- Save version
 					profile.mspver[field] = msp.char[senderID].ver[field];


### PR DESCRIPTION
We found a MSP profile that couldn't be properly retrieved with TRP despite working fine with MSP addons. Through investigation, we found the TT field was nil, but were unable to determine how that even happened. For now, we'll just assume if the field is nil, we let the process go ahead and save the data anyway, as the issue seems very rare anyway.