### PR TITLE
Avoid secret explosions from Nameplate color hooks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -233,6 +233,12 @@ stds.wow = {
 			},
 		},
 
+		C_ClassColor = {
+			fields = {
+				"GetClassColor",
+			},
+		},
+
 		C_ColorUtil = {
 			fields = {
 				"ConvertHSLToHSV",

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -27,12 +27,12 @@ end
 
 local function UpdateFontStringWidgetColor(widget)
 	local desiredColor = widget.TRP3_overrideColor or widget.TRP3_originalColor;
-	CallUnhookedMethod(widget, "SetVertexColor", desiredColor:GetRGBA());
+	CallUnhookedMethod(widget, "SetVertexColor", desiredColor.r, desiredColor.g, desiredColor.b, desiredColor.a);
 end
 
 local function UpdateStatusBarWidgetColor(widget)
 	local desiredColor = widget.TRP3_overrideColor or widget.TRP3_originalColor;
-	CallUnhookedMethod(widget, "SetStatusBarColor", desiredColor:GetRGBA());
+	CallUnhookedMethod(widget, "SetStatusBarColor", desiredColor.r, desiredColor.g, desiredColor.b, desiredColor.a);
 end
 
 local function ProcessWidgetVisibilityChanged(widget)
@@ -45,13 +45,18 @@ local function ProcessFontStringWidgetTextChanged(widget)
 	UpdateFontStringWidgetText(widget);
 end
 
+-- Colors obtained through posthooks may be secret. Don't construct proper
+-- color objects from them - instead, pack into a raw table that we unpack
+-- when applying.
 local function ProcessFontStringWidgetColorChanged(widget)
-	widget.TRP3_originalColor = TRP3_API.CreateColor(widget:GetVertexColor());
+	local r, g, b, a = widget:GetVertexColor();
+	widget.TRP3_originalColor = { r = r, g = g, b = b, a = a };
 	UpdateFontStringWidgetColor(widget);
 end
 
 local function ProcessStatusBarWidgetColorChanged(widget)
-	widget.TRP3_originalColor = TRP3_API.CreateColor(widget:GetStatusBarColor());
+	local r, g, b, a = widget:GetStatusBarColor();
+	widget.TRP3_originalColor = { r = r, g = g, b = b, a = a };
 	UpdateStatusBarWidgetColor(widget);
 end
 

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -381,7 +381,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateHealthBar(nameplate)
 	local overrideColor;
 
 	if displayInfo and displayInfo.shouldColorHealth then
-		overrideColor = TRP3_API.CreateColor(displayInfo.color:GetRGB());
+		overrideColor = displayInfo.color;
 	end
 
 	SetStatusBarWidgetOverrideColor(unitframe.healthBar, overrideColor);

--- a/totalRP3/Modules/NamePlates/NamePlates_Core.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Core.lua
@@ -160,7 +160,8 @@ local function GetCharacterColorForDisplay(player, classToken)
 	local color = player:GetCustomColorForDisplay();
 
 	if not color and TRP3_NamePlatesSettings.EnableClassColorFallback then
-		color = TRP3_API.GetClassDisplayColor(classToken);
+		-- Class token can be secret; avoid GetClassDisplayColor here.
+		color = C_ClassColor.GetClassColor(classToken);
 	end
 
 	return color;
@@ -261,7 +262,8 @@ local function GetCharacterUnitDisplayInfo(unitToken, characterID)
 			local classToken = UnitClassBase(unitToken);
 
 			if TRP3_NamePlatesSettings.EnableClassColorFallback then
-				displayInfo.color = TRP3_API.GetClassDisplayColor(classToken);
+				-- Class token can be secret; avoid GetClassDisplayColor here.
+				displayInfo.color = C_ClassColor.GetClassColor(classToken);
 			end
 		end
 


### PR DESCRIPTION
Avoid the use of our cached color machinery for colors obtained through secure posthooks in the Blizzard nameplate decorator. These can contain secret values, which error when we generate a cache key for the object.

We don't want to construct our brand of color objects where the components are individually secret as multiple methods on them would, also, implicitly fail in the face of secrets. Instead, pack the color components into a raw table with no methods and update the one place of code that's unpacking them to work with direct field access.