### PR TITLE
Clean up deprecated API usage and stale luacheck entries

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -217,6 +217,12 @@ stds.wow = {
 			},
 		},
 
+		C_AutoComplete = {
+			fields = {
+				"GetAutoCompleteRealms",
+			},
+		},
+
 		C_BattleNet = {
 			fields = {
 				"GetAccountInfoByGUID",
@@ -571,6 +577,12 @@ stds.wow = {
 			},
 		},
 
+		RaidWarningUtil = {
+			fields = {
+				"AddMessage",
+			},
+		},
+
 		ResizeLayoutMixin = {
 			fields = {
 				"OnShow",
@@ -606,9 +618,7 @@ stds.wow = {
 		"BNGetInfo",
 		"CalculateStringEditDistance",
 		"canaccessvalue",
-		"Chat_GetChatFrame",
 		"ChatConfigChannelSettings_SwapChannelsByIndex",
-		"ChatEdit_FocusActiveWindow",
 		"ChatEdit_GetActiveWindow",
 		"ChatFrame_AddMessageEventFilter",
 		"ChatFrame_OpenChat",
@@ -653,7 +663,6 @@ stds.wow = {
 		"GameTooltip_ShowDisabledTooltip",
 		"GenerateClosure",
 		"GetAppropriateTooltip",
-		"GetAutoCompleteRealms",
 		"GetBindingText",
 		"GetChannelDisplayInfo",
 		"GetChannelList",
@@ -721,7 +730,6 @@ stds.wow = {
 		"PlayMusic",
 		"PlaySound",
 		"PlaySoundFile",
-		"RaidNotice_AddMessage",
 		"RaidWarningFrame",
 		"RegisterStateDriver",
 		"ReloadUI",
@@ -742,7 +750,6 @@ stds.wow = {
 		"securecallfunction",
 		"SecureCmdOptionParse",
 		"secureexecuterange",
-		"SendChatMessage",
 		"SendSystemMessage",
 		"SetCursor",
 		"SetCVar",
@@ -948,13 +955,11 @@ stds.wow = {
 		"MAELSTROM",
 		"MANA",
 		"MAX_CHANNEL_BUTTONS",
-		"MAX_WOW_CHAT_CHANNELS",
 		"MODELFRAME_MAX_PLAYER_ZOOM",
 		"NO",
 		"NONE",
 		"NORMAL_FONT_COLOR",
 		"NOT_BOUND",
-		"NUM_CHAT_WINDOWS",
 		"OKAY",
 		"PAIN",
 		"PLAYER_FACTION_COLOR_ALLIANCE",

--- a/totalRP3/Core/Utils.lua
+++ b/totalRP3/Core/Utils.lua
@@ -33,7 +33,7 @@ Utils.message.displayMessage = function(message, messageType)
 	elseif messageType == messageTypes.ALERT_POPUP then
 		TRP3_API.popup.showAlertPopup(tostring(message));
 	elseif messageType == messageTypes.RAID_ALERT then
-		RaidNotice_AddMessage(RaidWarningFrame, tostring(message), ChatTypeInfo["RAID_WARNING"]);
+		RaidWarningUtil.AddMessage(tostring(message), ChatTypeInfo["RAID_WARNING"]);
 	elseif messageType == messageTypes.ALERT_MESSAGE then
 		UIErrorsFrame:AddMessage(message, 1.0, 0.0, 0.0);
 	end

--- a/totalRP3/Modules/Register/Main/RegisterList.lua
+++ b/totalRP3/Modules/Register/Main/RegisterList.lua
@@ -526,7 +526,7 @@ local function getCharacterLines()
 	local profileList = getProfileList();
 	local fullSize = CountTable(profileList);
 	local characterLines = {};
-	local connectedRealms = tInvert(GetAutoCompleteRealms());
+	local connectedRealms = tInvert(C_AutoComplete.GetAutoCompleteRealms());
 
 	for profileID, profile in pairs(profileList) do
 		local nameIsConform, guildIsConform, realmIsConform, notesIsConform = false, false, false, false;


### PR DESCRIPTION
Self-explanatory; the deprecations here aren't part of the removed set in 12.1.5, but they'll be cleaned up eventually - so migrating them to the newer API now.

We also had entries in luacheckrc for functions and constants we're not using anywhere, and are themselves deprecated.