### PR TITLE
Rework alpha check in CreateColor

### DIFF
--- a/totalRP3/Core/Color.lua
+++ b/totalRP3/Core/Color.lua
@@ -138,6 +138,10 @@ end
 local ColorCache = { cache = setmetatable({}, { __mode = "kv" }) };
 
 function ColorCache:Acquire(r, g, b, a)
+	if issecretvalue(a) then
+		a = 1;
+	end
+
 	local key = string.format("#%02x%02x%02x%02x", a * 255, r * 255, g * 255, b * 255);
 	local color = self.cache[key];
 
@@ -164,49 +168,30 @@ function TRP3_API.ApplyColorPrototype(color)
 end
 
 function TRP3_API.CreateColor(r, g, b, a)
-	if issecretvalue(a) or not a then
-		a = 1;
-	end
-	return ColorCache:Acquire(r, g, b, a);
+	return ColorCache:Acquire(r, g, b, a or 1);
 end
 
 function TRP3_API.CreateColorFromBytes(r, g, b, a)
-	if issecretvalue(a) or not a then
-		a = 255;
-	end
 	return ColorCache:Acquire(r / 255, g / 255, b / 255, a and (a / 255) or 1);
 end
 
 function TRP3_API.CreateColorFromTable(t)
-	local a = t.a;
-	if issecretvalue(a) or not a then
-		a = 1;
-	end
-	return ColorCache:Acquire(t.r, t.g, t.b, a);
+	return ColorCache:Acquire(t.r, t.g, t.b, t.a or 1);
 end
 
 function TRP3_API.CreateColorFromHSLA(h, s, l, a)
 	local r, g, b = ConvertHSLToRGB(h, s, l);
-	if issecretvalue(a) or not a then
-		a = 1;
-	end
-	return ColorCache:Acquire(r, g, b, a);
+	return ColorCache:Acquire(r, g, b, a or 1);
 end
 
 function TRP3_API.CreateColorFromHSVA(h, s, v, a)
 	local r, g, b = C_ColorUtil.ConvertHSVToRGB(h, s, v);
-	if issecretvalue(a) or not a then
-		a = 1;
-	end
-	return ColorCache:Acquire(r, g, b, a);
+	return ColorCache:Acquire(r, g, b, a or 1);
 end
 
 function TRP3_API.CreateColorFromHWBA(h, w, b, a)
 	local r, g, b = ConvertHWBToRGB(h, w, b);  -- luacheck: no redefined
-	if issecretvalue(a) or not a then
-		a = 1;
-	end
-	return ColorCache:Acquire(r, g, b, a);
+	return ColorCache:Acquire(r, g, b, a or 1);
 end
 
 function TRP3_API.CreateColorFromName(name)

--- a/totalRP3/Core/Color.lua
+++ b/totalRP3/Core/Color.lua
@@ -164,30 +164,49 @@ function TRP3_API.ApplyColorPrototype(color)
 end
 
 function TRP3_API.CreateColor(r, g, b, a)
-	return ColorCache:Acquire(r, g, b, a or 1);
+	if a == nil then
+		a = 1;
+	end
+	return ColorCache:Acquire(r, g, b, a);
 end
 
 function TRP3_API.CreateColorFromBytes(r, g, b, a)
+	if a == nil then
+		a = 255;
+	end
 	return ColorCache:Acquire(r / 255, g / 255, b / 255, a and (a / 255) or 1);
 end
 
 function TRP3_API.CreateColorFromTable(t)
-	return ColorCache:Acquire(t.r, t.g, t.b, t.a or 1);
+	local a = t.a;
+	if a == nil then
+		a = 1;
+	end
+	return ColorCache:Acquire(t.r, t.g, t.b, a);
 end
 
 function TRP3_API.CreateColorFromHSLA(h, s, l, a)
 	local r, g, b = ConvertHSLToRGB(h, s, l);
-	return ColorCache:Acquire(r, g, b, a or 1);
+	if a == nil then
+		a = 1;
+	end
+	return ColorCache:Acquire(r, g, b, a);
 end
 
 function TRP3_API.CreateColorFromHSVA(h, s, v, a)
 	local r, g, b = C_ColorUtil.ConvertHSVToRGB(h, s, v);
-	return ColorCache:Acquire(r, g, b, a or 1);
+	if a == nil then
+		a = 1;
+	end
+	return ColorCache:Acquire(r, g, b, a);
 end
 
 function TRP3_API.CreateColorFromHWBA(h, w, b, a)
 	local r, g, b = ConvertHWBToRGB(h, w, b);  -- luacheck: no redefined
-	return ColorCache:Acquire(r, g, b, a or 1);
+	if a == nil then
+		a = 1;
+	end
+	return ColorCache:Acquire(r, g, b, a);
 end
 
 function TRP3_API.CreateColorFromName(name)

--- a/totalRP3/Core/Color.lua
+++ b/totalRP3/Core/Color.lua
@@ -164,14 +164,14 @@ function TRP3_API.ApplyColorPrototype(color)
 end
 
 function TRP3_API.CreateColor(r, g, b, a)
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 1;
 	end
 	return ColorCache:Acquire(r, g, b, a);
 end
 
 function TRP3_API.CreateColorFromBytes(r, g, b, a)
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 255;
 	end
 	return ColorCache:Acquire(r / 255, g / 255, b / 255, a and (a / 255) or 1);
@@ -179,7 +179,7 @@ end
 
 function TRP3_API.CreateColorFromTable(t)
 	local a = t.a;
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 1;
 	end
 	return ColorCache:Acquire(t.r, t.g, t.b, a);
@@ -187,7 +187,7 @@ end
 
 function TRP3_API.CreateColorFromHSLA(h, s, l, a)
 	local r, g, b = ConvertHSLToRGB(h, s, l);
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 1;
 	end
 	return ColorCache:Acquire(r, g, b, a);
@@ -195,7 +195,7 @@ end
 
 function TRP3_API.CreateColorFromHSVA(h, s, v, a)
 	local r, g, b = C_ColorUtil.ConvertHSVToRGB(h, s, v);
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 1;
 	end
 	return ColorCache:Acquire(r, g, b, a);
@@ -203,7 +203,7 @@ end
 
 function TRP3_API.CreateColorFromHWBA(h, w, b, a)
 	local r, g, b = ConvertHWBToRGB(h, w, b);  -- luacheck: no redefined
-	if a == nil then
+	if issecretvalue(a) or not a then
 		a = 1;
 	end
 	return ColorCache:Acquire(r, g, b, a);

--- a/totalRP3/Core/Color.lua
+++ b/totalRP3/Core/Color.lua
@@ -138,7 +138,7 @@ end
 local ColorCache = { cache = setmetatable({}, { __mode = "kv" }) };
 
 function ColorCache:Acquire(r, g, b, a)
-	if issecretvalue(a) then
+	if not canaccessvalue(a) then
 		a = 1;
 	end
 


### PR DESCRIPTION
There was an error with secret alpha values in nameplates as Acquire would try to do math on secrets. I just changed so it shouldn't trip on secrets anymore (probably)

<img width="1064" height="707" alt="image" src="https://github.com/user-attachments/assets/26361703-c938-4ea8-a4bb-9b751e3d584b" />
