### PR TITLE
Fix nameplate castbar lookup after Blizzard changes

### DIFF
--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -259,7 +259,7 @@ function TRP3_BlizzardNamePlates:InitializeUnitFrame(unitframe)
 
 	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.aggroHighlight);
 	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.BuffFrame);
-	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.castBar);
+	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.CastBarsContainer.castBar);
 	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.ClassificationFrame);
 	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.healthBar);
 	TryCallWidgetFunction(InitWidgetVisibilityHooks, unitframe.LevelFrame);  -- Classic-only.
@@ -514,7 +514,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateVisibility(nameplate)
 
 	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.aggroHighlight, shouldShow);
 	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.BuffFrame, shouldShow);
-	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.castBar, shouldShow);
+	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.CastBarsContainer.castBar, shouldShow);
 	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.ClassificationFrame, shouldShow);
 	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.healthBar, shouldShow);
 	TryCallWidgetFunction(SetWidgetOverrideShownState, unitframe.LevelFrame, shouldShow);  -- Classic-only.


### PR DESCRIPTION
Heyo! I've been getting some reports of disappearing castbars when using TRP3 and BetterBlizzPlates together. Specifically when you target a nameplate thats casting. Here's a tiny fix it.

Blizzard moved the nameplate castbar to `NamePlate.UnitFrame.CastBarsContainer.castBar` on all clients and left no alias (like they did for HealthBarsContainer.healthBar). Currently TRP3 still tries to hook the nil `NamePlate.UnitFrame.castBar`

In BetterBlizzPlates I add an alias for it if its nil, both as a quickfix for myself and for compatibility with some other addons and older scripts etc and I would prefer to keep it that way.

Since TRP3 never hooked it properly but the alias from BBP gets made later on, then when TRP3 updates the nameplate it causes TRP3 to hide the castbar when targeting a nameplate that is casting.

All fixed by hooking the proper castbar. This closes https://github.com/Total-RP/Total-RP-3/issues/1354