### PR TITLE
Preserve Self-Notes When A Profile Is Imported

### DIFF
--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -605,7 +605,7 @@ function TRP3_API.profile.init()
 		if version ~= nil then
 			local import = function()
 				data.profileName = profiles[currentProfileID].profileName;
-				wipe(profiles[currentProfileID]);
+				profiles[currentProfileID] = nil;
 				local destinationProfileID = currentProfileID;
 				if not profiles[errorOrOldProfileID] then
 					destinationProfileID = errorOrOldProfileID;

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -602,7 +602,7 @@ function TRP3_API.profile.init()
 		local code = TRP3_ProfileImport.content.scroll.text:GetText();
 		local version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
 
-		if version ~= nil then
+		if version ~= nil and data ~= nil then
 			local import = function()
 				data.profileName = profiles[currentProfileID].profileName;
 				profiles[currentProfileID] = nil;

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -170,14 +170,6 @@ local function updateDefaultProfile()
 
 	local profileDefault = profiles[newProfileID];
 
-	-- The default profile is assigned a brand new ID every login. A note on the
-	-- default profile is keyed by its own (old) ID, so move it onto the new ID to keep the self-note from being orphaned.
-
-	if profileDefault.notes and oldProfileID ~= newProfileID and profileDefault.notes[oldProfileID] ~= nil then
-		profileDefault.notes[newProfileID] = profileDefault.notes[oldProfileID];
-		profileDefault.notes[oldProfileID] = nil;
-	end
-
 	-- Updating profile name in case of addon locale change
 	profileDefault.profileName = loc.PR_DEFAULT_PROFILE_NAME;
 
@@ -618,7 +610,6 @@ function TRP3_API.profile.init()
 
 				-- A note on your own profile is keyed by the profile's own ID, which is the
 				-- source profile's ID here, not this destination slot's ID. Re-key it onto the slot's ID so the self-note isn't orphaned
-				
 				local sourceProfileID = errorOrProfileID;
 				if data.notes and sourceProfileID and sourceProfileID ~= profileID and data.notes[sourceProfileID] ~= nil then
 					data.notes[profileID] = data.notes[sourceProfileID];

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -170,6 +170,14 @@ local function updateDefaultProfile()
 
 	local profileDefault = profiles[newProfileID];
 
+	-- The default profile is assigned a brand new ID every login. A note on the
+	-- default profile is keyed by its own (old) ID, so move it onto the new ID to keep the self-note from being orphaned.
+
+	if profileDefault.notes and oldProfileID ~= newProfileID and profileDefault.notes[oldProfileID] ~= nil then
+		profileDefault.notes[newProfileID] = profileDefault.notes[oldProfileID];
+		profileDefault.notes[oldProfileID] = nil;
+	end
+
 	-- Updating profile name in case of addon locale change
 	profileDefault.profileName = loc.PR_DEFAULT_PROFILE_NAME;
 
@@ -607,6 +615,15 @@ function TRP3_API.profile.init()
 				data.profileName = profiles[profileID].profileName;
 				wipe(profiles[profileID]);
 				profiles[profileID] = data;
+
+				-- A note on your own profile is keyed by the profile's own ID, which is the
+				-- source profile's ID here, not this destination slot's ID. Re-key it onto the slot's ID so the self-note isn't orphaned
+				
+				local sourceProfileID = errorOrProfileID;
+				if data.notes and sourceProfileID and sourceProfileID ~= profileID and data.notes[sourceProfileID] ~= nil then
+					data.notes[profileID] = data.notes[sourceProfileID];
+					data.notes[sourceProfileID] = nil;
+				end
 
 				if data then
 					-- Converting old music paths to new ID system

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -598,37 +598,38 @@ function TRP3_API.profile.init()
 	TRP3_ProfileImport.content.title:SetText(loc.PR_IMPORT_PROFILE_TT);
 	TRP3_ProfileImport.save:SetText(loc.PR_IMPORT);
 	TRP3_ProfileImport.save:SetScript("OnClick", function()
-		local profileID = TRP3_ProfileImport.profileID;
+		local currentProfileID = TRP3_ProfileImport.profileID;
 		local code = TRP3_ProfileImport.content.scroll.text:GetText();
-		local version, errorOrProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
+		local version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
 
 		if version ~= nil then
 			local import = function()
-				data.profileName = profiles[profileID].profileName;
-				wipe(profiles[profileID]);
-				profiles[profileID] = data;
+				data.profileName = profiles[currentProfileID].profileName;
+				wipe(profiles[currentProfileID]);
+				local destinationProfileID = currentProfileID;
+				if not profiles[errorOrOldProfileID] then
+					destinationProfileID = errorOrOldProfileID;
+				end
+				profiles[destinationProfileID] = data;
 
 				-- A note on your own profile is keyed by the profile's own ID, which is the
 				-- source profile's ID here, not this destination slot's ID. Re-key it onto the slot's ID so the self-note isn't orphaned
-				local sourceProfileID = errorOrProfileID;
-				if data.notes and sourceProfileID and sourceProfileID ~= profileID and data.notes[sourceProfileID] ~= nil then
-					data.notes[profileID] = data.notes[sourceProfileID];
-					data.notes[sourceProfileID] = nil;
+				if destinationProfileID ~= errorOrOldProfileID and data.notes and data.notes[errorOrOldProfileID] and not data.notes[destinationProfileID] then
+					data.notes[destinationProfileID] = data.notes[errorOrOldProfileID];
+					data.notes[errorOrOldProfileID] = nil;
 				end
 
-				if data then
-					-- Converting old music paths to new ID system
-					if data.player and data.player.about and data.player.about.MU and type(data.player.about.MU) == "string" then
-						profiles[profileID].player.about.MU = Utils.music.convertPathToID(data.player.about.MU);
-					end
+				-- Converting old music paths to new ID system
+				if data.player and data.player.about and data.player.about.MU and type(data.player.about.MU) == "string" then
+					profiles[destinationProfileID].player.about.MU = Utils.music.convertPathToID(data.player.about.MU);
+				end
 
-					-- Misc info ID conversion
-					if data.player and data.player.characteristics and data.player.characteristics.MI then
-						for _, miscData in ipairs(data.player.characteristics.MI) do
-							if not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-								-- Adding ID from name if ID missing, or setting a preset to custom if renamed
-								miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
-							end
+				-- Misc info ID conversion
+				if data.player and data.player.characteristics and data.player.characteristics.MI then
+					for _, miscData in ipairs(data.player.characteristics.MI) do
+						if not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom then
+							-- Adding ID from name if ID missing, or setting a preset to custom if renamed
+							miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
 						end
 					end
 				end
@@ -638,12 +639,12 @@ function TRP3_API.profile.init()
 			end
 
 			if version ~= Globals.version then
-				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING_2:format(Utils.str.color("g") .. profiles[profileID].profileName .. "|r"), import);
+				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING_2:format(Utils.str.color("g") .. profiles[currentProfileID].profileName .. "|r"), import);
 			else
-				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING:format(Utils.str.color("g") .. profiles[profileID].profileName .. "|r"), import);
+				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING:format(Utils.str.color("g") .. profiles[currentProfileID].profileName .. "|r"), import);
 			end
 		else
-			Utils.message.displayMessage(string.format(loc.PR_IMPORT_ERROR, errorOrProfileID), 2);
+			Utils.message.displayMessage(string.format(loc.PR_IMPORT_ERROR, errorOrOldProfileID), 2);
 		end
 	end);
 

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -47,6 +47,8 @@ local DEFAULT_RELATIONS = {
 local ACTIONS = {
 	DELETE = "DEL",
 	EDIT = "EDT",
+	MOVE_UP = "MUP",
+	MOVE_DOWN = "MDN",
 };
 
 --getRelationList function should get relations stored in config, or default relations if none are stored
@@ -255,6 +257,38 @@ end
 
 local updateRelationsList;
 
+-- Moves a relation up (delta = -1) or down (delta = 1) in the display order,
+-- then renumbers all orders to keep them consecutive.
+local function moveRelation(relationID, delta)
+	local sortedRelations = getRelationList(true);
+
+	local index;
+	for i, relation in ipairs(sortedRelations) do
+		if relation.id == relationID then
+			index = i;
+			break;
+		end
+	end
+	if not index then
+		return;
+	end
+
+	local targetIndex = index + delta;
+	-- The first position is reserved for the default "None" relation.
+	if targetIndex < 2 or targetIndex > #sortedRelations then
+		return;
+	end
+
+	sortedRelations[index], sortedRelations[targetIndex] = sortedRelations[targetIndex], sortedRelations[index];
+	-- Entries are references into the stored relation list, so renumbering
+	-- them here updates the saved configuration directly.
+	for i, relation in ipairs(sortedRelations) do
+		relation.order = i - 1;
+	end
+
+	updateRelationsList();
+end
+
 local function onActionSelected(selectedAction)
 	local action = selectedAction:sub(1, 3);
 	local relationID = selectedAction:sub(4);
@@ -262,6 +296,10 @@ local function onActionSelected(selectedAction)
 	local originalRelation = (getColor(relation) or TRP3_API.Colors.White)(relation.name or loc:GetText("REG_RELATION_" .. relation.id));
 	if action == ACTIONS.EDIT then
 		TRP3_API.register.relation.showEditor(relation.id);
+	elseif action == ACTIONS.MOVE_UP then
+		moveRelation(relationID, -1);
+	elseif action == ACTIONS.MOVE_DOWN then
+		moveRelation(relationID, 1);
 	elseif not relation.inUse and action == ACTIONS.DELETE then
 		TRP3_API.popup.showConfirmPopup(loc.CO_RELATIONS_DELETE_WARNING:format(originalRelation), function()
 			local relationList = getRelationList();
@@ -283,8 +321,9 @@ local widgetsList = {};
 function updateRelationsList()
 	local relations = getRelationList(true);
 
+	local relationCount = #relations;
 	local widgetCount = 1;
-	for _, relation in ipairs(relations) do
+	for index, relation in ipairs(relations) do
 		local widget = widgetsList[widgetCount];
 		if not widget then
 			widget = CreateFrame("Frame", nil, TRP3_RelationsList.ScrollFrame.Content, "TRP3_ConfigurationRelationsFrame");
@@ -307,6 +346,12 @@ function updateRelationsList()
 		TRP3_API.ui.tooltip.setTooltipForSameFrame(widget.Actions, "RIGHT", 0, 5, loc.CM_OPTIONS, TRP3_API.FormatShortcutWithInstruction("CLICK", loc.CM_OPTIONS_ADDITIONAL));
 		widget.Actions:SetScript("OnMouseDown", function(button)
 			TRP3_MenuUtil.CreateContextMenu(button, function(_, description)
+				local moveUpOption = description:CreateButton(loc.CM_MOVE_UP, onActionSelected, ACTIONS.MOVE_UP..relation.id);
+				-- Index 1 is the default "None" relation, which stays locked at the top.
+				moveUpOption:SetEnabled(index > 2);
+				local moveDownOption = description:CreateButton(loc.CM_MOVE_DOWN, onActionSelected, ACTIONS.MOVE_DOWN..relation.id);
+				moveDownOption:SetEnabled(index < relationCount);
+				description:CreateDivider();
 				description:CreateButton(loc.CO_RELATIONS_MENU_EDIT, onActionSelected, ACTIONS.EDIT..relation.id);
 				checkRelationUse();
 				if relation.inUse then

--- a/totalRP3/Modules/Register/Characters/RegisterRelations.lua
+++ b/totalRP3/Modules/Register/Characters/RegisterRelations.lua
@@ -47,8 +47,6 @@ local DEFAULT_RELATIONS = {
 local ACTIONS = {
 	DELETE = "DEL",
 	EDIT = "EDT",
-	MOVE_UP = "MUP",
-	MOVE_DOWN = "MDN",
 };
 
 --getRelationList function should get relations stored in config, or default relations if none are stored
@@ -257,38 +255,6 @@ end
 
 local updateRelationsList;
 
--- Moves a relation up (delta = -1) or down (delta = 1) in the display order,
--- then renumbers all orders to keep them consecutive.
-local function moveRelation(relationID, delta)
-	local sortedRelations = getRelationList(true);
-
-	local index;
-	for i, relation in ipairs(sortedRelations) do
-		if relation.id == relationID then
-			index = i;
-			break;
-		end
-	end
-	if not index then
-		return;
-	end
-
-	local targetIndex = index + delta;
-	-- The first position is reserved for the default "None" relation.
-	if targetIndex < 2 or targetIndex > #sortedRelations then
-		return;
-	end
-
-	sortedRelations[index], sortedRelations[targetIndex] = sortedRelations[targetIndex], sortedRelations[index];
-	-- Entries are references into the stored relation list, so renumbering
-	-- them here updates the saved configuration directly.
-	for i, relation in ipairs(sortedRelations) do
-		relation.order = i - 1;
-	end
-
-	updateRelationsList();
-end
-
 local function onActionSelected(selectedAction)
 	local action = selectedAction:sub(1, 3);
 	local relationID = selectedAction:sub(4);
@@ -296,10 +262,6 @@ local function onActionSelected(selectedAction)
 	local originalRelation = (getColor(relation) or TRP3_API.Colors.White)(relation.name or loc:GetText("REG_RELATION_" .. relation.id));
 	if action == ACTIONS.EDIT then
 		TRP3_API.register.relation.showEditor(relation.id);
-	elseif action == ACTIONS.MOVE_UP then
-		moveRelation(relationID, -1);
-	elseif action == ACTIONS.MOVE_DOWN then
-		moveRelation(relationID, 1);
 	elseif not relation.inUse and action == ACTIONS.DELETE then
 		TRP3_API.popup.showConfirmPopup(loc.CO_RELATIONS_DELETE_WARNING:format(originalRelation), function()
 			local relationList = getRelationList();
@@ -321,9 +283,8 @@ local widgetsList = {};
 function updateRelationsList()
 	local relations = getRelationList(true);
 
-	local relationCount = #relations;
 	local widgetCount = 1;
-	for index, relation in ipairs(relations) do
+	for _, relation in ipairs(relations) do
 		local widget = widgetsList[widgetCount];
 		if not widget then
 			widget = CreateFrame("Frame", nil, TRP3_RelationsList.ScrollFrame.Content, "TRP3_ConfigurationRelationsFrame");
@@ -346,12 +307,6 @@ function updateRelationsList()
 		TRP3_API.ui.tooltip.setTooltipForSameFrame(widget.Actions, "RIGHT", 0, 5, loc.CM_OPTIONS, TRP3_API.FormatShortcutWithInstruction("CLICK", loc.CM_OPTIONS_ADDITIONAL));
 		widget.Actions:SetScript("OnMouseDown", function(button)
 			TRP3_MenuUtil.CreateContextMenu(button, function(_, description)
-				local moveUpOption = description:CreateButton(loc.CM_MOVE_UP, onActionSelected, ACTIONS.MOVE_UP..relation.id);
-				-- Index 1 is the default "None" relation, which stays locked at the top.
-				moveUpOption:SetEnabled(index > 2);
-				local moveDownOption = description:CreateButton(loc.CM_MOVE_DOWN, onActionSelected, ACTIONS.MOVE_DOWN..relation.id);
-				moveDownOption:SetEnabled(index < relationCount);
-				description:CreateDivider();
 				description:CreateButton(loc.CO_RELATIONS_MENU_EDIT, onActionSelected, ACTIONS.EDIT..relation.id);
 				checkRelationUse();
 				if relation.inUse then


### PR DESCRIPTION
Notes written on your own profile are lost when that profile is imported into another slot. This re-keys the self-note so it survives the import, and fixes the same latent bug on the login path that rotates the default profile's ID.

---
Profile notes are stored in `profile.notes`, keyed by the target profile's ID:
- A note about another player is keyed by that player's profile ID.
- A note on your own profile is keyed by your own profile's ID and reads it back the same way.

A profile's ID is tied to its slot and not the data it holds. On import, the destination slot keeps its own ID but the imported self-note still carries the source profile's ID as its key. The lookup misses and the note renders blank.

Notes about other players are keyed by those players' IDs which don't change across the import so they come through fine which is why only the self-note disappears.

`updateDefaultProfile()` has the same flaw: it assigns the default profile a fresh ID on every login without re-keying the self-note.

In both cases the data is lost as it is orphaned under a key nothing looks up.

---

Note: This attempt was unable to recover already orphaned notes as their old key is gone from any lookup and only notes handled after the changes were made are fixed.