### PR TITLE
Fix calls to defunct functions in Plater nameplate module

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Plater.lua
@@ -227,12 +227,12 @@ function TRP3_PlaterNamePlates:CustomizeNameplate(nameplate, unitToken, displayI
 		if self.firstRun then
 			C_Timer.After(3, function()
 				if unitFrame.PlaterOnScreen and displayInfo.color then
-					Plater.SetNameplateColor(unitFrame, displayInfo.color:GetRGBTable());
+					Plater.SetNameplateColor(unitFrame, displayInfo.color);
 				end
 				self.firstRun = false;
 			end);
 		else
-			Plater.SetNameplateColor(unitFrame, displayInfo.color:GetRGBTable());
+			Plater.SetNameplateColor(unitFrame, displayInfo.color);
 		end
 	else
 		Plater.RefreshNameplateColor(unitFrame);


### PR DESCRIPTION
GetRGBTable? More like dead.

Not sure why I was using these functions to begin with. The color object already is an RGB table.