### PR TITLE
Upgrade precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: ^totalRP3/(Libs/(Ellyb/Libraries|TaintLess)/.*|Locales/.{4}\.lua)$
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -14,7 +14,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: 2.7.1
+    rev: 3.11.1
     hooks:
       - id: editorconfig-checker
         alias: ec


### PR DESCRIPTION
The existing config was using versions old enough to trigger some deprecation warnings.