### PR TITLE
RE: The ScrollingEditBox conundrum

### DIFF
--- a/totalRP3/UI/ScrollingEditBox.lua
+++ b/totalRP3/UI/ScrollingEditBox.lua
@@ -107,9 +107,6 @@ function TRP3_ScrollingEditBoxMixin:GetInputText()
 end
 
 function TRP3_ScrollingEditBoxMixin:IsReadOnly()
-	if self.readOnly == nil then
-		self.readOnly = true;
-	end
 	return self.readOnly;
 end
 


### PR DESCRIPTION
we should've just been returning `.readOnly`, I dunno what I was doing