### PR TITLE
Profiles Rework 2026

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -703,6 +703,7 @@ stds.wow = {
 		"ReloadUI",
 		"RemoveChatWindowChannel",
 		"ResetCursor",
+		"RunNextFrame",
 		"RoundToSignificantDigits",
 		"SafePack",
 		"Saturate",

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -363,38 +363,38 @@ end
 local function UiInitProfileList()
 	wipe(profileListID);
 	local defaultProfileID = getConfigValue("default_profile_id");
-    local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManager.list.SearchBox:GetText());
-    local searchMode = profileSearch ~= nil;
+	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManager.list.SearchBox:GetText());
+	local searchMode = profileSearch ~= nil;
 
 	-- Build filtered profile list
-    for profileID, _ in pairs(profiles) do
-        local shouldAdd = profileID ~= defaultProfileID;
+	for profileID, _ in pairs(profiles) do
+		local shouldAdd = profileID ~= defaultProfileID;
 
-        if shouldAdd and searchMode then
-            local profileName = profiles[profileID].profileName:lower();
-            shouldAdd = string.find(profileName, profileSearch:lower(), 1, true);
-        end
+		if shouldAdd and searchMode then
+			local profileName = profiles[profileID].profileName:lower();
+			shouldAdd = string.find(profileName, profileSearch:lower(), 1, true);
+		end
 
-        if shouldAdd then
-            tinsert(profileListID, profileID);
-        end
-    end
+		if shouldAdd then
+			tinsert(profileListID, profileID);
+		end
+	end
 
-    -- Sort profiles alphabetically
-    table.sort(profileListID, ProfileSortingByProfileName);
+	-- Sort profiles alphabetically
+	table.sort(profileListID, ProfileSortingByProfileName);
 
-    -- Handle empty state display
-    local isEmpty = #profileListID == 0;
-    TRP3_ProfileManager.list.ScrollBox.EmptyText:SetShown(searchMode and isEmpty);
+	-- Handle empty state display
+	local isEmpty = #profileListID == 0;
+	TRP3_ProfileManager.list.ScrollBox.EmptyText:SetShown(searchMode and isEmpty);
 
-    -- Add default profile at top when not searching
-    if not searchMode then
-        tinsert(profileListID, 1, defaultProfileID);
-    end
+	-- Add default profile at top when not searching
+	if not searchMode then
+		tinsert(profileListID, 1, defaultProfileID);
+	end
 
-    -- Update scrollbox
-    local provider = CreateDataProvider(profileListID);
-    TRP3_ProfileManager.list.ScrollBox:SetDataProvider(provider, ScrollBoxConstants.RetainScrollPosition);
+	-- Update scrollbox
+	local provider = CreateDataProvider(profileListID);
+	TRP3_ProfileManager.list.ScrollBox:SetDataProvider(provider, ScrollBoxConstants.RetainScrollPosition);
 end
 
 local showConfirmPopup = TRP3_API.popup.showConfirmPopup;
@@ -426,10 +426,10 @@ local profileIcon;
 --- SetupChoicesFrame prepares the Choices frame from the Profile Create flow.
 local function SetupChoicesFrame()
 	local frames = TRP3_ProfileCreateDialog.Frames;
-    local choicesFrame = frames.ChoicesFrame;
+	local choicesFrame = frames.ChoicesFrame;
 
-    choicesFrame.Title:SetText(loc.PR_CREATE_PROFILE);
-    frames:SetHeight(200);
+	choicesFrame.Title:SetText(loc.PR_CREATE_PROFILE);
+	frames:SetHeight(200);
 
 	forceClose, profileIcon, chosenProfile = false, nil, nil;
 
@@ -441,10 +441,10 @@ end
 --- SetupImportFrame prepares the Import frame from the Profile Create flow.
 local function SetupImportFrame()
 	local frames = TRP3_ProfileCreateDialog.Frames;
-    local importFrame = frames.ImportFrame;
+	local importFrame = frames.ImportFrame;
 
-    importFrame.Title:SetText(loc.PR_IMPORT_PROFILE);
-    frames:SetHeight(400);
+	importFrame.Title:SetText(loc.PR_IMPORT_PROFILE);
+	frames:SetHeight(400);
 
 	-- Show import and profile creation frame
 	importFrame:Show();
@@ -513,15 +513,15 @@ local function SetupFinalizeFrame(creationOption, profileName)
 	FinalizeFrame.Icon:SetShown(showIcon);
 
 	if showIcon then
-        FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPRIGHT", 15, -4);
-        -- Initialize and set up icon only when needed
+		FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPRIGHT", 15, -4);
+		-- Initialize and set up icon only when needed
 		profileIcon = profileIcon or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
 		setupIconButton(FinalizeFrame.Icon, profileIcon);
 		FinalizeFrame.ConfirmButton:SetText(loc.PR_CREATE_PROFILE);
-    else
-        FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPLEFT", 0, -4);
+	else
+		FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPLEFT", 0, -4);
 		FinalizeFrame.ConfirmButton:SetText(loc.PR_PROFILEMANAGER_RENAME);
-    end
+	end
 
 	FinalizeFrame.Name:SetText(name);
 	frames:SetHeight(150);
@@ -552,19 +552,19 @@ local function CloseProfileFlow()
 	local frames = TRP3_ProfileCreateDialog.Frames;
 	PlaySound(TRP3_InterfaceSounds.PopupClose);
 
-    -- Handle different visible frames
-    if frames.ExportFrame:IsVisible() then
-        -- Just close export and parent
-        frames.ExportFrame:Hide();
-        TRP3_ProfileCreateDialog:Hide();
-    elseif frames.ImportFrame:IsVisible() then
-        -- Clean up import frame
-        frames.ImportFrame:Hide();
-        frames.ImportFrame.Content.ImportText:ClearText();
-    elseif frames.FinalizeFrame:IsVisible() then
-        -- Clean up finalize frame
-        frames.FinalizeFrame:Hide();
-    end
+	-- Handle different visible frames
+	if frames.ExportFrame:IsVisible() then
+		-- Just close export and parent
+		frames.ExportFrame:Hide();
+		TRP3_ProfileCreateDialog:Hide();
+	elseif frames.ImportFrame:IsVisible() then
+		-- Clean up import frame
+		frames.ImportFrame:Hide();
+		frames.ImportFrame.Content.ImportText:ClearText();
+	elseif frames.FinalizeFrame:IsVisible() then
+		-- Clean up finalize frame
+		frames.FinalizeFrame:Hide();
+	end
 
 	-- If we're on the choices frame, or on forceClose we exit out fully.
 	if frames.ChoicesFrame:IsVisible() or forceClose then
@@ -591,21 +591,21 @@ end
 ---@return boolean valid Whether the evaluated profile name is valid.
 local function EvaluateProfileName()
 	local finalizeFrame = TRP3_ProfileCreateDialog.Frames.FinalizeFrame;
-    local profileName = finalizeFrame.Name:GetText();
-    local confirmButton = finalizeFrame.ConfirmButton;
+	local profileName = finalizeFrame.Name:GetText();
+	local confirmButton = finalizeFrame.ConfirmButton;
 
 	confirmButton:Enable();
-    if profileName == "" then
-        confirmButton:Disable();
-        setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_EMPTYNAME_PROFILE);
-        return false;
-    end
+	if profileName == "" then
+		confirmButton:Disable();
+		setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_EMPTYNAME_PROFILE);
+		return false;
+	end
 
-    if not IsProfileNameAvailable(profileName) then
-        confirmButton:Disable();
-        setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_DUPLICATE_PROFILE);
-        return false;
-    end
+	if not IsProfileNameAvailable(profileName) then
+		confirmButton:Disable();
+		setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_DUPLICATE_PROFILE);
+		return false;
+	end
 
 	setTooltipForSameFrame(confirmButton);
 	return true;
@@ -617,8 +617,8 @@ local function ProcessProfileData(data, creationOption)
 	chosenProfile = data;
 
 	-- Clean up Import
-    TRP3_ProfileCreateDialog.Frames.ImportFrame:Hide();
-    TRP3_ProfileCreateDialog.Frames.ImportFrame.Content.ImportText:ClearText();
+	TRP3_ProfileCreateDialog.Frames.ImportFrame:Hide();
+	TRP3_ProfileCreateDialog.Frames.ImportFrame.Content.ImportText:ClearText();
 
 	-- Build up Finalize
 	profileIcon = data.player.characteristics.IC or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
@@ -630,47 +630,47 @@ end
 ---@return boolean valid Whether the evaluated import data is valid.
 local function EvaluateImportData(forceImport)
 	local importFrame = TRP3_ProfileCreateDialog.Frames.ImportFrame;
-    local importButton = importFrame.ImportButton;
+	local importButton = importFrame.ImportButton;
 
 	-- Set defaults: Warning icon hidden, confirm button enabled.
-    importButton.WarningIcon:Hide();
-    setTooltipForSameFrame(importButton.WarningIcon);
-    importButton:Enable();
+	importButton.WarningIcon:Hide();
+	setTooltipForSameFrame(importButton.WarningIcon);
+	importButton:Enable();
 
-    -- Get import serial code
-    local code = importFrame.Content.ImportText:GetInputText();
-    if code == "" then
-        importButton:Disable();
-        setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, loc.PR_IMPORT_EMPTY_SERIAL);
-        return false;
-    end
+	-- Get import serial code
+	local code = importFrame.Content.ImportText:GetInputText();
+	if code == "" then
+		importButton:Disable();
+		setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, loc.PR_IMPORT_EMPTY_SERIAL);
+		return false;
+	end
 
-    -- Deserialize the serial code
+	-- Deserialize the serial code
 	local version, data;
-    version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
-    if version == nil or not data then
-        importButton:Disable();
-        setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, errorOrOldProfileID);
-        return false;
-    end
+	version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
+	if version == nil or not data then
+		importButton:Disable();
+		setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, errorOrOldProfileID);
+		return false;
+	end
 
 	local valid = true;
 
 	-- Check version compatibility
 	if version ~= Globals.version then
-        -- Export came from a different TRP version!
-        importButton.WarningIcon:Show();
-        setTooltipAll(importButton.WarningIcon, "RIGHT", 0, 5, "Warning", loc.PR_PROFILEMANAGER_IMPORT_WARNING_3);
+		-- Export came from a different TRP version!
+		importButton.WarningIcon:Show();
+		setTooltipAll(importButton.WarningIcon, "RIGHT", 0, 5, "Warning", loc.PR_PROFILEMANAGER_IMPORT_WARNING_3);
 		valid = false;
-    end
+	end
 
 	-- Set no tooltip if all is well.
 	setTooltipForSameFrame(importButton);
 
-    -- Import valid data automatically or if manually forced (button).
-    if valid or forceImport then
-        ProcessProfileData(data, chosenOption);
-    end
+	-- Import valid data automatically or if manually forced (button).
+	if valid or forceImport then
+		ProcessProfileData(data, chosenOption);
+	end
 
 	return valid;
 end

--- a/totalRP3/Core/Profiles.lua
+++ b/totalRP3/Core/Profiles.lua
@@ -10,17 +10,18 @@ TRP3_API.profile = {};
 -- imports
 local Globals, Events, Utils = TRP3_API.globals, TRP3_Addon.Events, TRP3_API.utils;
 local loc = TRP3_API.loc;
-local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
+local setTooltipForSameFrame, setTooltipAll = TRP3_API.ui.tooltip.setTooltipForSameFrame, TRP3_API.ui.tooltip.setTooltipAll;
 local registerPage = TRP3_API.navigation.page.registerPage;
 local displayMessage = TRP3_API.utils.message.displayMessage;
-local getPlayerCurrentProfile;
+local GetPlayerCurrentProfile;
 local getConfigValue = TRP3_API.configuration.getValue;
+local setupIconButton = TRP3_API.ui.frame.setupIconButton;
 
 -- Saved variables references
 local profiles, character, characters;
 
 local PATH_DELIMITER = "/";
-local currentProfile, currentProfileId;
+local currentProfile, currentProfileId, chosenOption, chosenProfileId, chosenProfile, errorOrOldProfileID, forceClose;
 local PR_DEFAULT_PROFILE = {
 	player = {},
 };
@@ -30,134 +31,233 @@ local PROFILEMANAGER_ACTIONS = {
 	RENAME = "RENAME",
 	DUPLICATE = "DUPLICATE",
 	IMPORT = "IMPORT",
-	EXPORT = "EXPORT"
+	EXPORT = "EXPORT",
+	CREATE = "CREATE"
 }
 
--- Return the default profile.
--- Note that this profile is never directly linked to a character, only duplicated !
+--- TRP3_API.profile.getDefaultProfile returns the default profile.
+---
+--- Note that this profile is never directly linked to a character, only duplicated!
+---@return table defaultProfile The default profile.
 TRP3_API.profile.getDefaultProfile = function()
 	return PR_DEFAULT_PROFILE;
 end
 
--- Get data from a profile in a XPATH way.
--- Example : "player/misc/PE" is equivalent to currentProfile.player.misc.PE but in a nil safe way.
--- Use currentProfile if profileRef is nil
-local function getData(fieldPath, profileRef)
-	assert(fieldPath, "Error: Fieldpath is nil.");
-	local split = {strsplit(PATH_DELIMITER, fieldPath)};
-	local pathPart = #split;
-	local ref = profileRef or getPlayerCurrentProfile();
-	for index, path in pairs(split) do
-		if index == pathPart then -- Last
-			return ref[path];
-		end
-		ref = ref[path];
+--- GetData gets the data from a profile in a XPATH way.
+--- Example: "player/misc/PE" is equivalent to currentProfile.player.misc.PE but in a nil safe way.
+---@param fieldPath string The XPATH to get data from.
+---@param profileRef table|nil Profile to retrieve data from, currentProfile if nil.
+---@return table|nil profile Given data on chosen profile's path.
+local function GetData(fieldPath, profileRef)
+	assert(type(fieldPath) == "string" and fieldPath ~= "", "Error: Invalid fieldPath.");
+
+	local ref = profileRef or GetPlayerCurrentProfile();
+	for path in fieldPath:gmatch("[^" .. PATH_DELIMITER .. "]+") do
 		if type(ref) ~= "table" then
 			return nil;
 		end
+		ref = ref[path];
 	end
+	return ref;
 end
-TRP3_API.profile.getData = getData;
+TRP3_API.profile.getData = GetData;
 
--- Get data from a profile in a XPATH way.
--- Example : "player/misc/PE" is equivalent to currentProfile.player.misc.PE but in a nil safe way.
--- Use currentProfile. If value is nil, return the ifNilValue.
-local function getDataDefault(fieldPath, ifNilValue, profileRef)
-	return getData(fieldPath, profileRef) or ifNilValue;
+--- GetDataDefault gets the data from a profile in a XPATH way, with a default fallback.
+--- Example: "player/misc/PE" is equivalent to currentProfile.player.misc.PE but in a nil safe way.
+---@param fieldPath string The XPATH to get data from.
+---@param ifNilValue table The default fallback if no profile data is found.
+---@param profileRef table|nil Profile to retrieve data from, currentProfile if nil.
+---@return table profile Given data on chosen profile's path.
+local function GetDataDefault(fieldPath, ifNilValue, profileRef)
+	return GetData(fieldPath, profileRef) or ifNilValue;
 end
-TRP3_API.profile.getDataDefault = getDataDefault;
+TRP3_API.profile.getDataDefault = GetDataDefault;
 
-local function getProfiles()
+local function GetProfiles()
 	return profiles;
 end
-TRP3_API.profile.getProfiles = getProfiles;
+TRP3_API.profile.getProfiles = GetProfiles;
 
+--- getProfileByID gets profile data by its ID.
+---@param profileID string Given profile ID.
+---@return table profile The retrieved profile data.
 function TRP3_API.profile.getProfileByID(profileID)
-	assert(profiles[profileID], "Unknown profile ID " .. tostring(profileID));
-	return profiles[profileID];
+	local profile = profiles[profileID];
+	assert(profile, "Unknown profile ID " .. tostring(profileID));
+
+	return profile;
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Logic
--- For decoupling reasons, the saved variables TRP3_Profiles and TRP3_Characters should'nt be used outside this file !
+-- For decoupling reasons, the saved variables TRP3_Profiles and TRP3_Characters shouldn't be used outside this file!
 -- You should use all the public methods instead.
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
--- Check if the profileName is not already used
-local function isProfileNameAvailable(profileName)
+--- IsProfileNameAvailable checks if given profile name is not already in use.
+---@param profileName string Given profile name to be checked.
+---@return boolean available Whether the profile is available.
+---@return table|nil existingProfileID ProfileID of existing profile with name.
+local function IsProfileNameAvailable(profileName)
+	assert(type(profileName) == "string" and profileName ~= "", "Invalid profile name.");
+
 	for profileID, profile in pairs(profiles) do
 		if profile.profileName == profileName then
 			return false, profileID;
 		end
 	end
-	return true;
-end
-TRP3_API.profile.isProfileNameAvailable = isProfileNameAvailable;
 
--- Duplicate an existing profile
-local function duplicateProfile(duplicatedProfile, profileName, isDefaultProfile)
-	assert(duplicatedProfile, "Nil profile");
-	assert(isProfileNameAvailable(profileName), "Unavailable profile name: "..tostring(profileName));
-	local profileID = Utils.str.id();
-	if isDefaultProfile then
-		profileID = string.sub(profileID, 1, -2) .. "*";
+	return true, nil;
+end
+TRP3_API.profile.isProfileNameAvailable = IsProfileNameAvailable;
+
+--- DuplicateProfile duplicates an existing profile.
+---@param duplicatedProfile table Profile to duplicate.
+---@param profileName string Name given to the newly duplicated profile.
+---@param isDefaultProfile boolean Whether the duplicated is the default profile.
+---@return string profileID ProfileID of the newly duplicated profile.
+local function DuplicateProfile(duplicatedProfile, profileName, isDefaultProfile)
+	assert(type(duplicatedProfile) == "table", "Invalid profile: expected table.");
+	assert(type(profileName) == "string" and profileName ~= "", "Invalid profile name.");
+	assert(IsProfileNameAvailable(profileName), "Unavailable profile name: " .. tostring(profileName));
+
+	local profileID = isDefaultProfile and (string.sub(Utils.str.id(), 1, -2) .. "*") or Utils.str.id();
+
+	local newProfile = {};
+	Utils.table.copy(newProfile, duplicatedProfile);
+	newProfile.profileName = profileName;
+	profiles[profileID] = newProfile;
+
+	if duplicatedProfile == PR_DEFAULT_PROFILE then
+		displayMessage(loc.PR_PROFILE_CREATED:format("|cnGREEN_FONT_COLOR:" .. profileName .. "|r"));
+	else
+		displayMessage(loc.PR_PROFILE_DUPLICATED:format("|cnGREEN_FONT_COLOR:" .. duplicatedProfile.profileName .. "|r", "|cnGREEN_FONT_COLOR:" .. profileName .. "|r"));
 	end
-	profiles[profileID] = {};
-	Utils.table.copy(profiles[profileID], duplicatedProfile);
-	profiles[profileID].profileName = profileName;
-	displayMessage(loc.PR_PROFILE_CREATED:format(Utils.str.color("g")..profileName.."|r"));
 	return profileID;
 end
-TRP3_API.profile.duplicateProfile = duplicateProfile;
+TRP3_API.profile.duplicateProfile = DuplicateProfile;
 
--- Creating a new profile using PR_DEFAULT_PROFILE as a template
-local function createProfile(profileName, isDefaultProfile)
-	return duplicateProfile(PR_DEFAULT_PROFILE, profileName, isDefaultProfile);
+--- CreateProfile creates a profile using PR_DEFAULT_PROFILE as a template.
+---@param profileName string Name given to the newly created profile.
+---@param isDefaultProfile boolean Whether the new profile is the default profile.
+---@return string profileID ProfileID of the newly created profile.
+local function CreateProfile(profileName, isDefaultProfile)
+	return DuplicateProfile(PR_DEFAULT_PROFILE, profileName, isDefaultProfile);
 end
-TRP3_API.profile.createProfile = createProfile;
+TRP3_API.profile.createProfile = CreateProfile;
 
--- Just internally switch the current profile structure. That's all.
-local function selectProfile(profileID)
-	if not profiles[profileID] then
-		error("Unknown profile id: " + profileID);
+--- CreateProfileFromImport creates a profile from given name and given data.
+---@param profileName string Name given to the newly created profile.
+---@param importedData table The profile data that is to be imported.
+---@return string profileID ProfileID of the newly created profile.
+local function CreateProfileFromImport(profileName, importedData)
+	assert(type(profileName) == "string" and profileName ~= "", "Invalid profile name.");
+	assert(type(importedData) == "table", "Invalid imported data.");
+
+	-- Prefer re-using the old imported profile ID if is free.
+	local profileID = (not profiles[errorOrOldProfileID]) and errorOrOldProfileID or Utils.str.id();
+	local newProfile = {};
+	Utils.table.copy(newProfile, importedData);
+	newProfile.profileName = profileName;
+	profiles[profileID] = newProfile;
+
+	-- If we had to generate a new profile ID, we move the profile-specific notes to said profile ID.
+	if profileID ~= errorOrOldProfileID and newProfile.notes and newProfile.notes[errorOrOldProfileID] and not newProfile.notes[profileID] then
+		newProfile.notes[profileID] = newProfile.notes[errorOrOldProfileID];
+		newProfile.notes[errorOrOldProfileID] = nil;
 	end
-	currentProfile = profiles[profileID];
+
+	-- Convert old music paths to the new ID system
+	local aboutData = newProfile.player and newProfile.player.about;
+	if type(aboutData) == "table" and type(aboutData.MU) == "string" then
+		aboutData.MU = Utils.music.convertPathToID(aboutData.MU);
+	end
+
+	-- Convert Misc Info IDs
+	local characteristics = newProfile.player and newProfile.player.characteristics;
+	if type(characteristics) == "table" and type(characteristics.MI) == "table" then
+		for _, miscData in ipairs(characteristics.MI) do
+			if type(miscData) == "table" and (not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom) then
+				-- Adding ID from name if ID missing, or setting a preset to custom if renamed
+				miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
+			end
+		end
+	end
+
+	displayMessage(loc.PR_PROFILE_IMPORTED:format("|cnGREEN_FONT_COLOR:" .. newProfile.profileName .. "|r"));
+	return profileID;
+end
+
+--- SelectProfile internally switches the current profile to given profile.
+---@param profileID string Given profile ID to select.
+local function SelectProfile(profileID)
+	local profile = profiles[profileID];
+	assert(profile, "Unknown profile id: " .. profileID);
+
+	currentProfile = profile;
 	currentProfileId = profileID;
 	character.profileID = profileID;
-	displayMessage(loc.PR_PROFILE_LOADED:format(Utils.str.color("g")..profiles[character.profileID]["profileName"].."|r"));
+
+	displayMessage(loc.PR_PROFILE_LOADED:format(Utils.str.color("g") .. profile.profileName .."|r"));
 	TRP3_Addon:TriggerEvent(Events.REGISTER_PROFILES_LOADED, currentProfile);
 	TRP3_Addon:TriggerEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, profileID);
 end
-TRP3_API.profile.selectProfile = selectProfile;
+TRP3_API.profile.selectProfile = SelectProfile;
 
--- Edit a profile name
-local function editProfile(profileID, newName)
-	assert(profiles[profileID], "Unknown profile: "..tostring(profileID));
-	assert(isProfileNameAvailable(newName), "Unavailable profile name: "..tostring(newName));
-	profiles[profileID]["profileName"] = newName;
+--- RenameProfile renames a profile with given name.
+---@param profileID string Given profile ID to rename.
+---@param newName string New name for the profile.
+local function RenameProfile(profileID, newName)
+	local profile = profiles[profileID];
+	assert(profile, "Unknown profile: " .. tostring(profileID));
+
+	local isAvailable, existingProfileID = IsProfileNameAvailable(newName);
+	assert(isAvailable or existingProfileID == profileID, "Unavailable profile name: " .. tostring(newName));
+
+	displayMessage(loc.PR_PROFILE_RENAMED:format("|cnGREEN_FONT_COLOR:" .. profile.profileName .. "|r", "|cnGREEN_FONT_COLOR:" .. newName .. "|r"));
+	profile.profileName = newName;
 end
 
--- Delete a profile
--- If the deleted profile is the currently selected one, assign the default profile
-local function deleteProfile(profileID)
-	assert(profiles[profileID], "Unknown profile: "..tostring(profileID));
-	assert(currentProfileId ~= profileID, "You can't delete the currently selected profile !");
-	local profileName = profiles[profileID]["profileName"];
-	wipe(profiles[profileID]);
+--- DeleteProfile deletes the chosen profile.
+---
+--- If chosen profile is current then switch to default profile.
+---@param profileID string Given profile ID to delete.
+local function DeleteProfile(profileID)
+	local profile = profiles[profileID];
+	assert(profile, "Unknown profile: " .. tostring(profileID));
+
+	-- If current profile is the one to be deleted, switch to default
+	if currentProfileId == profileID then
+		local defaultProfileID = getConfigValue("default_profile_id");
+		if defaultProfileID then
+			SelectProfile(defaultProfileID);
+		end
+	end
+
+	local profileName = profile.profileName;
+
+	-- Clear profile data and remove from profiles table
+	wipe(profile);
 	profiles[profileID] = nil;
-	displayMessage(loc.PR_PROFILE_DELETED:format(Utils.str.color("g")..profileName.."|r"));
+
+	displayMessage(loc.PR_PROFILE_DELETED:format(Utils.str.color("g") .. profileName .. "|r"));
 end
 
+--- getPlayerCurrentProfileID gets the player's current profile ID.
+---@return string currentProfileId ProfileID of the player's current profile.
 function TRP3_API.profile.getPlayerCurrentProfileID()
 	return currentProfileId;
 end
 
-function getPlayerCurrentProfile()
+--- getPlayerCurrentProfile gets the player's current profile.
+---@return table currentProfile Data of the player's current profile.
+function GetPlayerCurrentProfile()
 	return currentProfile;
 end
-TRP3_API.profile.getPlayerCurrentProfile = getPlayerCurrentProfile;
+TRP3_API.profile.getPlayerCurrentProfile = GetPlayerCurrentProfile;
 
-local function updateDefaultProfile()
+--- UpdateDefaultProfile updates the default profile based on current character.
+local function UpdateDefaultProfile()
 	-- We replace the profile ID every login session so multiple characters don't get linked to the same profile ID
 	-- The new profileID will automatically get selected during the init process
 	local oldProfileID = getConfigValue("default_profile_id");
@@ -174,6 +274,8 @@ local function updateDefaultProfile()
 	profileDefault.profileName = loc.PR_DEFAULT_PROFILE_NAME;
 
 	local profileCharacteristics = profileDefault.player.characteristics;
+
+	-- Update version and other character attributes
 	profileCharacteristics.v = profileCharacteristics.v + 1;
 	profileCharacteristics.RA = Globals.player_race_loc;
 	profileCharacteristics.CL = Globals.player_class_loc;
@@ -181,8 +283,11 @@ local function updateDefaultProfile()
 	profileCharacteristics.IC = TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
 end
 
+--- TRP3_API.profile.isDefaultProfile checks if given profile ID is the default profile.
+---@param profileID string Given profile ID to check.
+---@return boolean isDefaultProfile Whether this profile ID is the default profile.
 function TRP3_API.profile.isDefaultProfile(profileID)
-	if not profileID then return false end
+	if not profileID or profileID == "" then return false end
 	return string.sub(profileID, -1) == "*";
 end
 
@@ -191,12 +296,21 @@ end
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 local profileListID = {};
 
-local function decorateProfileList(widget, id)
+--- DecorateProfileList decorates chosen widget with given profile ID.
+---@param widget button Chosen widget to decorate.
+---@param id string Given profile ID to decorate with.
+local function DecorateProfileList(widget, id)
 	widget.profileID = id;
 	local profile = profiles[id];
-	local dataTab = getData("player/characteristics", profile);
+	if not profile then
+		-- If profile does not exist, return early to avoid errors
+		return;
+	end
+
+	local dataTab = GetData("player/characteristics", profile);
 	local mainText = profile.profileName;
 
+	-- Highlight current profile with a different border color
 	if id == currentProfileId then
 		widget:SetBorderColor(TRP3_API.CreateColor(0.1, 0.8, 0.1));
 		widget.CurrentText:Show();
@@ -205,19 +319,23 @@ local function decorateProfileList(widget, id)
 		widget.CurrentText:Hide();
 	end
 
-	widget:SetIcon(dataTab.IC);
+	-- Set profile icon
+	local icon = dataTab and dataTab.IC or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));  -- Use a fallback icon if dataTab.IC is missing
+	widget:SetIcon(icon);
 	widget:SetNameText(mainText);
 
-	local listText = "";
+	-- Prepare character list text
+	local listText = {};
 	local i = 0;
 	for characterID, characterInfo in pairs(characters) do
 		if characterInfo.profileID == id then
 			local charactName, charactRealm = TRP3_API.utils.str.unitIDToInfo(characterID);
-			listText = listText.."- |cff00ff00"..charactName.." ( "..charactRealm.." )|r\n";
+			table.insert(listText, "- |cnGREEN_FONT_COLOR:" .. charactName .. " ( " .. charactRealm .. " )|r");
 			i = i + 1;
 		end
 	end
 
+	-- Handle default profile
 	if id == getConfigValue("default_profile_id") then
 		widget.HelpButton:Hide();
 		widget:SetCountText(nil);
@@ -225,176 +343,378 @@ local function decorateProfileList(widget, id)
 	else
 		widget.HelpButton:Show();
 		widget.MenuButton:Show();
-
 		widget:SetCountText(loc.PR_PROFILEMANAGER_COUNT:format(i));
 
-		local text = "";
-		if i > 0 then
-			text = text..loc.PR_PROFILE_DETAIL..":\n"..listText;
-		else
-			text = text..loc.PR_UNUSED_PROFILE;
-		end
-
+		-- Tooltip for profile
+		local text = i > 0 and (loc.PR_PROFILE_DETAIL .. ":|n" .. table.concat(listText, "|n")) or loc.PR_UNUSED_PROFILE;
 		setTooltipForSameFrame(widget.HelpButton, "RIGHT", 0, 5, loc.PR_PROFILE, text);
 	end
 end
 
-local function profileSortingByProfileName(profileID1, profileID2)
+--- ProfileSortingByProfileName sorts profile order alphabetically by comparing two profile IDs.
+---@param profileID1 string First profile ID to compare for alphabetical sorting.
+---@param profileID2 string Second profile ID to compare for alphabetical sorting.
+---@return boolean comesFirst Whether the first profile ID comes first alphabetically.
+local function ProfileSortingByProfileName(profileID1, profileID2)
 	return profiles[profileID1].profileName < profiles[profileID2].profileName;
 end
 
--- Refresh list display
-local function uiInitProfileList()
+--- UiInitProfileList refreshes the profile list display.
+local function UiInitProfileList()
 	wipe(profileListID);
 	local defaultProfileID = getConfigValue("default_profile_id");
-	local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManager.list.SearchBox:GetText());
-	for profileID, _ in pairs(profiles) do
-		if profileID ~= defaultProfileID and (not profileSearch or string.find(profiles[profileID].profileName:lower(), profileSearch:lower(), 1, true)) then
-			tinsert(profileListID, profileID);
-		end
-	end
+    local profileSearch = Utils.str.emptyToNil(TRP3_ProfileManager.list.SearchBox:GetText());
+    local searchMode = profileSearch ~= nil;
 
-	table.sort(profileListID, profileSortingByProfileName);
+	-- Build filtered profile list
+    for profileID, _ in pairs(profiles) do
+        local shouldAdd = profileID ~= defaultProfileID;
 
-	local size = #profileListID;
-	TRP3_ProfileManager.list.ScrollBox.EmptyText:Hide();
-	if profileSearch then
-		if size == 0 then
-			TRP3_ProfileManager.list.ScrollBox.EmptyText:Show();
-		end
-	else
-		tinsert(profileListID, 1, defaultProfileID);
-	end
+        if shouldAdd and searchMode then
+            local profileName = profiles[profileID].profileName:lower();
+            shouldAdd = string.find(profileName, profileSearch:lower(), 1, true);
+        end
 
-	local provider = CreateDataProvider(profileListID);
-	TRP3_ProfileManager.list.ScrollBox:SetDataProvider(provider, ScrollBoxConstants.RetainScrollPosition);
+        if shouldAdd then
+            tinsert(profileListID, profileID);
+        end
+    end
+
+    -- Sort profiles alphabetically
+    table.sort(profileListID, ProfileSortingByProfileName);
+
+    -- Handle empty state display
+    local isEmpty = #profileListID == 0;
+    TRP3_ProfileManager.list.ScrollBox.EmptyText:SetShown(searchMode and isEmpty);
+
+    -- Add default profile at top when not searching
+    if not searchMode then
+        tinsert(profileListID, 1, defaultProfileID);
+    end
+
+    -- Update scrollbox
+    local provider = CreateDataProvider(profileListID);
+    TRP3_ProfileManager.list.ScrollBox:SetDataProvider(provider, ScrollBoxConstants.RetainScrollPosition);
 end
 
-local showTextInputPopup, showConfirmPopup = TRP3_API.popup.showTextInputPopup, TRP3_API.popup.showConfirmPopup;
+local showConfirmPopup = TRP3_API.popup.showConfirmPopup;
 
-local function uiCheckNameAvailability(profileName)
-	if not isProfileNameAvailable(profileName) then
-		TRP3_API.ui.tooltip.toast(loc.PR_PROFILEMANAGER_ALREADY_IN_USE:format(Utils.str.color("r")..profileName.."|r"), 3);
-		return false;
-	end
-	return true;
-end
+--- UiDeleteProfile handles the ui prommpt portion of deleting a profile.
+---@param profileID string Given profile ID to delete the profile of.
+local function UiDeleteProfile(profileID)
+	local profile = profiles[profileID];
 
-local function uiCreateProfile()
-	showTextInputPopup(loc.PR_PROFILEMANAGER_CREATE_POPUP,
-	function(newName)
-		if newName and #newName ~= 0 then
-			if not uiCheckNameAvailability(newName) then return end
-			createProfile(newName);
-			uiInitProfileList();
-		end
-	end,
-	nil,
-	Globals.player_realm .. " - " .. Globals.player
-	);
-end
-
--- Promps profile delete confirmation
-local function uiDeleteProfile(profileID)
-	showConfirmPopup(loc.PR_PROFILEMANAGER_DELETE_WARNING:format(Utils.str.color("g")..profiles[profileID].profileName.."|r"),
+	showConfirmPopup(loc.PR_PROFILEMANAGER_DELETE_WARNING:format(Utils.str.color("g") .. profile.profileName .. "|r"),
 	function()
-		deleteProfile(profileID);
-		uiInitProfileList();
+		DeleteProfile(profileID);
+		UiInitProfileList();
 	end);
 end
 
-local function uiEditProfile(profileID)
-	showTextInputPopup(
-	loc.PR_PROFILEMANAGER_EDIT_POPUP:format(Utils.str.color("g")..profiles[profileID].profileName.."|r"),
-	function(newName)
-		if newName and #newName ~= 0 then
-			if not uiCheckNameAvailability(newName) then return end
-			editProfile(profileID, newName);
-			uiInitProfileList();
-		end
-	end,
-	nil,
-	profiles[profileID].profileName
-	);
-end
-
-local function uiSelectProfile(profileID)
+--- UiSelectProfile handles the ui portion of selecting a new profile by profile ID.
+---@param profileID string Given profile ID of the profile to select.
+local function UiSelectProfile(profileID)
 	if character.profileID == profileID then
 		return;
 	end
-	selectProfile(profileID);
-	uiInitProfileList();
+	SelectProfile(profileID);
+	UiInitProfileList();
 end
 
-local function uiDuplicateProfile(profileID)
-	showTextInputPopup(
-	loc.PR_PROFILEMANAGER_DUPP_POPUP:format(Utils.str.color("g")..profiles[profileID].profileName.."|r"),
-	function(newName)
-		if newName and #newName ~= 0 then
-			if not uiCheckNameAvailability(newName) then return end
-			duplicateProfile(profiles[profileID], newName);
-			uiInitProfileList();
-		end
-	end,
-	nil,
-	profiles[profileID].profileName
+local profileIcon;
+
+--- SetupChoicesFrame prepares the Choices frame from the Profile Create flow.
+local function SetupChoicesFrame()
+	local frames = TRP3_ProfileCreateDialog.Frames;
+    local choicesFrame = frames.ChoicesFrame;
+
+    choicesFrame.Title:SetText(loc.PR_CREATE_PROFILE);
+    frames:SetHeight(200);
+
+	forceClose, profileIcon, chosenProfile = false, nil, nil;
+
+	-- Show choices and profile creation frame
+	choicesFrame:Show();
+	TRP3_ProfileCreateDialog:Show();
+end
+
+--- SetupImportFrame prepares the Import frame from the Profile Create flow.
+local function SetupImportFrame()
+	local frames = TRP3_ProfileCreateDialog.Frames;
+    local importFrame = frames.ImportFrame;
+
+    importFrame.Title:SetText(loc.PR_IMPORT_PROFILE);
+    frames:SetHeight(400);
+
+	-- Show import and profile creation frame
+	importFrame:Show();
+	TRP3_ProfileCreateDialog:Show();
+
+	-- Focus the import EditBox for easy pasting.
+	importFrame.Content.ImportText:SetFocus();
+end
+
+--- SetupExportFrame prepares the Export frame from the Profile Create flow.
+---@param profileID string Profile ID to be used for export.
+---@param profile table Profile data to be exported from.
+local function SetupExportFrame(profileID, profile)
+	local frames = TRP3_ProfileCreateDialog.Frames;
+	local exportFrame = frames.ExportFrame;
+	local serial = TRP3_ProfileUtil.SerializeProfile(Globals.version, profileID, profile);
+	local maxSerialSize = 20000;
+	forceClose = true;
+
+	-- Check if the profile data is too large
+	if serial:len() >= maxSerialSize then
+		Utils.message.displayMessage(loc.PR_EXPORT_TOO_LARGE:format(serial:len() / 1000), 2);
+		return;
+	end
+
+	local exportWarningText = loc.PR_EXPORT_WARNING;
+	local copyShortcut = TRP3_API.FormatShortcut("CTRL-C", TRP3_API.ShortcutType.System);
+	local pasteShortcut = TRP3_API.FormatShortcut("CTRL-V", TRP3_API.ShortcutType.System);
+
+	exportFrame.Content.Warning:SetText(
+		exportWarningText ..
+		"|n|n" .. loc.COPY_DROPDOWN_POPUP_TEXT:format(TRP3_API.Colors.Orange(copyShortcut), TRP3_API.Colors.Orange(pasteShortcut)) ..
+		"|n|n|cnNORMAL_FONT_COLOR:" .. loc.PR_EXPORT_NAME:format("|cnGREEN_FONT_COLOR:" .. profile.profileName .. "|r", serial:len() / 1000) .. "|r"
 	);
+
+	exportFrame.Title:SetText(loc.PR_EXPORT_PROFILE);
+	exportFrame.Content.ExportText:SetText(serial);
+	frames:SetHeight(400);
+
+	-- Show export and profile creation frame
+	exportFrame:Show();
+	TRP3_ProfileCreateDialog:Show();
+
+	-- Focus the export EditBox for easy copying.
+	exportFrame.Content.ExportText:SetFocus();
 end
 
-local function onProfileSelected(button)
-	local profileID = button.profileID;
-	uiSelectProfile(profileID);
+--- SetupFinalizeFrame prepares the Finalize frame from the Profile Create flow.
+---@param creationOption string chosen option (blank, import, duplicate).
+---@param profileName string|nil Optional profile name to use instead of default.
+local function SetupFinalizeFrame(creationOption, profileName)
+	local frames = TRP3_ProfileCreateDialog.Frames;
+	local FinalizeFrame = frames.FinalizeFrame;
+	local name = profileName or (Globals.player_realm .. " - " .. Globals.player);
+
+	-- Set title based on creation option
+	local titles = {
+		[PROFILEMANAGER_ACTIONS.DUPLICATE] = loc.PR_DUPLICATE_PROFILE,
+		[PROFILEMANAGER_ACTIONS.IMPORT] = loc.PR_IMPORT_PROFILE,
+		[PROFILEMANAGER_ACTIONS.RENAME] = loc.PR_PROFILEMANAGER_RENAME
+	}
+	FinalizeFrame.Title:SetText(titles[creationOption] or loc.PR_FINALIZE_PROFILE);
+
+	-- Handle icon visibility and name position
+	local showIcon = creationOption ~= PROFILEMANAGER_ACTIONS.RENAME;
+	FinalizeFrame.Icon:SetShown(showIcon);
+
+	if showIcon then
+        FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPRIGHT", 15, -4);
+        -- Initialize and set up icon only when needed
+		profileIcon = profileIcon or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+		setupIconButton(FinalizeFrame.Icon, profileIcon);
+		FinalizeFrame.ConfirmButton:SetText(loc.PR_CREATE_PROFILE);
+    else
+        FinalizeFrame.Name:SetPoint("TOPLEFT", FinalizeFrame.Icon, "TOPLEFT", 0, -4);
+		FinalizeFrame.ConfirmButton:SetText(loc.PR_PROFILEMANAGER_RENAME);
+    end
+
+	FinalizeFrame.Name:SetText(name);
+	frames:SetHeight(150);
+
+	-- Show finalize and profile creation frame
+	FinalizeFrame:Show();
+	TRP3_ProfileCreateDialog:Show();
+
+	FinalizeFrame.Name:SetFocus();
 end
 
-local function onActionSelected(value, button)
-	local profileID = button:GetParent().profileID;
+--- OpenProfileFlow allows opening a specific profile flow frame.
+---@param frameName string chosen profile flow frame (import, finalize, etc).
+---@param creationOption string chosen option (blank, import, duplicate).
+---@param profileName string|nil Optional profile name to use instead of default.
+local function OpenProfileFlow(frameName, creationOption, profileName)
+	local profileActions = {
+		[PROFILEMANAGER_ACTIONS.IMPORT] = SetupImportFrame,
+		[PROFILEMANAGER_ACTIONS.EXPORT] = function() SetupExportFrame(chosenProfileId, chosenProfile); end,
+		[PROFILEMANAGER_ACTIONS.CREATE] = function() SetupFinalizeFrame(creationOption, profileName); end
+	};
 
-	if value == PROFILEMANAGER_ACTIONS.DELETE then
-		uiDeleteProfile(profileID);
-	elseif value == PROFILEMANAGER_ACTIONS.RENAME then
-		uiEditProfile(profileID);
-	elseif value == PROFILEMANAGER_ACTIONS.DUPLICATE then
-		uiDuplicateProfile(profileID);
-	elseif value == PROFILEMANAGER_ACTIONS.EXPORT then
-		local profile = profiles[profileID];
-		local serial = TRP3_ProfileUtil.SerializeProfile(Globals.version, profileID, profile);
-		if serial:len() < 20000 then
-			TRP3_ProfileExport.content.scroll.text:SetReadOnlyText(serial);
-			TRP3_ProfileExport.content.title:SetText(loc.PR_EXPORT_NAME:format(profile.profileName, serial:len() / 1000));
-			TRP3_ProfileExport:Show();
-			TRP3_ProfileExport.content.scroll.text:SetFocus();
-		else
-			Utils.message.displayMessage(loc.PR_EXPORT_TOO_LARGE:format(serial:len() / 1000), 2);
-		end
-	elseif value == PROFILEMANAGER_ACTIONS.IMPORT then
-		TRP3_ProfileImport.profileID = profileID;
-		TRP3_ProfileImport:Show();
-		TRP3_ProfileImport.content.scroll.text:SetText("");
+	(profileActions[frameName] or SetupChoicesFrame)();
+end
+
+--- CloseProfileFlow handles closing the profile flow depending on frame visibility.
+local function CloseProfileFlow()
+	local frames = TRP3_ProfileCreateDialog.Frames;
+	PlaySound(TRP3_InterfaceSounds.PopupClose);
+
+    -- Handle different visible frames
+    if frames.ExportFrame:IsVisible() then
+        -- Just close export and parent
+        frames.ExportFrame:Hide();
+        TRP3_ProfileCreateDialog:Hide();
+    elseif frames.ImportFrame:IsVisible() then
+        -- Clean up import frame
+        frames.ImportFrame:Hide();
+        frames.ImportFrame.Content.ImportText:ClearText();
+    elseif frames.FinalizeFrame:IsVisible() then
+        -- Clean up finalize frame
+        frames.FinalizeFrame:Hide();
+    end
+
+	-- If we're on the choices frame, or on forceClose we exit out fully.
+	if frames.ChoicesFrame:IsVisible() or forceClose then
+		frames.ChoicesFrame:Hide();
+		TRP3_ProfileCreateDialog:Hide();
+		TRP3_API.popup.hidePopups();
+	else
+		-- Reopen choices after closing Import/Finalize
+		OpenProfileFlow();
 	end
 end
 
-local function onActionClicked(_, button)
-	local profileID = button:GetParent().profileID;
+--- PasteCopiedIcon handles receiving an icon from the right-click menu.
+---@param frame Frame The frame the icon belongs to.
+local function PasteCopiedIcon(frame)
+	local icon = TRP3_API.GetLastCopiedIcon() or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+	profileIcon = icon;
+	setupIconButton(frame, icon);
+end
 
+--- evaluateProfileName checks if given profile name is valid.
+---
+--- This prevents empty or duplicate profile names.
+---@return boolean valid Whether the evaluated profile name is valid.
+local function EvaluateProfileName()
+	local finalizeFrame = TRP3_ProfileCreateDialog.Frames.FinalizeFrame;
+    local profileName = finalizeFrame.Name:GetText();
+    local confirmButton = finalizeFrame.ConfirmButton;
+
+	confirmButton:Enable();
+    if profileName == "" then
+        confirmButton:Disable();
+        setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_EMPTYNAME_PROFILE);
+        return false;
+    end
+
+    if not IsProfileNameAvailable(profileName) then
+        confirmButton:Disable();
+        setTooltipForSameFrame(confirmButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_DUPLICATE_PROFILE);
+        return false;
+    end
+
+	setTooltipForSameFrame(confirmButton);
+	return true;
+end
+
+--- ProcessProfileData readies the given profile data for creation.
+---@param data table The imported data to process.
+local function ProcessProfileData(data, creationOption)
+	chosenProfile = data;
+
+	-- Clean up Import
+    TRP3_ProfileCreateDialog.Frames.ImportFrame:Hide();
+    TRP3_ProfileCreateDialog.Frames.ImportFrame.Content.ImportText:ClearText();
+
+	-- Build up Finalize
+	profileIcon = data.player.characteristics.IC or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+	OpenProfileFlow(PROFILEMANAGER_ACTIONS.CREATE, creationOption, data.profileName);
+end
+
+--- EvaluateImportData checks if given import data is valid.
+---@param forceImport boolean Whether data should be forcefully imported.
+---@return boolean valid Whether the evaluated import data is valid.
+local function EvaluateImportData(forceImport)
+	local importFrame = TRP3_ProfileCreateDialog.Frames.ImportFrame;
+    local importButton = importFrame.ImportButton;
+
+	-- Set defaults: Warning icon hidden, confirm button enabled.
+    importButton.WarningIcon:Hide();
+    setTooltipForSameFrame(importButton.WarningIcon);
+    importButton:Enable();
+
+    -- Get import serial code
+    local code = importFrame.Content.ImportText:GetInputText();
+    if code == "" then
+        importButton:Disable();
+        setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, loc.PR_IMPORT_EMPTY_SERIAL);
+        return false;
+    end
+
+    -- Deserialize the serial code
+	local version, data;
+    version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
+    if version == nil or not data then
+        importButton:Disable();
+        setTooltipForSameFrame(importButton, "RIGHT", 0, 5, loc.PR_IMPORT, errorOrOldProfileID);
+        return false;
+    end
+
+	local valid = true;
+
+	-- Check version compatibility
+	if version ~= Globals.version then
+        -- Export came from a different TRP version!
+        importButton.WarningIcon:Show();
+        setTooltipAll(importButton.WarningIcon, "RIGHT", 0, 5, "Warning", loc.PR_PROFILEMANAGER_IMPORT_WARNING_3);
+		valid = false;
+    end
+
+	-- Set no tooltip if all is well.
+	setTooltipForSameFrame(importButton);
+
+    -- Import valid data automatically or if manually forced (button).
+    if valid or forceImport then
+        ProcessProfileData(data, chosenOption);
+    end
+
+	return valid;
+end
+
+--- OnProfileSelected handles profile selection when a button is clicked.
+---@param button Button The button that was selected.
+local function OnProfileSelected(button)
+	local profileID = button.profileID;
+	UiSelectProfile(profileID);
+end
+
+--- OnActionSelected handles actions selected from the profile manager.
+---@param value string The selected action from PROFILEMANAGER_ACTIONS
+---@param button Button The button that triggered the action.
+local function OnActionSelected(value, button)
+	local parent = button:GetParent();
+	local profileID = parent.profileID;
+	local profile = profiles[profileID];
+	forceClose = true;
+
+	-- Save chosen data for further use.
+	chosenOption, chosenProfileId, chosenProfile = value, profileID, profile;
+
+	if value == PROFILEMANAGER_ACTIONS.DELETE then
+		UiDeleteProfile(profileID);
+	elseif value == PROFILEMANAGER_ACTIONS.RENAME then
+		OpenProfileFlow(PROFILEMANAGER_ACTIONS.CREATE, value, profile.profileName);
+	elseif value == PROFILEMANAGER_ACTIONS.DUPLICATE then
+		ProcessProfileData(profile, value);
+	elseif value == PROFILEMANAGER_ACTIONS.EXPORT then
+		OpenProfileFlow(PROFILEMANAGER_ACTIONS.EXPORT);
+	end
+end
+
+--- onActionClicked handles the action when a profile button is clicked.
+---@param _ Frame The list element parent of the button.
+---@param button Button The button that was clicked to trigger the menu.
+local function OnActionClicked(_, button)
 	TRP3_MenuUtil.CreateContextMenu(button, function(_, description)
 		description:CreateTitle(loc.PR_PROFILE_MANAGEMENT_TITLE);
-		description:CreateButton(loc.PR_PROFILEMANAGER_RENAME, function() onActionSelected(PROFILEMANAGER_ACTIONS.RENAME, button); end);
-		description:CreateButton(loc.PR_DUPLICATE_PROFILE, function() onActionSelected(PROFILEMANAGER_ACTIONS.DUPLICATE, button); end);
-		if currentProfileId ~= profileID then
-			description:CreateButton("|cnRED_FONT_COLOR:" .. loc.PR_DELETE_PROFILE .. "|r", function() onActionSelected(PROFILEMANAGER_ACTIONS.DELETE, button); end);
-		else
-			description:CreateButton(loc.PR_DELETE_PROFILE):SetEnabled(false);
-		end
-
-		description:CreateDivider();
-
-		description:CreateTitle(loc.PR_EXPORT_IMPORT_TITLE);
-		if currentProfileId ~= profileID then
-			description:CreateButton(loc.PR_IMPORT_PROFILE, function() onActionSelected(PROFILEMANAGER_ACTIONS.IMPORT, button); end);
-		else
-			description:CreateButton(loc.PR_IMPORT_PROFILE):SetEnabled(false);
-		end
-		description:CreateButton(loc.PR_EXPORT_PROFILE, function() onActionSelected(PROFILEMANAGER_ACTIONS.EXPORT, button); end);
+		description:CreateButton(loc.PR_PROFILEMANAGER_RENAME, function() OnActionSelected(PROFILEMANAGER_ACTIONS.RENAME, button); end);
+		description:CreateButton(loc.PR_DUPLICATE_PROFILE, function() OnActionSelected(PROFILEMANAGER_ACTIONS.DUPLICATE, button); end);
+		description:CreateButton(loc.PR_EXPORT_PROFILE, function() OnActionSelected(PROFILEMANAGER_ACTIONS.EXPORT, button); end);
+		description:CreateButton("|cnRED_FONT_COLOR:" .. loc.PR_DELETE_PROFILE .. "|r", function() OnActionSelected(PROFILEMANAGER_ACTIONS.DELETE, button); end);
 	end);
 end
 
@@ -402,6 +722,8 @@ end
 -- Character
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
+--- getPlayerCharacter gets the current player character.
+---@return table character The current player character's data.
 function TRP3_API.profile.getPlayerCharacter()
 	return character;
 end
@@ -413,7 +735,7 @@ end
 -- Tutorial
 local TUTORIAL_STRUCTURE;
 
-local function createTutorialStructure()
+local function CreateTutorialStructure()
 	TUTORIAL_STRUCTURE = {
 		{
 			box = {
@@ -429,9 +751,8 @@ local function createTutorialStructure()
 	}
 end
 
-
 function TRP3_API.profile.init()
-	createTutorialStructure();
+	CreateTutorialStructure();
 
 	-- Saved structures
 	if not TRP3_Profiles then
@@ -460,17 +781,17 @@ function TRP3_API.profile.init()
 				break;
 			end
 		end
-		TRP3_API.configuration.setValue("default_profile_id", createProfile(loc.PR_DEFAULT_PROFILE_NAME, true));
+		TRP3_API.configuration.setValue("default_profile_id", CreateProfile(loc.PR_DEFAULT_PROFILE_NAME, true));
 	else
-		updateDefaultProfile();
+		UpdateDefaultProfile();
 	end
 
 	-- First time this character is connected with TRP3 or if deleted profile through another character
 	-- So we select the default profile.
 	if not character.profileID or not profiles[character.profileID] then
-		selectProfile(getConfigValue("default_profile_id"));
+		SelectProfile(getConfigValue("default_profile_id"));
 	else
-		selectProfile(character.profileID);
+		SelectProfile(character.profileID);
 	end
 
 	-- UI
@@ -479,7 +800,7 @@ function TRP3_API.profile.init()
 	local function OnSearchTextChanged()
 		local text = TRP3_ProfileManager.list:GetSearchText();
 
-		uiInitProfileList();
+		UiInitProfileList();
 
 		if text == "" then
 			TRP3_ProfileManager.list.ScrollBox:ScrollToElementData(currentProfileId);
@@ -489,7 +810,7 @@ function TRP3_API.profile.init()
 	end
 
 	local function OnHelpButtonTooltip(_, description)
-		TRP3_TooltipTemplates.CreateBasicTooltip(description, loc.PR_EXPORT_IMPORT_TITLE, loc.PR_EXPORT_IMPORT_HELP);
+		TRP3_TooltipTemplates.CreateBasicTooltip(description, loc.PR_PROFILE_OPTIONS, loc.PR_PROFILE_OPTIONS_HELP:format(TRP3_API.Colors.Orange(TRP3_API.FormatShortcut("CTRL-C", TRP3_API.ShortcutType.System))));
 	end
 
 	local function OnMenuButtonTooltip(_, description)
@@ -516,22 +837,184 @@ function TRP3_API.profile.init()
 			end);
 		else
 			if currentProfileId ~= button.profileID then
-				onProfileSelected(button);
+				OnProfileSelected(button);
 				PlaySound(TRP3_InterfaceSounds.ButtonClick);
 			end
 		end
 	end
 
 	local function OnListElementInitialize(button, profileID)
-		button:SetMenuButtonCallback(onActionClicked);
+		button:SetMenuButtonCallback(OnActionClicked);
 		button:SetMenuButtonTooltip(OnMenuButtonTooltip);
 		button:SetScript("OnClick", OnListElementClick);
 		button:SetTooltip(OnListElementTooltip);
-		decorateProfileList(button, profileID);
+		DecorateProfileList(button, profileID);
 	end
 
 	TRP3_ProfileManager.list:SetElementInitializer("TRP3_ProfileManagerListElement", OnListElementInitialize);
-	TRP3_ProfileManager.list:SetCreateCallback(uiCreateProfile);
+
+	-- INIT PROFILE FLOW
+
+	-- Handle escaping during the profile flow.
+	TRP3_ProfileCreateDialog:SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "ESCAPE" then
+			TRP3_ProfileCreateDialog:SetPropagateKeyboardInput(false);
+			CloseProfileFlow();
+		else
+			TRP3_ProfileCreateDialog:SetPropagateKeyboardInput(true);
+		end
+	end);
+	-- Handle clicking the close button during the profile flow.
+	TRP3_ProfileCreateDialog.Frames.CloseButton:SetScript("OnClick", function()
+		CloseProfileFlow();
+	end);
+
+	-- Init choices frame elements.
+	local blankIcon = TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+	TRP3_ProfileCreateDialog.Frames.ChoicesFrame.Title:SetText(loc.PR_CREATE_PROFILE);
+
+	-- Blank profile card.
+	local blankProfileChoice = TRP3_ProfileCreateDialog.Frames.ChoicesFrame.BlankProfile;
+	blankProfileChoice.Icon:SetIconTexture(blankIcon);
+	blankProfileChoice.Text:SetText(loc.PR_CREATE_PROFILE_CHOICE);
+	setTooltipAll(blankProfileChoice, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE_CHOICE, loc.PR_CREATE_PROFILE_CHOICE_TT);
+	blankProfileChoice.Border:SetVertexColor(TRP3_BACKDROP_COLOR_CREAMY_BROWN:GetRGB());
+
+	blankProfileChoice:SetScript("OnClick", function()
+		TRP3_ProfileCreateDialog.Frames.ChoicesFrame:Hide();
+		chosenOption = PROFILEMANAGER_ACTIONS.CREATE;
+		OpenProfileFlow(PROFILEMANAGER_ACTIONS.CREATE);
+	end);
+
+	-- Import profile card.
+	local importProfileChoice = TRP3_ProfileCreateDialog.Frames.ChoicesFrame.ImportProfile;
+	importProfileChoice.Text:SetText(loc.PR_IMPORT_PROFILE);
+	setTooltipAll(importProfileChoice, "RIGHT", 0, 5, loc.PR_IMPORT_PROFILE, loc.PR_IMPORT_PROFILE_CHOICE_TT);
+	importProfileChoice.Border:SetVertexColor(TRP3_BACKDROP_COLOR_CREAMY_BROWN:GetRGB());
+
+	importProfileChoice:SetScript("OnClick", function()
+		TRP3_ProfileCreateDialog.Frames.ChoicesFrame:Hide();
+		chosenOption = PROFILEMANAGER_ACTIONS.IMPORT;
+		OpenProfileFlow(PROFILEMANAGER_ACTIONS.IMPORT);
+	end);
+
+	-- Init create profile callback for profile manager list.
+	TRP3_ProfileManager.list:SetCreateCallback(OpenProfileFlow);
+	setTooltipAll(TRP3_ProfileManager.list.CreateButton, "RIGHT", 0, 5, loc.PR_CREATE_PROFILE, loc.PR_CREATE_PROFILE_TT);
+
+	-- Init import frame elements.
+	local importOption = TRP3_ProfileCreateDialog.Frames.ImportFrame.Content;
+	importOption.Text:SetText(loc.PR_IMPORT_PROFILE_TT:format(TRP3_API.Colors.Orange(TRP3_API.FormatShortcut("CTRL-V", TRP3_API.ShortcutType.System))));
+	TRP3_ProfileCreateDialog.Frames.ImportFrame.ImportButton:SetText(loc.PR_IMPORT);
+
+	-- Evaluate the import data whenever it is written through evaluateImport.
+	importOption.ImportText:SetEscapeSanitized(true);
+	importOption.ImportText:RegisterCallback("OnTextChanged", EvaluateImportData, false);
+	importOption.ImportText:RegisterCallback("OnEditFocusGained", EvaluateImportData, false);
+
+	-- Allow people to CTRL+V into the import editbox, handle it after.
+	importOption.ImportText:GetEditBox():SetScript("OnKeyDown", function(_, key)
+		-- Do not steal input if we're in combat.
+		if InCombatLockdown() then return; end
+
+		if key == "V" and IsControlKeyDown() then
+			importOption.ImportText:SetPropagateKeyboardInput(false);
+
+			local systemInfo = ChatTypeInfo["SYSTEM"];
+			UIErrorsFrame:AddMessage(TRP3_API.loc.PASTE_SYSTEM_MESSAGE, systemInfo.r, systemInfo.g, systemInfo.b);
+
+			EvaluateImportData(false);
+
+			PlaySound(TRP3_InterfaceSounds.PopupClose);
+		else
+			importOption.ImportText:SetPropagateKeyboardInput(true);
+		end
+	end);
+
+	TRP3_ProfileCreateDialog.Frames.ImportFrame.ImportButton:SetScript("OnClick", function()
+		-- canImport == true will evaluate and import the data after.
+		EvaluateImportData(true);
+	end);
+
+	-- Init finalize frame elements.
+	local finalizeOption = TRP3_ProfileCreateDialog.Frames.FinalizeFrame;
+	finalizeOption.Name.title:SetText(loc.CM_NAME);
+	finalizeOption.ConfirmButton:SetText(loc.PR_CREATE_PROFILE);
+
+	-- Evaluate the profile name on text change to prevent empty or duplicates.
+	finalizeOption.Name:SetScript("OnTextChanged", EvaluateProfileName);
+	finalizeOption.Name:SetScript("OnEditFocusGained", EvaluateProfileName);
+
+	-- Setup the profile icon button.
+	setTooltipAll(finalizeOption.Icon, "RIGHT", 0, 5, loc.UI_ICON_SELECT, TRP3_API.FormatShortcutWithInstruction("LCLICK", loc.UI_ICON_OPENBROWSER) .. "|n" .. TRP3_API.FormatShortcutWithInstruction("RCLICK", loc.UI_ICON_OPTIONS));
+	profileIcon = TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+
+	setupIconButton(finalizeOption.Icon, profileIcon);
+	finalizeOption.Icon:SetScript("OnMouseDown", function(self, button)
+		if button == "LeftButton" then
+			TRP3_API.popup.showPopup(TRP3_API.popup.ICONS, nil, {function(icon)
+				profileIcon = icon;
+				setupIconButton(finalizeOption.Icon, icon or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player")));
+			end, nil, nil, profileIcon});
+		elseif button == "RightButton" then
+			profileIcon = profileIcon or TRP3_API.ui.misc.getUnitTexture(Globals.player_character.race, UnitSex("player"));
+			TRP3_MenuUtil.CreateContextMenu(self, function(_, description)
+				description:CreateButton(loc.UI_ICON_COPY, TRP3_API.SetLastCopiedIcon, profileIcon);
+				description:CreateButton(loc.UI_ICON_COPYNAME, function() TRP3_API.popup.showCopyDropdownPopup({profileIcon}); end);
+				description:CreateButton(loc.UI_ICON_PASTE, function() PasteCopiedIcon(finalizeOption.Icon); end);
+			end);
+		end
+	end);
+
+	-- Handle profile creation, either through import or blank.
+	finalizeOption.ConfirmButton:SetScript("OnClick", function()
+		local profileID = chosenProfileId;
+		local name = finalizeOption.Name:GetText();
+
+		-- Handle different profile actions
+		if chosenOption == PROFILEMANAGER_ACTIONS.RENAME then
+			RenameProfile(profileID, name);
+		else
+			if chosenOption == PROFILEMANAGER_ACTIONS.DUPLICATE then
+				profileID = DuplicateProfile(chosenProfile, name);
+			elseif chosenOption == PROFILEMANAGER_ACTIONS.IMPORT then
+				profileID = CreateProfileFromImport(name, chosenProfile);
+			else -- Blank profile creation
+				profileID = CreateProfile(name);
+			end
+		end
+
+		-- Honor the changed profile icon.
+		if profileID and profiles[profileID] and chosenOption ~= PROFILEMANAGER_ACTIONS.RENAME then
+			profiles[profileID].player.characteristics.IC = profileIcon;
+		end
+
+		-- Cleanup and refresh UI
+		finalizeOption:Hide();
+		TRP3_ProfileCreateDialog:Hide();
+		UiInitProfileList();
+	end);
+
+	-- Init export frame.
+	local exportFrame = TRP3_ProfileCreateDialog.Frames.ExportFrame.Content;
+	exportFrame.ExportText:SetReadOnly(true)
+	exportFrame.ExportText:SetHighlightOnFocus(true);
+	exportFrame.ExportText:SetEscapeSanitized(true);
+
+	exportFrame.ExportText:GetEditBox():SetScript("OnKeyDown", function(_, key)
+		if key == "C" and IsControlKeyDown() then
+			local systemInfo = ChatTypeInfo["SYSTEM"];
+			UIErrorsFrame:AddMessage(TRP3_API.loc.COPY_SYSTEM_MESSAGE, systemInfo.r, systemInfo.g, systemInfo.b);
+			PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+
+			-- Close on next frame, otherwise copy operation will fail.
+			RunNextFrame(CloseProfileFlow);
+		end
+	end);
+
 	TRP3_ProfileManager.list:SetHelpCallback(OnHelpButtonTooltip);
 	TRP3_ProfileManager.list:SetSearchCallback(TRP3_FunctionUtil.Debounce(0.25, OnSearchTextChanged));
 
@@ -550,7 +1033,7 @@ function TRP3_API.profile.init()
 	});
 
 	TRP3_ProfileManager.list.onTab = function()
-		uiInitProfileList();
+		UiInitProfileList();
 		TRP3_ProfileManager.list.ScrollBox:ScrollToElementData(currentProfileId);
 	end
 
@@ -585,79 +1068,10 @@ function TRP3_API.profile.init()
 	TRP3_API.RegisterCallback(TRP3_Addon, Events.REGISTER_PROFILES_LOADED, function()
 		if getCurrentPageID() == "player_profiles" then
 			if tabGroup.current == 1 then
-				uiInitProfileList();  -- Force refresh
+				UiInitProfileList();  -- Force refresh
 			end
 		end
 	end);
-
-	-- Export/Import
-	local exportWarningText = IsMacClient() and loc.PR_EXPORT_WARNING_MAC or loc.PR_EXPORT_WARNING_WINDOWS;
-	TRP3_ProfileExport.title:SetText(loc.PR_EXPORT_PROFILE);
-	TRP3_ProfileExport.warning:SetText(TRP3_API.Colors.Red(loc.PR_EXPORT_WARNING_TITLE) .. "\n" .. exportWarningText);
-	TRP3_ProfileImport.title:SetText(loc.PR_IMPORT_PROFILE);
-	TRP3_ProfileImport.content.title:SetText(loc.PR_IMPORT_PROFILE_TT);
-	TRP3_ProfileImport.save:SetText(loc.PR_IMPORT);
-	TRP3_ProfileImport.save:SetScript("OnClick", function()
-		local currentProfileID = TRP3_ProfileImport.profileID;
-		local code = TRP3_ProfileImport.content.scroll.text:GetText();
-		local version, errorOrOldProfileID, data = TRP3_ProfileUtil.DeserializeProfile(string.trim(code));
-
-		if version ~= nil and data ~= nil then
-			local import = function()
-				data.profileName = profiles[currentProfileID].profileName;
-				profiles[currentProfileID] = nil;
-				local destinationProfileID = currentProfileID;
-				if not profiles[errorOrOldProfileID] then
-					destinationProfileID = errorOrOldProfileID;
-				end
-				profiles[destinationProfileID] = data;
-
-				-- A note on your own profile is keyed by the profile's own ID, which is the
-				-- source profile's ID here, not this destination slot's ID. Re-key it onto the slot's ID so the self-note isn't orphaned
-				if destinationProfileID ~= errorOrOldProfileID and data.notes and data.notes[errorOrOldProfileID] and not data.notes[destinationProfileID] then
-					data.notes[destinationProfileID] = data.notes[errorOrOldProfileID];
-					data.notes[errorOrOldProfileID] = nil;
-				end
-
-				-- Converting old music paths to new ID system
-				if data.player and data.player.about and data.player.about.MU and type(data.player.about.MU) == "string" then
-					profiles[destinationProfileID].player.about.MU = Utils.music.convertPathToID(data.player.about.MU);
-				end
-
-				-- Misc info ID conversion
-				if data.player and data.player.characteristics and data.player.characteristics.MI then
-					for _, miscData in ipairs(data.player.characteristics.MI) do
-						if not miscData.ID or miscData.ID ~= TRP3_API.MiscInfoType.Custom then
-							-- Adding ID from name if ID missing, or setting a preset to custom if renamed
-							miscData.ID = TRP3_API.GetMiscInfoTypeByName(miscData.NA);
-						end
-					end
-				end
-
-				TRP3_ProfileImport:Hide();
-				uiInitProfileList();
-			end
-
-			if version ~= Globals.version then
-				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING_2:format(Utils.str.color("g") .. profiles[currentProfileID].profileName .. "|r"), import);
-			else
-				showConfirmPopup(loc.PR_PROFILEMANAGER_IMPORT_WARNING:format(Utils.str.color("g") .. profiles[currentProfileID].profileName .. "|r"), import);
-			end
-		else
-			Utils.message.displayMessage(string.format(loc.PR_IMPORT_ERROR, errorOrOldProfileID), 2);
-		end
-	end);
-
-	-- Setup edit boxes to handle serialized data
-	Mixin(TRP3_ProfileExport.content.scroll.text, TRP3_FocusHighlightEditBoxMixin);
-	Mixin(TRP3_ProfileExport.content.scroll.text, TRP3_ReadOnlyEditBoxMixin);
-	Mixin(TRP3_ProfileExport.content.scroll.text, TRP3_EscapeSanitizedEditBoxMixin);
-
-	TRP3_ProfileExport.content.scroll.text:HookScript("OnChar", TRP3_ProfileExport.content.scroll.text.OnChar);
-	TRP3_ProfileExport.content.scroll.text:HookScript("OnEditFocusGained", TRP3_ProfileExport.content.scroll.text.OnEditFocusGained);
-	TRP3_ProfileExport.content.scroll.text:HookScript("OnEditFocusLost", TRP3_ProfileExport.content.scroll.text.OnEditFocusLost);
-
-	Mixin(TRP3_ProfileImport.content.scroll.text, TRP3_EscapeSanitizedEditBoxMixin);
 
 	TRP3_API.slash.registerCommand({
 		id = "profile",
@@ -678,7 +1092,7 @@ function TRP3_API.profile.init()
 
 			for profileID, profile in pairs(profiles) do
 				if profile.profileName == profileName then
-					selectProfile(profileID);
+					SelectProfile(profileID);
 					return;
 				end
 			end

--- a/totalRP3/Locales/enUS.lua
+++ b/totalRP3/Locales/enUS.lua
@@ -713,22 +713,29 @@ Possible status:
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
 	PR_PROFILEMANAGER_TITLE = "Character profiles",
-	PR_PROFILEMANAGER_DELETE_WARNING = "Are you sure you want to delete the profile %s?\nThis action cannot be undone and all TRP3 information linked to this profile (Character info, inventory, quest log, applied states...) will be destroyed!",
+	PR_PROFILEMANAGER_DELETE_WARNING = "Are you sure you want to delete profile |W%s|w?|n|n|cnWARNING_FONT_COLOR:This will permanently erase all information linked to the profile.|r",
 	PR_PROFILE = "Profile",
 	PR_PROFILES = "Profiles",
 	PR_PROFILE_CREATED = "Profile %s created.",
+	PR_PROFILE_DUPLICATED = "Profile %1$s duplicated to %2$s.",
+	PR_PROFILE_RENAMED = "Profile %1$s renamed to %2$s.",
 	PR_CREATE_PROFILE = "Create profile",
+	PR_CREATE_PROFILE_TT = "Create a |cnGREEN_FONT_COLOR:blank profile|r or |cnGREEN_FONT_COLOR:import one from a previous export|r.",
+	PR_CREATE_PROFILE_CHOICE = "Blank profile",
+	PR_CREATE_PROFILE_CHOICE_TT = "Create a new profile |cnGREEN_FONT_COLOR:from scratch|r.",
+	PR_FINALIZE_PROFILE = "Create blank profile",
 	PR_PROFILE_DELETED = "Profile %s deleted.",
-	PR_PROFILE_HELP = "A profile contains all information about a |cnGREEN_FONT_COLOR:\"character\"|r as a |cnGREEN_FONT_COLOR:roleplay character|r.|n|nA real |cnGREEN_FONT_COLOR:\"WoW character\"|r can be linked to only one profile at a time, but can switch from one to another whenever you want.|n|nYou can also link several |cnGREEN_FONT_COLOR:\"WoW characters\"|r to the same |cnGREEN_FONT_COLOR:profile|r!",
-	PR_PROFILE_DETAIL = "This profile is currently linked to these WoW characters",
+	PR_PROFILE_HELP = "A profile contains all information about a |cnGREEN_FONT_COLOR:\"character\"|r as a |cnGREEN_FONT_COLOR:roleplay character|r.|n|nA real |cnGREEN_FONT_COLOR:\"WoW character\"|r can be linked to only one profile at a time, but can switch between them whenever you want.|n|nYou can also link several |cnGREEN_FONT_COLOR:\"WoW characters\"|r to the same |cnGREEN_FONT_COLOR:profile|r!",
+	PR_PROFILE_DETAIL = "This profile is currently linked to the following WoW characters",
 	PR_DELETE_PROFILE = "Delete profile",
 	PR_DUPLICATE_PROFILE = "Duplicate profile",
-	PR_UNUSED_PROFILE = "This profile is currently not linked to any WoW character.",
-	PR_PROFILE_LOADED = "The profile %s is loaded.",
-	PR_PROFILEMANAGER_CREATE_POPUP = "Please enter a name for the new profile.\nThe name cannot be empty.",
-	PR_PROFILEMANAGER_DUPP_POPUP = "Please enter a name for the new profile.\nThe name cannot be empty.\n\nThis duplication will not change the character's links to %s.",
-	PR_PROFILEMANAGER_EDIT_POPUP = "Please enter a new name for this profile %s.\nThe name cannot be empty.\n\nChanging the name will not change any link between this profile and your characters.",
-	PR_PROFILEMANAGER_ALREADY_IN_USE = "The profile name %s is not available.",
+	PR_EMPTYNAME_PROFILE = "Empty profile name.",
+	PR_UNUSED_PROFILE = "This profile is not currently linked to any WoW character.",
+	PR_PROFILE_LOADED = "Profile %s is loaded.",
+	PR_PROFILEMANAGER_CREATE_POPUP = "Please enter a name for the new profile.|nThe name cannot be empty.",
+	PR_PROFILEMANAGER_DUPP_POPUP = "Please enter a name for the new profile.|nThe name cannot be empty.|n|nThis duplication will not change the character's links to %s.",
+	PR_PROFILEMANAGER_EDIT_POPUP = "Please enter a new name for this profile %s.|nThe name cannot be empty.|n|nChanging the name will not change any link between this profile and your characters.",
+	PR_PROFILEMANAGER_ALREADY_IN_USE = "The profile name %s is unavailable.",
 	PR_PROFILEMANAGER_COUNT = "%s WoW |4character:characters; linked to this profile.",
 	PR_PROFILEMANAGER_ACTIONS = "Actions",
 	PR_PROFILEMANAGER_SWITCH = "Select profile",
@@ -774,19 +781,25 @@ Link a pet/mount to an existing profile or create a new one:
 	PR_IMPORT_WILL_BE_IMPORTED = "Will be imported",
 	PR_IMPORT_EMPTY = "No importable profile",
 	PR_PROFILE_MANAGEMENT_TITLE = "Profile management",
-	PR_EXPORT_IMPORT_TITLE = "Export/import profile",
-	PR_EXPORT_IMPORT_HELP = [[You can export and import profiles using the options in the dropdown menu.
+	PR_PROFILE_OPTIONS = "Profile options",
+	PR_PROFILE_OPTIONS_HELP = [[You can rename, duplicate, export, and delete profiles using the options in the dropdown menu.
 
-Use the |cnGREEN_FONT_COLOR:Export profile|r option to generate a chunk of text that contains the serialized profile data. You can copy the text using Control-C (or Command-C on a Mac) and paste it somewhere else as a backup.
+|cnGREEN_FONT_COLOR:Rename profile|r option allows you to rename the selected profile.
 
-|cnWARNING_FONT_COLOR:Note that some advanced text editors, such as Microsoft Word, reformat special characters such as quotation marks, which changes the data. Use a simpler text editor such as Notepad.|r
+|cnGREEN_FONT_COLOR:Duplicate profile|r option allows you to create a duplicate of the selected profile with a new name.
 
-Use the |cnGREEN_FONT_COLOR:Import profile|r option to paste data from a previous export into an existing profile. The existing data in that profile will be replaced by the pasted data. You cannot import data directly into the currently selected profile.]],
+|cnGREEN_FONT_COLOR:Export profile|r option generates a chunk of text containing the serialized profile data. You can copy (%s) and paste it somewhere else as a backup.
+
+We strongly recommend that you |cnGREEN_FONT_COLOR:copy the exported data below into a simple text editor|r, such as Notepad, that does |cnWARNING_FONT_COLOR:not alter special characters|r.
+
+|cnGREEN_FONT_COLOR:Delete profile|r option allows you to remove the selected profile.]],
 	PR_EXPORT_PROFILE = "Export profile",
 	PR_IMPORT_PROFILE = "Import profile",
-	PR_EXPORT_NAME = "Serial for profile %s (size %0.2f kB)",
-	PR_EXPORT_TOO_LARGE = "This profile is too large and can't be exported.\n\nSize of profile: %0.2f kB\nMax: 20 kB",
-	PR_IMPORT_PROFILE_TT = "Paste a profile serial here",
+	PR_IMPORT_PROFILE_CHOICE_TT = "Import a profile |cnGREEN_FONT_COLOR:from a previous export|r.",
+	PR_PROFILE_IMPORTED = "Profile %s imported.",
+	PR_EXPORT_NAME = "Profile %s serial (size: %0.2f kB)",
+	PR_EXPORT_TOO_LARGE = "This profile is too large to be exported.|n|nProfile size: %0.2f kB|nMax allowed: 20 kB",
+	PR_IMPORT_PROFILE_TT = "Paste (%s) a profile serial here.",
 	PR_IMPORT = "Import",
 	PR_IMPORT_ERROR = "Failed to import profile: %s",
 	PR_IMPORT_ERROR_DESERIALIZE_ACE = "Failed to deserialize Ace data",
@@ -794,17 +807,19 @@ Use the |cnGREEN_FONT_COLOR:Import profile|r option to paste data from a previou
 	PR_IMPORT_ERROR_PEM_LABEL = "PEM block has an invalid header",
 	PR_IMPORT_ERROR_DECOMPRESS = "Failed to decompress PEM data",
 	PR_IMPORT_ERROR_DESERIALIZE_CBOR = "Failed to deserialize CBOR data",
+	PR_IMPORT_EMPTY_SERIAL = "Empty profile serial.",
 	PR_PROFILEMANAGER_IMPORT_WARNING = "Replace all the content of profile %s with this imported data?",
-	PR_PROFILEMANAGER_IMPORT_WARNING_2 = "Warning: this profile serial has been made from an older version of TRP3.\nThis can bring incompatibilities.\n\nReplacing all the content of profile %s with this imported data?",
-	PR_SLASH_SWITCH_HELP = "Switch to another profile using its name.",
-	PR_SLASH_EXAMPLE = "|cffffff00Command usage:|r |cffcccccc/trp3 profile Millidan Foamrage|r |cffffff00to switch to Millidan Foamrage's profile.|r",
-	PR_SLASH_NOT_FOUND = "|cffff0000Could not find a profile named|r |cffffff00%s|r|cffff0000.|r",
-	PR_SLASH_OPEN_HELP = "Open a character's profile using its in-game name, or your target's profile if no name is provided.",
-	PR_SLASH_OPEN_EXAMPLE = "|cffffff00Command usage:|r |cffcccccc/trp3 open|r |cffffff00to open your target's profile or |cffcccccc/trp3 open CharacterName-RealmName|r |cffffff00to open that character's profile.|r",
-	PR_SLASH_OPEN_WAITING = "|cffffff00Requesting profile, please wait...|r",
-	PR_SLASH_OPEN_ABORTING = "|cffffff00Aborted profile request.|r",
+	PR_PROFILEMANAGER_IMPORT_WARNING_2 = "This profile serial was created using |cnGREEN_FONT_COLOR:an older version of TRP3|r.|n|n|cnWARNING_FONT_COLOR:This may cause incompatibilities.|r|n|nReplace all the content of profile %s with this imported data?",
+	PR_PROFILEMANAGER_IMPORT_WARNING_3 = "This profile serial was created using |cnGREEN_FONT_COLOR:an older version of TRP3|r.|n|n|cnWARNING_FONT_COLOR:This may cause incompatibilities.|r",
+	PR_SLASH_SWITCH_HELP = "Switch to another profile by its name.",
+	PR_SLASH_EXAMPLE = "Usage: |cnGREEN_FONT_COLOR:/trp3 profile Millidan Foamrage|r to switch to Millidan Foamrage's profile.",
+	PR_SLASH_NOT_FOUND = "|cnWARNING_FONT_COLOR:Could not find a profile named |cnGREEN_FONT_COLOR:%s|r.|r",
+	PR_SLASH_OPEN_HELP = "Open a character's profile by its in-game name, or your target's profile if no name is provided.",
+	PR_SLASH_OPEN_EXAMPLE = "Usage: |cnGREEN_FONT_COLOR:/trp3 open|r to open your target's profile, or |cnGREEN_FONT_COLOR:/trp3 open CharacterName-RealmName|r to open that character's profile.|r",
+	PR_SLASH_OPEN_WAITING = "Requesting profile. Please wait...",
+	PR_SLASH_OPEN_ABORTING = "Profile request aborted.",
 	PR_DEFAULT_PROFILE_NAME = "Default profile",
-	PR_DEFAULT_PROFILE_WARNING = "Create a new profile\nor link to an existing one in Profiles\nto edit your character's information.",
+	PR_DEFAULT_PROFILE_WARNING = "Create a new profile|nor link to an existing one in Profiles|nto edit your character's information.",
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- DASHBOARD
@@ -1328,13 +1343,8 @@ This module modifies Blizzard player and target frames to use RP name and color,
 	CO_TOOLTIP_PREFERRED_OOC_INDICATOR = "Preferred OOC indicator",
 	CO_TOOLTIP_PREFERRED_OOC_INDICATOR_TEXT = "Text: ",
 	CO_TOOLTIP_PREFERRED_OOC_INDICATOR_ICON = "Icon: ",
-	PR_EXPORT_WARNING_TITLE = "Warning:",
-	PR_EXPORT_WARNING_WINDOWS = [[Please note that some advanced text editing tools like Microsoft Word or Discord will reformat special characters like quotes, altering the content of the data.
-
-If you are planning on copying the text below inside a document, please use simpler text editing tools that do not automatically change characters, like Notepad.]],
-	PR_EXPORT_WARNING_MAC = [[Please note that some advanced text editing tools like Text Edit or Discord will reformat special characters like quotes, altering the content of the data.
-
-If you are planning on copying the text below inside a document, please use simpler text editing tools that do not automatically change characters (in Text Edit go to Format > Make Plain Text before pasting)]],
+	PR_EXPORT_WARNING_TITLE = "Warning",
+	PR_EXPORT_WARNING = "We strongly recommend that you |cnGREEN_FONT_COLOR:copy the exported data below into a simple text editor|r, such as Notepad, that does |cnWARNING_FONT_COLOR:not alter special characters|r.",
 	CL_DIRECTORY_PLAYER_PROFILE = "Directory player profile",
 	CL_DIRECTORY_COMPANION_PROFILE = "Directory companion profile",
 	CL_CONTENT_SIZE = [[Size: %s]],
@@ -1430,6 +1440,7 @@ If you wish to report %s's profile and you cannot target them you will need to o
 
 	COPY_DROPDOWN_POPUP_TEXT = "Copy with %1$s. Paste with %2$s.\nThis frame will close upon copy.",
 	COPY_SYSTEM_MESSAGE = "Copied to clipboard.",
+	PASTE_SYSTEM_MESSAGE = "Pasted from clipboard.",
 	UNIT_POPUPS_MODULE_NAME = "Unit Popups",
 	UNIT_POPUPS_MODULE_DESCRIPTION = "Adds integration with right-click menus on unit frames and player names in chat frames.",
 	UNIT_POPUPS_ROLEPLAY_OPTIONS_HEADER = "Roleplay Options",

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsMain.lua
@@ -151,12 +151,12 @@ end
 TRP3_API.companions.player.createProfile = createProfile;
 
 -- Edit a profile name
-local function editProfile(profileID, newName)
+local function RenameProfile(profileID, newName)
 	assert(playerCompanions[profileID], "Unknown profile: "..tostring(profileID));
 	assert(isProfileNameAvailable(newName), "Unavailable profile name: "..tostring(newName));
 	playerCompanions[profileID]["profileName"] = newName;
 end
-TRP3_API.companions.player.editProfile = editProfile;
+TRP3_API.companions.player.renameProfile = RenameProfile;
 
 -- Delete a profile
 -- If the deleted profile is the currently selected one, assign the default profile

--- a/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
+++ b/totalRP3/Modules/Register/Companions/RegisterCompanionsProfiles.lua
@@ -15,7 +15,7 @@ local showAlertPopup, showTextInputPopup, showConfirmPopup = TRP3_API.popup.show
 local getProfiles, isProfileNameAvailable = TRP3_API.companions.player.getProfiles, TRP3_API.companions.player.isProfileNameAvailable;
 local createProfile, deleteProfile = TRP3_API.companions.player.createProfile, TRP3_API.companions.player.deleteProfile;
 local duplicateProfile = TRP3_API.companions.player.duplicateProfile;
-local editProfile = TRP3_API.companions.player.editProfile;
+local renameProfile = TRP3_API.companions.player.renameProfile;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
 local getCompanionProfile, getCompanionProfileID = TRP3_API.companions.player.getCompanionProfile, TRP3_API.companions.player.getCompanionProfileID;
 local getCompanionProfiles = TRP3_API.companions.player.getProfiles;
@@ -105,14 +105,14 @@ end
 
 local getMenuItem = TRP3_API.navigation.menu.getMenuItem;
 
-local function uiEditProfile(profileID)
+local function uiRenameProfile(profileID)
 	local profile = getProfiles()[profileID];
 	showTextInputPopup(
 	loc.PR_CO_PROFILEMANAGER_EDIT_POPUP:format(Utils.str.color("g") .. profile.profileName .. "|r"),
 	function(newName)
 		if newName and #newName ~= 0 then
 			if not uiCheckNameAvailability(newName) then return end
-			editProfile(profileID, newName);
+			renameProfile(profileID, newName);
 			uiInitProfileList();
 			if isMenuRegistered(currentlyOpenedProfilePrefix .. profileID) then
 				getMenuItem(currentlyOpenedProfilePrefix .. profileID).text = newName;
@@ -245,7 +245,7 @@ local function onActionSelected(value, button)
 	if value == 1 then
 		uiDeleteProfile(profileID);
 	elseif value == 2 then
-		uiEditProfile(profileID);
+		uiRenameProfile(profileID);
 	elseif value == 3 then
 		uiDuplicateProfile(profileID);
 	elseif value == 4 then

--- a/totalRP3/UI/Profiles.xml
+++ b/totalRP3/UI/Profiles.xml
@@ -20,129 +20,288 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 
 	<Frame name="TRP3_ProfileManager" inherits="TRP3_ProfileManagerTemplate" hidden="true"/>
 
-	<Frame name="TRP3_ProfileExport" parentKey="export" parent="TRP3_ProfileManager" inherits="TRP3_AltHoveredFrame" enableMouse="true" frameStrata="HIGH" hidden="true">
-		<Size x="400" y="300"/>
-
-		<Anchors>
-			<Anchor point="CENTER" x="0" y="0"/>
-		</Anchors>
-
+	<!-- Template for choice buttons -->
+	<Button name="TRP3_ChoiceButtonTemplate" virtual="true">
+		<Size x="180" y="120"/>
 		<Layers>
+			<Layer level="BACKGROUND">
+				<Texture parentKey="Background" inherits="TRP3_UIFrameMediumFillTextureTemplate"/>
+			</Layer>
+			<Layer level="BORDER">
+				<Texture parentKey="Border" inherits="TRP3_UIFrameMediumEdgeTextureTemplate"/>
+			</Layer>
+			<Layer level="HIGHLIGHT">
+				<Texture parentKey="Highlight" file="Interface\AddOns\totalRP3\Resources\UI\ui-frame-slice-md-glow" alphaMode="ADD">
+					<TextureSliceMargins left="32" top="32" right="32" bottom="32"/>
+					<TextureSliceMode mode="Tiled"/>
+					<Color r="0.92" g="0.68" b="0"/>
+				</Texture>
+			</Layer>
 			<Layer level="OVERLAY">
-				<FontString parentKey="title" inherits="GameFontNormalLarge" justifyH="CENTER" justifyV="MIDDLE">
-					<Size x="0" y="30"/>
+				<FontString parentKey="Text" inherits="GameFontHighlightLarge" justifyH="MIDDLE" wordwrap="false">
+					<Size y="20"/>
 					<Anchors>
-						<Anchor point="TOP" x="0" y="-10"/>
-						<Anchor point="RIGHT" x="-10" y="0"/>
-						<Anchor point="LEFT" x="10" y="0"/>
+						<Anchor point="BOTTOM" y="20"/>
 					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
-				<FontString parentKey="warning" inherits="GameFontNormalSmall" justifyH="LEFT">
-					<Anchors>
-						<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title"/>
-						<Anchor point="RIGHT" x="-30" y="0"/>
-						<Anchor point="LEFT" x="30" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
 				</FontString>
 			</Layer>
 		</Layers>
-
 		<Frames>
-			<Button parentKey="Close" inherits="TRP3_RedButtonCloseArtTemplate">
-				<Size x="24" y="24"/>
+			<Frame parentKey="Icon" inherits="TRP3_BorderedIconTemplate">
+				<Size x="48" y="48"/>
 				<Anchors>
-					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
-				</Anchors>
-				<Scripts>
-					<OnClick>
-						self:GetParent():Hide();
-					</OnClick>
-				</Scripts>
-			</Button>
-
-			<Frame parentKey="content" inherits="TRP3_TextArea">
-				<Layers>
-					<Layer level="OVERLAY">
-						<FontString parentKey="title" inherits="GameFontNormalSmall" justifyH="LEFT">
-							<Anchors>
-								<Anchor point="TOPLEFT" x="10" y="12"/>
-								<Anchor point="TOPRIGHT" x="0" y="12"/>
-							</Anchors>
-							<Color r="0.95" g="0.75" b="0.1"/>
-						</FontString>
-					</Layer>
-				</Layers>
-				<Anchors>
-					<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.warning" x="0" y="-25"/>
-					<Anchor point="RIGHT" x="-30" y="0"/>
-					<Anchor point="LEFT" x="20" y="0"/>
-					<Anchor point="BOTTOM" x="0" y="30"/>
+					<Anchor point="TOP" y="-20"/>
 				</Anchors>
 			</Frame>
 		</Frames>
-	</Frame>
+	</Button>
 
-	<Frame parentKey="import" name="TRP3_ProfileImport" parent="TRP3_ProfileManager" inherits="TRP3_AltHoveredFrame" enableMouse="true" frameStrata="HIGH" hidden="true">
-		<Size x="400" y="300"/>
-
+	<Frame name="TRP3_ProfileCreateDialog" parent="TRP3_ProfileManager" frameStrata="HIGH" enableMouse="true" hidden="true">
 		<Anchors>
-			<Anchor point="CENTER" x="0" y="0"/>
+			<Anchor point="TOPLEFT"/>
+			<Anchor point="BOTTOMRIGHT"/>
 		</Anchors>
-
-		<Layers>
-			<Layer level="OVERLAY">
-				<FontString parentKey="title" inherits="GameFontNormalLarge" justifyH="CENTER" justifyV="MIDDLE">
-					<Size x="0" y="30"/>
-					<Anchors>
-						<Anchor point="TOP" x="0" y="-10"/>
-						<Anchor point="RIGHT" x="-10" y="0"/>
-						<Anchor point="LEFT" x="10" y="0"/>
-					</Anchors>
-					<Color r="0.95" g="0.95" b="0.95"/>
-				</FontString>
-			</Layer>
-		</Layers>
-
 		<Frames>
-			<Button parentKey="Close" inherits="TRP3_RedButtonCloseArtTemplate">
-				<Size x="24" y="24"/>
-				<Anchors>
-					<Anchor point="TOPRIGHT" x="-5" y="-5"/>
-				</Anchors>
-				<Scripts>
-					<OnClick>
-						self:GetParent():Hide();
-					</OnClick>
-				</Scripts>
-			</Button>
+			<Frame parentKey="Backdrop" inherits="TRP3_OverlayBackdropTemplate" setAllPoints="true" useParentLevel="true"/>
 
-			<Button parentKey="save" inherits="TRP3_CommonButton">
+			<!-- Profile Create frames holder -->
+			<Frame parentKey="Frames">
+				<Size x="400" y="200"/>
+				<KeyValues>
+					<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+				</KeyValues>
 				<Anchors>
-					<Anchor point="BOTTOM" x="0" y="20"/>
+					<Anchor point="CENTER"/>
 				</Anchors>
-			</Button>
+				<Frames>
+					<Button parentKey="CloseButton" inherits="TRP3_RedButtonCloseArtTemplate">
+						<Size x="24" y="24"/>
+						<Anchors>
+							<Anchor point="TOPRIGHT" x="-5" y="-5"/>
+						</Anchors>
+					</Button>
 
-			<Frame parentKey="content" inherits="TRP3_TextArea">
-				<Layers>
-					<Layer level="OVERLAY">
-						<FontString parentKey="title" inherits="GameFontNormalSmall" justifyH="LEFT">
-							<Anchors>
-								<Anchor point="TOPLEFT" x="10" y="12"/>
-								<Anchor point="TOPRIGHT" x="0" y="12"/>
-							</Anchors>
-							<Color r="0.95" g="0.75" b="0.1"/>
-						</FontString>
-					</Layer>
-				</Layers>
-				<Anchors>
-					<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" x="0" y="-21"/>
-					<Anchor point="RIGHT" x="-30" y="0"/>
-					<Anchor point="LEFT" x="20" y="0"/>
-					<Anchor point="BOTTOM" relativePoint="TOP" relativeKey="$parent.save" x="0" y="5"/>
-				</Anchors>
+					<!-- Choices frame (Blank and import button options) -->
+					<Frame parentKey="ChoicesFrame" hidden="true">
+						<Anchors>
+							<Anchor point="TOPLEFT"/>
+							<Anchor point="BOTTOMRIGHT"/>
+						</Anchors>
+						<Layers>
+							<Layer level="OVERLAY">
+								<FontString parentKey="Title" inherits="GameFontHighlightLarge" wordwrap="false">
+									<Anchors>
+										<Anchor point="TOPLEFT" x="0" y="-20"/>
+										<Anchor point="TOPRIGHT" x="0" y="-20"/>
+									</Anchors>
+								</FontString>
+							</Layer>
+						</Layers>
+						<Frames>
+							<Frame parentKey="Backdrop" inherits="TRP3_BrowserDialogBackdropTemplate" setAllPoints="true" useParentLevel="true">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+								</KeyValues>
+							</Frame>
+
+							<Button parentKey="BlankProfile" inherits="TRP3_ChoiceButtonTemplate">
+								<Anchors>
+									<Anchor point="RIGHT" relativePoint="CENTER"/>
+								</Anchors>
+							</Button>
+
+							<Button parentKey="ImportProfile" inherits="TRP3_ChoiceButtonTemplate">
+								<Anchors>
+									<Anchor point="LEFT" relativePoint="CENTER"/>
+								</Anchors>
+							</Button>
+						</Frames>
+					</Frame>
+
+					<!-- Import frame (Inputbox with import button) -->
+					<Frame parentKey="ImportFrame" hidden="true">
+						<Anchors>
+							<Anchor point="TOPLEFT"/>
+							<Anchor point="BOTTOMRIGHT"/>
+						</Anchors>
+						<Layers>
+							<Layer level="OVERLAY">
+								<FontString parentKey="Title" inherits="GameFontHighlightLarge" wordwrap="false">
+									<Anchors>
+										<Anchor point="TOPLEFT" x="0" y="-20"/>
+										<Anchor point="TOPRIGHT" x="0" y="-20"/>
+									</Anchors>
+								</FontString>
+							</Layer>
+						</Layers>
+						<Frames>
+							<Frame parentKey="Backdrop" inherits="TRP3_BrowserDialogBackdropTemplate" setAllPoints="true" useParentLevel="true">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+								</KeyValues>
+							</Frame>
+
+							<Button parentKey="ImportButton" inherits="TRP3_CommonButton" motionScriptsWhileDisabled="true">
+								<Size x="150" y="22"/>
+								<Anchors>
+									<Anchor point="BOTTOM" y="20"/>
+								</Anchors>
+								<Layers>
+									<Layer level="OVERLAY">
+										<Texture parentKey="WarningIcon" atlas="services-icon-warning" useAtlasSize="false" hidden="true">
+										<Size x="22" y="22"/>
+											<Anchors>
+												<Anchor point="RIGHT" relativePoint="LEFT" x="-10"/>
+											</Anchors>
+										</Texture>
+									</Layer>
+								</Layers>
+							</Button>
+
+							<Frame parentKey="Content" inherits="TRP3_TooltipBackdropTemplate">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_CREAMY_BROWN" type="global"/>
+								</KeyValues>
+								<Anchors>
+									<Anchor point="TOP" relativeKey="$parent.Title" relativePoint="BOTTOM" y="-10" />
+									<Anchor point="LEFT" x="10"/>
+									<Anchor point="RIGHT" x="-10"/>
+									<Anchor point="BOTTOM" relativeKey="$parent.ImportButton" relativePoint="TOP" y="10" />
+								</Anchors>
+								<Layers>
+									<Layer level="OVERLAY">
+										<FontString parentKey="Text" inherits="GameFontNormalSmall" justifyH="LEFT">
+											<Anchors>
+												<Anchor point="TOP" y="-15"/>
+												<Anchor point="LEFT" x="15"/>
+												<Anchor point="RIGHT" x="-15"/>
+											</Anchors>
+											<Color r="0.95" g="0.95" b="0.95"/>
+										</FontString>
+									</Layer>
+								</Layers>
+								<Frames>
+									<Frame parentKey="ImportText" inherits="TRP3_InsetScrollingEditBoxTemplate">
+										<Anchors>
+											<Anchor point="TOP" relativeKey="$parent.Text" relativePoint="BOTTOM" y="-10"/>
+											<Anchor point="LEFT" x="10"/>
+											<Anchor point="RIGHT" x="-10"/>
+											<Anchor point="BOTTOM" y="10"/>
+										</Anchors>
+									</Frame>
+								</Frames>
+							</Frame>
+						</Frames>
+					</Frame>
+
+					<!-- Export frame (Read-only inputbox with profile data) -->
+					<Frame parentKey="ExportFrame" hidden="true">
+						<Anchors>
+							<Anchor point="TOPLEFT"/>
+							<Anchor point="BOTTOMRIGHT"/>
+						</Anchors>
+						<Layers>
+							<Layer level="OVERLAY">
+								<FontString parentKey="Title" inherits="GameFontHighlightLarge" wordwrap="false">
+									<Anchors>
+										<Anchor point="TOPLEFT" x="0" y="-20"/>
+										<Anchor point="TOPRIGHT" x="0" y="-20"/>
+									</Anchors>
+								</FontString>
+							</Layer>
+						</Layers>
+						<Frames>
+							<Frame parentKey="Backdrop" inherits="TRP3_BrowserDialogBackdropTemplate" setAllPoints="true" useParentLevel="true">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+								</KeyValues>
+							</Frame>
+
+							<Frame parentKey="Content" inherits="TRP3_TooltipBackdropTemplate">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_CREAMY_BROWN" type="global"/>
+								</KeyValues>
+								<Anchors>
+									<Anchor point="TOP" relativeKey="$parent.Title" relativePoint="BOTTOM" y="-10"/>
+									<Anchor point="LEFT" x="10"/>
+									<Anchor point="BOTTOMRIGHT" x="-10" y="10"/>
+								</Anchors>
+								<Layers>
+									<Layer level="OVERLAY">
+										<FontString parentKey="Warning" inherits="GameFontNormalSmall" justifyH="LEFT">
+											<Anchors>
+												<Anchor point="TOP" y="-15"/>
+												<Anchor point="LEFT" x="15"/>
+												<Anchor point="RIGHT" x="-15"/>
+											</Anchors>
+											<Color r="0.95" g="0.95" b="0.95"/>
+										</FontString>
+									</Layer>
+								</Layers>
+								<Frames>
+									<Frame parentKey="ExportText" inherits="TRP3_InsetScrollingEditBoxTemplate">
+										<Anchors>
+											<Anchor point="TOP" relativeKey="$parent.Warning" relativePoint="BOTTOM" y="-10"/>
+											<Anchor point="BOTTOM" y="10"/>
+											<Anchor point="LEFT" x="10"/>
+											<Anchor point="RIGHT" x="-10"/>
+										</Anchors>
+									</Frame>
+								</Frames>
+							</Frame>
+						</Frames>
+					</Frame>
+
+					<!-- Finalize frame (Name + icon with confirm button) -->
+					<Frame parentKey="FinalizeFrame" hidden="true">
+						<Anchors>
+							<Anchor point="TOPLEFT"/>
+							<Anchor point="BOTTOMRIGHT"/>
+						</Anchors>
+						<Layers>
+							<Layer level="OVERLAY">
+								<FontString parentKey="Title" inherits="GameFontHighlightLarge" wordwrap="false">
+									<Anchors>
+										<Anchor point="TOPLEFT" x="0" y="-20"/>
+										<Anchor point="TOPRIGHT" x="0" y="-20"/>
+									</Anchors>
+								</FontString>
+							</Layer>
+						</Layers>
+						<Frames>
+							<Frame parentKey="Backdrop" inherits="TRP3_BrowserDialogBackdropTemplate" setAllPoints="true" useParentLevel="true">
+								<KeyValues>
+									<KeyValue key="backdropBorderColor" value="TRP3_BACKDROP_COLOR_GREY" type="global"/>
+								</KeyValues>
+							</Frame>
+
+							<Button parentKey="Icon" inherits="TRP3_BorderedIconButtonTemplate">
+								<Size x="55" y="55"/>
+								<Anchors>
+									<Anchor point="LEFT" x="20" y="-10"/>
+								</Anchors>
+							</Button>
+
+							<EditBox parentKey="Name" inherits="TRP3_TitledHelpEditBox">
+								<Size x="0" y="18"/>
+								<Anchors>
+									<Anchor point="TOPLEFT" x="15" y="-4" relativeKey="$parent.Icon" relativePoint="TOPRIGHT"/>
+									<Anchor point="RIGHT" x="-20"/>
+								</Anchors>
+							</EditBox>
+
+							<Button parentKey="ConfirmButton" inherits="TRP3_CommonButton" motionScriptsWhileDisabled="true">
+								<Size x="150" y="22"/>
+								<Anchors>
+									<Anchor point="BOTTOM" y="20"/>
+								</Anchors>
+							</Button>
+						</Frames>
+					</Frame>
+
+				</Frames>		
 			</Frame>
+
 		</Frames>
 	</Frame>
 </Ui>

--- a/totalRP3/UI/Profiles.xml
+++ b/totalRP3/UI/Profiles.xml
@@ -299,7 +299,7 @@ https://raw.githubusercontent.com/Meorawr/wow-ui-schema/main/UI.xsd">
 						</Frames>
 					</Frame>
 
-				</Frames>		
+				</Frames>
 			</Frame>
 
 		</Frames>

--- a/totalRP3/UI/ScrollingEditBox.lua
+++ b/totalRP3/UI/ScrollingEditBox.lua
@@ -42,7 +42,7 @@ function TRP3_ScrollingEditBoxMixin:OnLoad()
 end
 
 function TRP3_ScrollingEditBoxMixin:OnChar(char)
-	if self.readOnly then
+	if self:IsReadOnly() then
 		local cursorPosition = self.EditBox:GetUTF8CursorPosition();
 		self.EditBox:SetText(self.currentInputText);
 		self.EditBox:SetCursorPosition(cursorPosition - strlenutf8(char));
@@ -55,10 +55,14 @@ end
 
 function TRP3_ScrollingEditBoxMixin:OnEditFocusGained()
 	self:TriggerEvent("OnEditFocusGained");
+	if self.highlightOnFocus then
+		RunNextFrame(function() self.EditBox:HighlightText(); end);
+	end
 end
 
 function TRP3_ScrollingEditBoxMixin:OnEditFocusLost()
 	self:TriggerEvent("OnEditFocusLost");
+	self.EditBox:HighlightText(0, 0);
 end
 
 function TRP3_ScrollingEditBoxMixin:OnEscapePressed()
@@ -87,7 +91,7 @@ function TRP3_ScrollingEditBoxMixin:ClearFocus()
 end
 
 function TRP3_ScrollingEditBoxMixin:ClearText()
-	self.EditBox:ClearText();
+    self.ScrollFrame:ClearText();
 end
 
 function TRP3_ScrollingEditBoxMixin:GetFontHeight()
@@ -95,15 +99,19 @@ function TRP3_ScrollingEditBoxMixin:GetFontHeight()
 end
 
 function TRP3_ScrollingEditBoxMixin:GetInputText()
-	return self.EditBox:GetInputText();
+	local text = self.EditBox:GetInputText();
+	if self.escapeSanitized then
+		text = string.gsub(text, "||", "|");
+	end
+	return text;
 end
 
 function TRP3_ScrollingEditBoxMixin:IsReadOnly()
-	return self.readOnlyText ~= nil;
+	return self.readOnly ~= nil;
 end
 
 function TRP3_ScrollingEditBoxMixin:SetDefaultText(defaultText)
-	self.EditBox:SetDefaultText(defaultText);
+    self.EditBox:ApplyDefaultText(defaultText);
 end
 
 function TRP3_ScrollingEditBoxMixin:SetDefaultTextColor(color)
@@ -130,7 +138,19 @@ function TRP3_ScrollingEditBoxMixin:SetFontObject(fontName)
 	self.EditBox:SetFontObject(fontName);
 end
 
+function TRP3_ScrollingEditBoxMixin:SetEscapeSanitized(enabled)
+    self.escapeSanitized = enabled;
+end
+
+function TRP3_ScrollingEditBoxMixin:SetHighlightOnFocus(enabled)
+    self.highlightOnFocus = enabled;
+end
+
 function TRP3_ScrollingEditBoxMixin:SetText(text)
+	if self.escapeSanitized then
+		text = string.gsub(text, "|", "||");
+	end
+	self.currentInputText = text;
 	self.EditBox:SetText(text);
 end
 

--- a/totalRP3/UI/ScrollingEditBox.lua
+++ b/totalRP3/UI/ScrollingEditBox.lua
@@ -91,7 +91,7 @@ function TRP3_ScrollingEditBoxMixin:ClearFocus()
 end
 
 function TRP3_ScrollingEditBoxMixin:ClearText()
-    self.ScrollFrame:ClearText();
+	self.ScrollFrame:ClearText();
 end
 
 function TRP3_ScrollingEditBoxMixin:GetFontHeight()
@@ -111,7 +111,7 @@ function TRP3_ScrollingEditBoxMixin:IsReadOnly()
 end
 
 function TRP3_ScrollingEditBoxMixin:SetDefaultText(defaultText)
-    self.EditBox:ApplyDefaultText(defaultText);
+	self.EditBox:ApplyDefaultText(defaultText);
 end
 
 function TRP3_ScrollingEditBoxMixin:SetDefaultTextColor(color)
@@ -139,11 +139,11 @@ function TRP3_ScrollingEditBoxMixin:SetFontObject(fontName)
 end
 
 function TRP3_ScrollingEditBoxMixin:SetEscapeSanitized(enabled)
-    self.escapeSanitized = enabled;
+	self.escapeSanitized = enabled;
 end
 
 function TRP3_ScrollingEditBoxMixin:SetHighlightOnFocus(enabled)
-    self.highlightOnFocus = enabled;
+	self.highlightOnFocus = enabled;
 end
 
 function TRP3_ScrollingEditBoxMixin:SetText(text)


### PR DESCRIPTION
This was meant to release in like 2024? 2025? You know how it goes.

Definitely will require a lot of checking given how it changes profiles.lua as a whole, probably tweaking too if the two overlords don't like it (this has not changed code-wise since its original inception over a year+ ago).

Note that this includes the note fixes on profile import from #1331.

Below is a video of it in action (video dated March 2025).
Video still has the old import/export code, but it is adapted to work with PEM etc from #1204.

https://github.com/user-attachments/assets/f92712a3-9cc5-4aef-ab8f-209690831120

Some extra notes:
- Import no longer happens on / overwrites an existing profile. It creates a new profile instead.
- There are clear errors telling the user when a profile name is duplicated or other potential issues.
