### PR TITLE
Fix nameplate text inside health bar test

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -548,6 +548,16 @@ stds.wow = {
 			},
 		},
 
+		NamePlateConstants = {
+			fields = {
+				NAME_ANCHOR_STYLES = {
+					fields = {
+						"InsideHealthBar",
+					},
+				},
+			},
+		},
+
 		PixelUtil = {
 			fields = {
 				"SetPoint",
@@ -703,15 +713,6 @@ stds.wow = {
 		"Lerp",
 		"Mixin",
 		"MouseIsOver",
-		NamePlateConstants = {
-			fields = {
-				NAME_ANCHOR_STYLES = {
-					fields = {
-						"InsideHealthBar",
-					},
-				},
-			},
-		},
 		"NamePlateSetupOptions",
 		"NeutralPlayerSelectFaction",
 		"nop",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -703,6 +703,15 @@ stds.wow = {
 		"Lerp",
 		"Mixin",
 		"MouseIsOver",
+		NamePlateConstants = {
+			fields = {
+				NAME_ANCHOR_STYLES = {
+					fields = {
+						"InsideHealthBar",
+					},
+				},
+			},
+		},
 		"NamePlateSetupOptions",
 		"NeutralPlayerSelectFaction",
 		"nop",

--- a/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
+++ b/totalRP3/Modules/NamePlates/NamePlates_Blizzard.lua
@@ -356,7 +356,7 @@ function TRP3_BlizzardNamePlates:UpdateNamePlateName(nameplate)
 		-- Process color overrides.
 		-- Do not color name when unit name is within the health bar, except when name-only mode is on.
 		-- Companion nameplates don't have a name-only option, so exclude them from the name-only check.
-		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameAnchorStyle and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() or not displayInfo.isPlayerUnit;
+		local hasHealthBarOverlap = NamePlateSetupOptions.unitNameAnchorStyle == NamePlateConstants.NAME_ANCHOR_STYLES.InsideHealthBar and not TRP3_NamePlatesUtil.IsNameOnlyModeEnabled() or not displayInfo.isPlayerUnit;
 
 		if displayInfo.shouldColorName and not hasHealthBarOverlap then
 			overrideColor = displayInfo.color;


### PR DESCRIPTION
#1345 fixed names being colored inside health bars but also removed colors from every other nameplate mode with healthbars. The test now properly disables colors only when the name is inside the healthbar.