### PR TITLE
Add LibChatFilter for greater inter-addon chat transform compatibilities

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -40,6 +40,7 @@ externals:
     url: https://www.townlong-yak.com/addons.git/taintless
     commit: default
   totalRP3/Libs/UTF8: https://repos.curseforge.com/wow/utf8/trunk
+  totalRP3/Libs/LibChatFilter: https://github.com/Ghostopheles/LibChatFilter
 
 manual-changelog:
   filename: CHANGELOG.md

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -28,6 +28,7 @@ externals:
   totalRP3/Libs/ChatThrottleLib: https://repos.curseforge.com/wow/chatthrottlelib/trunk
   totalRP3/Libs/Chomp: https://github.com/wow-rp-addons/Chomp
   totalRP3/Libs/LibChatAnims: https://repos.curseforge.com/wow/libchatanims/trunk/LibChatAnims
+  totalRP3/Libs/LibChatFilter: https://github.com/Ghostopheles/LibChatFilter
   totalRP3/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   totalRP3/Libs/LibDBCompartment: https://github.com/Meorawr/LibDBCompartment
   totalRP3/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
@@ -40,7 +41,6 @@ externals:
     url: https://www.townlong-yak.com/addons.git/taintless
     commit: default
   totalRP3/Libs/UTF8: https://repos.curseforge.com/wow/utf8/trunk
-  totalRP3/Libs/LibChatFilter: https://github.com/Ghostopheles/LibChatFilter
 
 manual-changelog:
   filename: CHANGELOG.md

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -734,7 +734,6 @@ function Utils.customGetColoredName(event, _, _, unitID, _, _, _, _, _, _, _, _,
 	return characterName;
 end
 
-local textBeforeParse, parsedEditBox;
 function hooking()
 	for _, channel in pairs(POSSIBLE_CHANNELS) do
 		ChatFrameUtil.RemoveMessageEventFilter(channel, handleCharacterMessage);
@@ -792,7 +791,7 @@ function hooking()
 		end
 	end
 
-	local function ParseTokens(text, context)
+	local function ParseTokens(text)
 		local player = AddOn_TotalRP3.Player.GetCurrentUser();
 		local tokens = {
 			["%xtf"] = GetTokenSafe(getUnitRPFirstName("target"), TARGET_TOKEN_NOT_FOUND),

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -14,6 +14,8 @@ local getUnitIDCurrentProfile, getUnitRPName, getUnitRPFirstName, getUnitRPLastN
 local getConfigValue, registerConfigKey, registerHandler = TRP3_API.configuration.getValue, TRP3_API.configuration.registerConfigKey, TRP3_API.configuration.registerHandler;
 local handleCharacterMessage, hooking;
 
+local LibChatFilter = LibStub:GetLibrary("LibChatFilter");
+
 TRP3_API.chat = {};
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -790,39 +792,23 @@ function hooking()
 		end
 	end
 
-	local function ParseTokens(editBox, send)
-		local text = editBox:GetText();
-		if text and send == 1 then
-			textBeforeParse = text;
-			parsedEditBox = editBox;
-			local player = AddOn_TotalRP3.Player.GetCurrentUser();
-			local tokens = {
-				["%xtf"] = GetTokenSafe(getUnitRPFirstName("target"), TARGET_TOKEN_NOT_FOUND),
-				["%xtl"] = GetTokenSafe(getUnitRPLastName("target"), TARGET_TOKEN_NOT_FOUND),
-				["%xff"] = GetTokenSafe(getUnitRPFirstName("focus"), FOCUS_TOKEN_NOT_FOUND),
-				["%xfl"] = GetTokenSafe(getUnitRPLastName("focus"), FOCUS_TOKEN_NOT_FOUND),
-				["%xpf"] = GetTokenSafe(player:GetFirstName(), ""),
-				["%xpl"] = GetTokenSafe(player:GetLastName(), ""),
-				["%xt"] = GetTokenSafe(getUnitRPName("target"), TARGET_TOKEN_NOT_FOUND),
-				["%xf"] = GetTokenSafe(getUnitRPName("focus"), FOCUS_TOKEN_NOT_FOUND),
-				["%xp"] = GetTokenSafe(player:GetFullName(), ""),
-			};
-			text = string.gsub(text, "%%x.[fl]?", tokens);
-			editBox:SetText(text);
-		end
+	local function ParseTokens(text, context)
+		local player = AddOn_TotalRP3.Player.GetCurrentUser();
+		local tokens = {
+			["%xtf"] = GetTokenSafe(getUnitRPFirstName("target"), TARGET_TOKEN_NOT_FOUND),
+			["%xtl"] = GetTokenSafe(getUnitRPLastName("target"), TARGET_TOKEN_NOT_FOUND),
+			["%xff"] = GetTokenSafe(getUnitRPFirstName("focus"), FOCUS_TOKEN_NOT_FOUND),
+			["%xfl"] = GetTokenSafe(getUnitRPLastName("focus"), FOCUS_TOKEN_NOT_FOUND),
+			["%xpf"] = GetTokenSafe(player:GetFirstName(), ""),
+			["%xpl"] = GetTokenSafe(player:GetLastName(), ""),
+			["%xt"] = GetTokenSafe(getUnitRPName("target"), TARGET_TOKEN_NOT_FOUND),
+			["%xf"] = GetTokenSafe(getUnitRPName("focus"), FOCUS_TOKEN_NOT_FOUND),
+			["%xp"] = GetTokenSafe(player:GetFullName(), ""),
+		};
+		text = string.gsub(text, "%%x.[fl]?", tokens);
+		return text;
 	end
-	for i = 1, Constants.ChatFrameConstants.MaxChatWindows do
-		hooksecurefunc(_G["ChatFrame" .. i .. "EditBox"], "ParseText", ParseTokens);
-	end
-
-	-- Restore the text without substitution before it's stored in the chat history
-	hooksecurefunc(ChatFrameUtil, "SubstituteChatMessageBeforeSend", function()
-		if parsedEditBox and textBeforeParse then
-			parsedEditBox:SetText(textBeforeParse);
-			parsedEditBox = nil;
-			textBeforeParse = nil;
-		end
-	end);
+	LibChatFilter.RegisterTransform(ParseTokens);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/Modules/ChatFrame/ChatFrame.lua
+++ b/totalRP3/Modules/ChatFrame/ChatFrame.lua
@@ -807,7 +807,9 @@ function hooking()
 		text = string.gsub(text, "%%x.[fl]?", tokens);
 		return text;
 	end
-	LibChatFilter.RegisterTransform(ParseTokens);
+	local stage = LibChatFilter.Stage.TRANSFORM;
+	local track = LibChatFilter.Track.SEND; -- only modifying the text being sent, not the chat history
+	LibChatFilter.RegisterMutator(ParseTokens, stage, track);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -49,6 +49,7 @@ Libs\LibMSP\LibMSP.xml
 Libs\LibRPMedia\lib.xml
 Libs\LibWindow-1.1\LibWindow-1.1.lua
 Libs\UTF8\lib.xml
+Libs\LibChatFilter\lib.xml
 
 totalRP3.xml
 Deprecated.xml

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -41,6 +41,7 @@ Libs\TaintLess\TaintLess.xml
 Libs\Chomp\Chomp.xml
 Libs\Ellyb\Ellyb.xml
 Libs\LibChatAnims\LibChatAnims.xml
+Libs\LibChatFilter\lib.xml
 Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
 Libs\LibDBCompartment\lib.xml
 Libs\LibDBIcon-1.0\lib.xml
@@ -49,7 +50,6 @@ Libs\LibMSP\LibMSP.xml
 Libs\LibRPMedia\lib.xml
 Libs\LibWindow-1.1\LibWindow-1.1.lua
 Libs\UTF8\lib.xml
-Libs\LibChatFilter\lib.xml
 
 totalRP3.xml
 Deprecated.xml


### PR DESCRIPTION
[LibChatFilter](https://github.com/Ghostopheles/LibChatFilter) coordinates outgoing message hooks to ensure addons aren't fighting and/or overwriting each other when it comes to mutating messages before they're sent out. It also ensures that the chat history buffer is separated from the outgoing message itself, so users won't see post-transform text in their history.

Will fix the TRP3 chat token parsing when in the presence of these addons (after their respective PRs are merged):
- https://github.com/Ghostopheles/Chattery/pull/2
- https://github.com/keyboardturner/Languages/pull/2