### PR TITLE
Fix ScrollingEditBox readOnly flag acting out of line

### DIFF
--- a/totalRP3/UI/ScrollingEditBox.lua
+++ b/totalRP3/UI/ScrollingEditBox.lua
@@ -107,7 +107,10 @@ function TRP3_ScrollingEditBoxMixin:GetInputText()
 end
 
 function TRP3_ScrollingEditBoxMixin:IsReadOnly()
-	return self.readOnly ~= nil;
+	if self.readOnly == nil then
+		self.readOnly = true;
+	end
+	return self.readOnly;
 end
 
 function TRP3_ScrollingEditBoxMixin:SetDefaultText(defaultText)


### PR DESCRIPTION
previous check disregarded a `false` value for `.readOnly`. It now behaves better