### PR TITLE
Fix 12.1 Nameplate issues

### DIFF
--- a/totalRP3/Modules/Flyway/Flyway.lua
+++ b/totalRP3/Modules/Flyway/Flyway.lua
@@ -3,7 +3,7 @@
 
 TRP3_API.flyway = {};
 
-local SCHEMA_VERSION = 24;
+local SCHEMA_VERSION = 25;
 
 if not TRP3_Flyway then
 	TRP3_Flyway = {};

--- a/totalRP3/Modules/Flyway/FlywayPatches.lua
+++ b/totalRP3/Modules/Flyway/FlywayPatches.lua
@@ -453,7 +453,7 @@ TRP3_API.flyway.patches["23"] = function()
 end
 
 TRP3_API.flyway.patches["24"] = function()
-	-- v23 converts CustomizeFullTitles (TRP3_NamePlatesSettings) to use CustomizeSubText
+	-- v24 converts CustomizeFullTitles (TRP3_NamePlatesSettings) to use CustomizeSubText
 
 	if TRP3_Configuration then
 		-- If FT was on, convert to FT + GN. If FT was off, 'Nothing' is chosen by default.
@@ -466,5 +466,16 @@ TRP3_API.flyway.patches["24"] = function()
 		end
 
 		TRP3_Configuration["NamePlates_CustomizeFullTitles"] = nil;
+	end
+end
+
+TRP3_API.flyway.patches["25"] = function()
+	-- v25 sets the NamePlateShowOnlyNameForFriendlyPlayerUnits CVar to our NamePlates_EnableNameOnlyMode (as it now persists)
+
+	if TRP3_Configuration then
+		if TRP3_Configuration["NamePlates_EnableNameOnlyMode"] then
+			local value = TRP3_Configuration["NamePlates_EnableNameOnlyMode"] and "1" or "0";
+			C_CVar.SetCVar(TRP3_CVarConstants.NamePlateShowOnlyNameForFriendlyPlayerUnits, value);
+		end
 	end
 end

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -128,7 +128,6 @@ function TRP3_BlizzardNamePlates:OnModuleEnable()
 
 	TRP3_CVarCache.RegisterCallback(self, TRP3_CVarConstants.NamePlateShowOnlyNameForFriendlyPlayerUnits, "OnNamePlateNameOnlyModeChanged");
 	TRP3_NamePlates.RegisterCallback(self, "OnNamePlateDataUpdated");
-	TRP3_NamePlatesUtil.SyncNameOnlyModeState();
 
 	-- luacheck: no unused (self)
 	hooksecurefunc(NamePlateDriverFrame, "OnNamePlateCreated", function(_self, nameplate) self:OnNamePlateCreated(nameplate); end);
@@ -165,11 +164,6 @@ function TRP3_BlizzardNamePlates:OnNamePlateUnitCleared(nameplate)
 end
 
 function TRP3_BlizzardNamePlates:OnNamePlateNameOnlyModeChanged()
-	-- Write back the latest CVar state to TRP settings when adjusted from
-	-- the native Blizzard settings interface.
-	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
-		TRP3_API.configuration.setValue("NamePlates_EnableNameOnlyMode", C_CVar.GetCVarBool(TRP3_CVarConstants.NamePlateShowOnlyNameForFriendlyPlayerUnits));
-	end
 	self:UpdateAllNamePlates();
 end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -165,6 +165,11 @@ function TRP3_BlizzardNamePlates:OnNamePlateUnitCleared(nameplate)
 end
 
 function TRP3_BlizzardNamePlates:OnNamePlateNameOnlyModeChanged()
+	-- Write back the latest CVar state to TRP settings when adjusted from
+	-- the native Blizzard settings interface.
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+		TRP3_API.configuration.setValue("NamePlates_EnableNameOnlyMode", C_CVar.GetCVarBool(TRP3_CVarConstants.NamePlateShowOnlyNameForFriendlyPlayerUnits));
+	end
 	self:UpdateAllNamePlates();
 end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -352,7 +352,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateName(nameplate)
 		-- Process color overrides.
 		-- Do not color name when unit name is within the health bar, except when name-only mode is on.
 		-- Companion nameplates don't have a name-only option, so exclude them from the name-only check.
-		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameInsideHealthBar and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() or not displayInfo.isPlayerUnit;
+		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameAnchorStyle and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() or not displayInfo.isPlayerUnit;
 
 		if displayInfo.shouldColorName and not hasHealthBarOverlap then
 			overrideColor = displayInfo.color;

--- a/totalRP3/Modules/NamePlates/NamePlates_Settings.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Settings.lua
@@ -324,6 +324,9 @@ function TRP3_NamePlatesUtil.RegisterSettings()
 				title = L.NAMEPLATES_CONFIG_BLIZZARD_NAME_ONLY,
 				help = L.NAMEPLATES_CONFIG_BLIZZARD_NAME_ONLY_HELP,
 				configKey = MapSettingToConfigKey("EnableNameOnlyMode"),
+				OnShow = function(button)
+					button:SetChecked(TRP3_NamePlatesUtil.IsNameOnlyModeEnabled());
+				end,
 				OnClick = function(button)
 					TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(button:GetChecked());
 				end,

--- a/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Shared.lua
@@ -70,10 +70,6 @@ function TRP3_NamePlatesUtil.GetUnitCharacterID(unitToken)
 	return characterID;
 end
 
-function TRP3_NamePlatesUtil.SyncNameOnlyModeState()
-	TRP3_NamePlatesUtil.SetNameOnlyModeEnabled(TRP3_API.configuration.getValue("NamePlates_EnableNameOnlyMode"));
-end
-
 function TRP3_NamePlatesUtil.IsNameOnlyModeEnabled()
 	return TRP3_CVarCache:GetCVarBool(TRP3_CVarConstants.NamePlateShowOnlyNameForFriendlyPlayerUnits);
 end


### PR DESCRIPTION
This PR does four things:
1. Fixes name to be white font again when they are within the nameplates' health bar.
2. Blizz now exposes "Only Show Names" from their settings, mirror this CVar when it is set to our settings so it stays in sync (and make the setting query it in `OnShow` as well).
3. Add a flyway so that when people log in on 12.1, their Blizzard CVar is synchronized to what they set on our settings page.
4. The old system remains as a fallback for Classic, as I can't test myself if the CVar there also persists now or not.