### PR TITLE
Restructure CompanionUtil implementation

### DIFF
--- a/totalRP3/Core/CompanionProviderJournal.lua
+++ b/totalRP3/Core/CompanionProviderJournal.lua
@@ -1,0 +1,104 @@
+-- Copyright The Total RP 3 Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+local cachedSummonedMountID = nil;
+
+local CompanionProviderJournal = {};
+
+function CompanionProviderJournal:CanRenameCompanionPets()
+	return true;
+end
+
+function CompanionProviderJournal:GetCompanionPetIDs()
+	return C_PetJournal.GetOwnedPetIDs();
+end
+
+function CompanionProviderJournal:GetCompanionPetInfo(petID)
+	local speciesID, customName, _, _, _, _, _, speciesName, icon, _, _, _, description = C_PetJournal.GetPetInfoByPetID(petID);
+
+	if not speciesID then
+		return;
+	end
+
+	return {
+		id = petID,
+		name = (customName ~= "") and customName or speciesName,
+		customName = customName ~= "" and customName or nil,
+		icon = icon,
+		description = description,
+		speciesName = speciesName,
+		isCollected = true,
+	};
+end
+
+function CompanionProviderJournal:IsCompanionPetUnit(unitToken)
+	return UnitIsBattlePetCompanion(unitToken);
+end
+
+function CompanionProviderJournal:GetCompanionPetUnitName(unitToken)
+	return UnitNameUnmodified(unitToken);
+end
+
+function CompanionProviderJournal:GetSummonedCompanionPetID()
+	return C_PetJournal.GetSummonedPetGUID();
+end
+
+function CompanionProviderJournal:GetMountIDs()
+	return C_MountJournal.GetMountIDs();
+end
+
+function CompanionProviderJournal:GetMountInfo(mountID)
+	local name, spellID, icon, _, _, _, _, _, _, _, isCollected = C_MountJournal.GetMountInfoByID(mountID);
+	local _, description = C_MountJournal.GetMountInfoExtraByID(mountID);
+
+	if not spellID then
+		return;
+	end
+
+	return {
+		id = mountID,
+		name = name,
+		icon = icon,
+		description = description,
+		isCollected = isCollected,
+		spellID = spellID,
+	};
+end
+
+function CompanionProviderJournal:GetMountSpellID(mountID)
+	local _, spellID = C_MountJournal.GetMountInfoByID(mountID);
+	return spellID;
+end
+
+function CompanionProviderJournal:GetSummonedMountID()
+	if not IsMounted() then
+		return nil;
+	end
+
+	-- Is the last mount that we tested still the current summon?
+	if cachedSummonedMountID ~= nil then
+		local _, _, _, isActive = C_MountJournal.GetMountInfoByID(cachedSummonedMountID);
+
+		if not isActive then
+			cachedSummonedMountID = nil;
+		end
+	end
+
+	-- Has our cache been invalidated? If so, scan the journal.
+	if cachedSummonedMountID == nil then
+		for _, mountID in ipairs(self:GetMountIDs()) do
+			local _, _, _, isActive = C_MountJournal.GetMountInfoByID(mountID);
+
+			if isActive then
+				cachedSummonedMountID = mountID;
+				break;
+			end
+		end
+	end
+
+	return cachedSummonedMountID;
+end
+
+function TRP3_CompanionUtil.GetDataProvider()
+	return CompanionProviderJournal;
+end

--- a/totalRP3/Core/CompanionProviderStatic.lua
+++ b/totalRP3/Core/CompanionProviderStatic.lua
@@ -1,16 +1,6 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
--- This should be converted to an [AllowLoadGameType ...] directive when supported
--- on all clients.
---
--- While the collections journal wasn't introduced until Mists, it was added
--- into Cataclysm and then Wrath (CN) as part of Classic.
-
-if LE_EXPANSION_LEVEL_CURRENT >= LE_EXPANSION_WRATH_OF_THE_LICH_KING then
-	return;
-end
-
 local cachedSummonedMountID = nil;
 local staticCompanionPetsByID = {};
 local staticCompanionPetsByCreatureID = {};
@@ -38,15 +28,17 @@ local function SetSummonedCompanionPetID(petID)
 	TRP3_Companions.summonedPetID = petID;
 end
 
-function TRP3_CompanionUtil.CanRenameCompanionPets()
+local CompanionProviderStatic = {};
+
+function CompanionProviderStatic:CanRenameCompanionPets()
 	return false;
 end
 
-function TRP3_CompanionUtil.GetCompanionPetIDs()
+function CompanionProviderStatic:GetCompanionPetIDs()
 	return GetKeysArray(staticCompanionPetsByID);
 end
 
-function TRP3_CompanionUtil.GetCompanionPetInfo(petID)
+function CompanionProviderStatic:GetCompanionPetInfo(petID)
 	local staticPetInfo = staticCompanionPetsByID[petID];
 
 	if not staticPetInfo then
@@ -64,7 +56,7 @@ function TRP3_CompanionUtil.GetCompanionPetInfo(petID)
 	};
 end
 
-function TRP3_CompanionUtil.IsCompanionPetUnit(unitToken)
+function CompanionProviderStatic:IsCompanionPetUnit(unitToken)
 	if UnitPlayerControlled(unitToken) then
 		local unitGUID = UnitGUID(unitToken);
 		local guidType, _, _, _, _, creatureID = string.split("-", unitGUID or "", 7);
@@ -76,7 +68,7 @@ function TRP3_CompanionUtil.IsCompanionPetUnit(unitToken)
 	end
 end
 
-function TRP3_CompanionUtil.GetCompanionPetUnitName(unitToken)
+function CompanionProviderStatic:GetCompanionPetUnitName(unitToken)
 	-- In Classic flavors using static data rather than the pet journal, we
 	-- can't localize the summoned name of creatures ahead of time.
 	--
@@ -91,17 +83,17 @@ function TRP3_CompanionUtil.GetCompanionPetUnitName(unitToken)
 	end
 end
 
-function TRP3_CompanionUtil.GetSummonedCompanionPetID()
+function CompanionProviderStatic:GetSummonedCompanionPetID()
 	if TRP3_Companions then
 		return TRP3_Companions.summonedPetID;
 	end
 end
 
-function TRP3_CompanionUtil.GetMountIDs()
+function CompanionProviderStatic:GetMountIDs()
 	return GetKeysArray(staticMountsByID);
 end
 
-function TRP3_CompanionUtil.GetMountInfo(mountID)
+function CompanionProviderStatic:GetMountInfo(mountID)
 	local staticMountInfo = staticMountsByID[mountID];
 
 	if not staticMountInfo then
@@ -118,7 +110,7 @@ function TRP3_CompanionUtil.GetMountInfo(mountID)
 	};
 end
 
-function TRP3_CompanionUtil.GetMountSpellID(mountID)
+function CompanionProviderStatic:GetMountSpellID(mountID)
 	local staticMountInfo = staticMountsByID[mountID];
 
 	if staticMountInfo then
@@ -144,14 +136,14 @@ local function GetUnitAuraSpells(unitToken, filter)
 	return appliedAuras;
 end
 
-function TRP3_CompanionUtil.GetSummonedMountID()
+function CompanionProviderStatic:GetSummonedMountID()
 	if not IsMounted() then
 		return nil;
 	end
 
 	-- Is the last mount that we tested still the current summon?
 	if cachedSummonedMountID ~= nil then
-		local spellID = TRP3_CompanionUtil.GetMountSpellID(cachedSummonedMountID);
+		local spellID = self:GetMountSpellID(cachedSummonedMountID);
 
 		if not C_UnitAuras.GetPlayerAuraBySpellID(spellID) then
 			cachedSummonedMountID = nil;
@@ -162,8 +154,8 @@ function TRP3_CompanionUtil.GetSummonedMountID()
 	if cachedSummonedMountID == nil then
 		local appliedAuras = GetUnitAuraSpells("player", "HELPFUL|PLAYER|CANCELABLE");
 
-		for _, mountID in ipairs(TRP3_CompanionUtil.GetMountIDs()) do
-			local spellID = TRP3_CompanionUtil.GetMountSpellID(mountID);
+		for _, mountID in ipairs(self:GetMountIDs()) do
+			local spellID = self:GetMountSpellID(mountID);
 
 			if appliedAuras[spellID] then
 				cachedSummonedMountID = mountID;
@@ -335,4 +327,8 @@ do
 			CompanionStateDriver:RequestLoadSpellData(mountInfo.spellID, OnMountSpellLoaded);
 		end
 	end
+end
+
+function TRP3_CompanionUtil.GetDataProvider()
+	return CompanionProviderStatic;
 end

--- a/totalRP3/Core/CompanionUtil.lua
+++ b/totalRP3/Core/CompanionUtil.lua
@@ -1,47 +1,34 @@
 -- Copyright The Total RP 3 Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local cachedSummonedMountID = nil;
-
 TRP3_CompanionUtil = {};
 
+function TRP3_CompanionUtil.GetDataProvider()
+	return nil;
+end
+
 function TRP3_CompanionUtil.CanRenameCompanionPets()
-	return true;
+	return TRP3_CompanionUtil.GetDataProvider():CanRenameCompanionPets();
 end
 
 function TRP3_CompanionUtil.GetCompanionPetIDs()
-	return C_PetJournal.GetOwnedPetIDs();
+	return TRP3_CompanionUtil.GetDataProvider():GetCompanionPetIDs();
 end
 
 function TRP3_CompanionUtil.GetCompanionPetInfo(petID)
-	local speciesID, customName, _, _, _, _, _, speciesName, icon, _, _, _, description = C_PetJournal.GetPetInfoByPetID(petID);
-
-	if not speciesID then
-		return;
-	end
-
-	return {
-		id = petID,
-		name = (customName ~= "") and customName or speciesName,
-		customName = customName ~= "" and customName or nil,
-		icon = icon,
-		description = description,
-		speciesName = speciesName,
-		isCollected = true,
-	};
+	return TRP3_CompanionUtil.GetDataProvider():GetCompanionPetInfo(petID);
 end
 
 function TRP3_CompanionUtil.IsCompanionPetUnit(unitToken)
-	return UnitIsBattlePetCompanion(unitToken);
+	return TRP3_CompanionUtil.GetDataProvider():IsCompanionPetUnit(unitToken);
 end
 
 function TRP3_CompanionUtil.GetCompanionPetUnitName(unitToken)
-	local name = UnitNameUnmodified(unitToken);
-	return name;
+	return TRP3_CompanionUtil.GetDataProvider():GetCompanionPetUnitName(unitToken);
 end
 
 function TRP3_CompanionUtil.GetSummonedCompanionPetID()
-	return C_PetJournal.GetSummonedPetGUID();
+	return TRP3_CompanionUtil.GetDataProvider():GetSummonedCompanionPetID();
 end
 
 function TRP3_CompanionUtil.EnumerateCompanionPets()
@@ -61,59 +48,19 @@ function TRP3_CompanionUtil.EnumerateCompanionPets()
 end
 
 function TRP3_CompanionUtil.GetMountIDs()
-	return C_MountJournal.GetMountIDs();
+	return TRP3_CompanionUtil.GetDataProvider():GetMountIDs();
 end
 
 function TRP3_CompanionUtil.GetMountInfo(mountID)
-	local name, spellID, icon, _, _, _, _, _, _, _, isCollected = C_MountJournal.GetMountInfoByID(mountID);
-	local _, description = C_MountJournal.GetMountInfoExtraByID(mountID);
-
-	if not spellID then
-		return;
-	end
-
-	return {
-		id = mountID,
-		name = name,
-		icon = icon,
-		description = description,
-		isCollected = isCollected,
-		spellID = spellID,
-	};
+	return TRP3_CompanionUtil.GetDataProvider():GetMountInfo(mountID);
 end
 
 function TRP3_CompanionUtil.GetMountSpellID(mountID)
-	local _, spellID = C_MountJournal.GetMountInfoByID(mountID);
-	return spellID;
+	return TRP3_CompanionUtil.GetDataProvider():GetMountSpellID(mountID);
 end
 
 function TRP3_CompanionUtil.GetSummonedMountID()
-	if not IsMounted() then
-		return nil;
-	end
-
-	-- Is the last mount that we tested still the current summon?
-	if cachedSummonedMountID ~= nil then
-		local _, _, _, isActive = C_MountJournal.GetMountInfoByID(cachedSummonedMountID);
-
-		if not isActive then
-			cachedSummonedMountID = nil;
-		end
-	end
-
-	-- Has our cache been invalidated? If so, scan the journal.
-	if cachedSummonedMountID == nil then
-		for _, mountID in ipairs(TRP3_CompanionUtil.GetMountIDs()) do
-			local _, _, _, isActive = C_MountJournal.GetMountInfoByID(mountID);
-
-			if isActive then
-				cachedSummonedMountID = mountID;
-				break;
-			end
-		end
-	end
-
-	return cachedSummonedMountID;
+	return TRP3_CompanionUtil.GetDataProvider():GetSummonedMountID();
 end
 
 function TRP3_CompanionUtil.EnumerateMounts()

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -93,7 +93,7 @@ Core\RegionUtil.lua
 Core\MarkupUtil.lua
 Core\CompanionUtil.lua
 Core\CompanionProviderJournal.lua [AllowLoadGameType mainline, mists, wrath]
-Core\Vanilla\CompanionUtilOverrides.lua
+Core\CompanionProviderStatic.lua [AllowLoadGameType vanilla, tbc]
 Core\Utils.lua
 Core\ProfileUtil.lua
 Core\UITools.lua

--- a/totalRP3/totalRP3.toc
+++ b/totalRP3/totalRP3.toc
@@ -92,6 +92,7 @@ Core\BindingUtil.lua
 Core\RegionUtil.lua
 Core\MarkupUtil.lua
 Core\CompanionUtil.lua
+Core\CompanionProviderJournal.lua [AllowLoadGameType mainline, mists, wrath]
 Core\Vanilla\CompanionUtilOverrides.lua
 Core\Utils.lua
 Core\ProfileUtil.lua


### PR DESCRIPTION
This is a small code cleanup for our CompanionUtil abstraction.

There's no functional change to the API here. All that's been done is relocating the implementations to dedicated data provider tables, and providing one extension point (`CompanionUtil.GetDataProvider()`) which is overridden to select an appropriate backing data source for companion data. This means we're only overriding _one_ function, rather than about 12. I also got rid of the ugly `Vanilla/` directory as we no longer really need it with this setup.