### PR TITLE
12.1 removed `MouseIsOver`, introduces `InputUtil.IsMouseOver` (with Classic fallback)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -514,6 +514,13 @@ stds.wow = {
 			},
 		},
 
+		InputUtil = {
+			fields = {
+				"IsMouseOver",
+			}
+		},
+
+
 		Menu = {
 			fields = {
 				"ModifyMenu",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -520,7 +520,6 @@ stds.wow = {
 			}
 		},
 
-
 		Menu = {
 			fields = {
 				"ModifyMenu",
@@ -579,9 +578,9 @@ stds.wow = {
 		},
 
 		TimerunningUtil = {
-		    fields = {
-                "AddSmallIcon",
-            },
+			fields = {
+				"AddSmallIcon",
+			},
 		},
 
 		"AbbreviateLargeNumbers",

--- a/totalRP3/Core/UITools.lua
+++ b/totalRP3/Core/UITools.lua
@@ -122,9 +122,11 @@ function TRP3_API.ui.frame.getTiledBackgroundList()
 	return tab;
 end
 
+local IsMouseOverFrame = (InputUtil and InputUtil.IsMouseOver) or MouseIsOver;
+
 function TRP3_API.ui.frame.showIfMouseOverFrame(frame, frameOver)
 	assert(frame and frameOver, "Frames can't be nil");
-	if MouseIsOver(frameOver) then
+	if IsMouseOverFrame(frameOver) then
 		frame:Show();
 	else
 		frame:Hide();


### PR DESCRIPTION
Handles 12.1's removal of `MouseIsOver` in favor of `InputUtil.IsMouseOver`, while keeping a fallback for Classic flavors.

Tested on 12.1 PTR, still requires testing in Classic however.